### PR TITLE
chore: use near-api v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,8 +3051,9 @@ dependencies = [
 
 [[package]]
 name = "near-api"
-version = "0.7.8"
-source = "git+https://github.com/near/near-api-rs?rev=f07473256aa7a70e094432618bac174e60d533df#f07473256aa7a70e094432618bac174e60d533df"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4db0fc73b5d3312219b251b9b777da274867c48e9793f6916f5c17d3914384a7"
 dependencies = [
  "async-trait",
  "base64",
@@ -3076,8 +3077,9 @@ dependencies = [
 
 [[package]]
 name = "near-api-types"
-version = "0.7.8"
-source = "git+https://github.com/near/near-api-rs?rev=f07473256aa7a70e094432618bac174e60d533df#f07473256aa7a70e094432618bac174e60d533df"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82ad7dfc45b9bd7755d7a036d406aada171eb5d95428cbc324dc916018ec3ffb"
 dependencies = [
  "base64",
  "borsh",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -44,7 +44,7 @@ services = { path = "../services", features = ["utoipa"] }
 database = { path = "../database" }
 config = { path = "../config" }
 hex = "0.4.3"
-near-api = { git = "https://github.com/near/near-api-rs", rev = "f07473256aa7a70e094432618bac174e60d533df" }
+near-api = "0.8.0"
 
 # VPC authentication
 reqwest = { version = "0.12", features = ["json"] }

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -42,7 +42,7 @@ dstack-sdk = "0.1"
 opentelemetry = { version = "0.31", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio", "metrics"] }
 utoipa = { version = "5", optional = true }
-near-api = { git = "https://github.com/near/near-api-rs", rev = "f07473256aa7a70e094432618bac174e60d533df" }
+near-api = "0.8.0"
 
 [features]
 utoipa = ["dep:utoipa"]


### PR DESCRIPTION
`near-api-rs` has released the v0.8.0 version: https://github.com/near/near-api-rs/releases/tag/near-api-v0.8.0

Let's switch to near-api v0.8.0