### PR TITLE
chore: update frontend version to v0.1.11 dev

### DIFF
--- a/build-config.toml
+++ b/build-config.toml
@@ -8,7 +8,7 @@
 #   - "main" (branch)
 #   - "v1.2.3" (tag)
 #   - "abc123def456" (commit hash)
-private_chat_frontend_version = "a6e034845fdb845ce72762e2596e433cb4c08057" # v0.1.10
+private_chat_frontend_version = "6c1b1907b803ad13ea1b902e1f812dd74279b164" # v0.1.11-dev
 
 # PostHog key and host for the private-chat frontend
 posthog_key = "phc_glaMeuuO1gLFSB2U9y27MchidXEmSnFOQLB8cceyVSb"


### PR DESCRIPTION
This is not the final v0.1.11 version. Update staging to a dev version of v0.1.11.