### PR TITLE
fix: cloud-api vpc auth route

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -48,7 +48,7 @@ async fn vpc_authenticate(
     tracing::debug!("VPC auth timestamp: {}", timestamp);
 
     // Build the auth URL
-    let auth_url = format!("{}/v1/auth/vpc/login", base_url.trim_end_matches('/'));
+    let auth_url = format!("{}/auth/vpc/login", base_url.trim_end_matches('/'));
 
     // Make authentication request
     let client = reqwest::Client::new();


### PR DESCRIPTION
Remove the extra `/v1` for `/v1/auth/vpc/login` endpoint of cloud-api.

The below error was returned when querying https://cloud-stg-api.near.ai/v1/v1/auth/vpc/login

```
Error: VPC authentication failed with status 404 Not Found:
```