### PR TITLE
fix: skip empty model attestations

### DIFF
--- a/crates/api/src/models.rs
+++ b/crates/api/src/models.rs
@@ -128,6 +128,7 @@ pub struct CombinedAttestationReport {
     pub cloud_api_gateway_attestation: ApiGatewayAttestation,
 
     /// Model provider attestations (can be multiple when routing to different models)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub model_attestations: Option<Vec<ModelAttestation>>,
 }
 


### PR DESCRIPTION
The attestation report endpoint (https://private.near.ai/v1/attestation/report) now returns 

```
  "model_attestations": null
```

Skip serializing the field if it's none. 