### PR TITLE
feat: add OAuth2 and NEAR authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4862,6 +4862,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64",
  "bytes",
  "chrono",
  "config",

--- a/crates/api/src/routes/oauth_server.rs
+++ b/crates/api/src/routes/oauth_server.rs
@@ -1,0 +1,500 @@
+//! OAuth 2.0 Authorization Server Routes
+//!
+//! Implements RFC 6749 authorization code grant flow endpoints:
+//! - GET /v1/oauth/authorize - Authorization endpoint
+//! - POST /v1/oauth/token - Token endpoint
+//! - GET /v1/oauth/consent/{id} - Get pending authorization for consent UI
+//! - POST /v1/oauth/consent/{id} - Approve or deny consent
+
+use axum::{
+    extract::{Path, Query, State},
+    http::header,
+    response::{IntoResponse, Redirect, Response},
+    routing::{get, post},
+    Extension, Form, Json, Router,
+};
+use base64::{engine::general_purpose::STANDARD, Engine};
+use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
+use uuid::Uuid;
+
+use crate::{
+    error::{OAuthError, OAuthErrorResponse},
+    middleware::AuthenticatedUser,
+    state::AppState,
+};
+use services::auth::AuthorizeResult;
+
+// =============================================================================
+// Authorization Endpoint (GET /v1/oauth/authorize)
+// =============================================================================
+
+/// Query parameters for the authorization endpoint.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct AuthorizeQuery {
+    /// Must be "code" for authorization code flow
+    pub response_type: String,
+    /// The client identifier
+    pub client_id: String,
+    /// URI to redirect to after authorization
+    pub redirect_uri: String,
+    /// Space-separated list of requested scopes
+    #[serde(default)]
+    pub scope: String,
+    /// Opaque value for CSRF protection
+    pub state: Option<String>,
+    /// PKCE code challenge (required for public clients)
+    pub code_challenge: Option<String>,
+    /// PKCE code challenge method (must be S256 if provided)
+    pub code_challenge_method: Option<String>,
+}
+
+/// Authorization endpoint.
+///
+/// Initiates the authorization code flow. If the user has already granted
+/// consent for the requested scopes, redirects directly with an authorization code.
+/// Otherwise, returns a response indicating consent is needed.
+#[utoipa::path(
+    get,
+    path = "/v1/oauth/authorize",
+    tag = "OAuth",
+    params(AuthorizeQuery),
+    responses(
+        (status = 302, description = "Redirect to client with code or consent page"),
+        (status = 400, description = "Invalid request", body = OAuthErrorResponse),
+    )
+)]
+pub async fn authorize(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Query(params): Query<AuthorizeQuery>,
+) -> Response {
+    // Validate response_type
+    if params.response_type != "code" {
+        return error_redirect(
+            &params.redirect_uri,
+            "unsupported_response_type",
+            "Only 'code' response_type is supported",
+            params.state.as_deref(),
+        );
+    }
+
+    // Call the service
+    let result = state
+        .oauth_server_service
+        .authorize(
+            user.user_id,
+            &params.client_id,
+            &params.redirect_uri,
+            &params.scope,
+            params.state.as_deref(),
+            params.code_challenge.as_deref(),
+            params.code_challenge_method.as_deref(),
+        )
+        .await;
+
+    match result {
+        Ok(AuthorizeResult::Success { code, state: s }) => {
+            // Redirect back to client with authorization code
+            let mut redirect_url = params.redirect_uri.clone();
+            redirect_url.push_str(if redirect_url.contains('?') { "&" } else { "?" });
+            redirect_url.push_str(&format!("code={}", urlencoding::encode(&code)));
+            if let Some(state_value) = s {
+                redirect_url.push_str(&format!("&state={}", urlencoding::encode(&state_value)));
+            }
+            Redirect::to(&redirect_url).into_response()
+        }
+        Ok(AuthorizeResult::NeedsConsent {
+            pending_id,
+            client_name: _,
+            scopes: _,
+        }) => {
+            // Redirect to consent page
+            let consent_url = format!("/oauth/consent.html?pending_id={}", pending_id);
+            Redirect::to(&consent_url).into_response()
+        }
+        Err(e) => {
+            // For client errors (invalid redirect_uri, invalid client), return JSON error
+            // For other errors, redirect with error
+            let error_code = e.error_code();
+            if error_code == "invalid_client" || error_code == "invalid_request" {
+                OAuthError::from(e).into_response()
+            } else {
+                error_redirect(
+                    &params.redirect_uri,
+                    error_code,
+                    &e.to_string(),
+                    params.state.as_deref(),
+                )
+            }
+        }
+    }
+}
+
+/// Response when consent is needed.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AuthorizeNeedsConsentResponse {
+    /// Always true for this response type
+    pub needs_consent: bool,
+    /// ID of the pending authorization to approve/deny
+    pub pending_id: Uuid,
+    /// Name of the client application
+    pub client_name: String,
+    /// Scopes being requested
+    pub scopes: Vec<String>,
+}
+
+/// Build an error redirect URL per RFC 6749.
+fn error_redirect(
+    redirect_uri: &str,
+    error: &str,
+    description: &str,
+    state: Option<&str>,
+) -> Response {
+    let mut url = redirect_uri.to_string();
+    url.push_str(if url.contains('?') { "&" } else { "?" });
+    url.push_str(&format!(
+        "error={}&error_description={}",
+        urlencoding::encode(error),
+        urlencoding::encode(description)
+    ));
+    if let Some(s) = state {
+        url.push_str(&format!("&state={}", urlencoding::encode(s)));
+    }
+    Redirect::to(&url).into_response()
+}
+
+// =============================================================================
+// Consent Endpoints
+// =============================================================================
+
+/// Get pending authorization details for consent UI.
+#[utoipa::path(
+    get,
+    path = "/v1/oauth/consent/{id}",
+    tag = "OAuth",
+    params(
+        ("id" = Uuid, Path, description = "Pending authorization ID")
+    ),
+    responses(
+        (status = 200, description = "Pending authorization details", body = ConsentInfoResponse),
+        (status = 404, description = "Not found"),
+    )
+)]
+pub async fn get_consent(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<ConsentInfoResponse>, OAuthError> {
+    let info = state
+        .oauth_server_service
+        .get_pending_authorization(id, user.user_id)
+        .await
+        .map_err(OAuthError::from)?
+        .ok_or_else(|| OAuthError::invalid_request("Pending authorization not found"))?;
+
+    // Get user email
+    let user_data = state
+        .user_service
+        .get_user_profile(user.user_id)
+        .await
+        .map_err(|_| OAuthError::server_error("Failed to get user data"))?;
+
+    Ok(Json(ConsentInfoResponse {
+        client_name: info.client_name,
+        client_id: info.client_id,
+        scopes: info.scopes,
+        redirect_uri: info.redirect_uri,
+        user_email: user_data.user.email,
+    }))
+}
+
+/// Response with consent information.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ConsentInfoResponse {
+    pub client_name: String,
+    pub client_id: String,
+    pub scopes: Vec<String>,
+    pub redirect_uri: String,
+    pub user_email: String,
+}
+
+/// Request body for consent decision.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ConsentDecisionRequest {
+    /// Whether the user approved the authorization
+    pub approved: bool,
+    /// Scopes the user approved (must be subset of requested scopes)
+    #[serde(default)]
+    pub scopes: Vec<String>,
+}
+
+/// Response after consent decision.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ConsentDecisionResponse {
+    /// Redirect URL with code or error
+    pub redirect_url: String,
+}
+
+/// Submit consent decision.
+#[utoipa::path(
+    post,
+    path = "/v1/oauth/consent/{id}",
+    tag = "OAuth",
+    params(
+        ("id" = Uuid, Path, description = "Pending authorization ID")
+    ),
+    request_body = ConsentDecisionRequest,
+    responses(
+        (status = 200, description = "Consent processed", body = ConsentDecisionResponse),
+        (status = 400, description = "Invalid request", body = OAuthErrorResponse),
+    )
+)]
+pub async fn post_consent(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<ConsentDecisionRequest>,
+) -> Result<Json<ConsentDecisionResponse>, OAuthError> {
+    if !body.approved {
+        // User denied - get pending auth info for redirect before deleting
+        let info = state
+            .oauth_server_service
+            .get_pending_authorization(id, user.user_id)
+            .await
+            .map_err(OAuthError::from)?;
+
+        // Delete the pending authorization
+        state
+            .oauth_server_service
+            .deny_consent(id)
+            .await
+            .map_err(OAuthError::from)?;
+
+        // Build error redirect
+        let redirect_url = if let Some(pending_info) = info {
+            format!(
+                "{}{}error=access_denied&error_description={}",
+                pending_info.redirect_uri,
+                if pending_info.redirect_uri.contains('?') { "&" } else { "?" },
+                urlencoding::encode("User denied the authorization request")
+            )
+        } else {
+            // No redirect info available - return generic error
+            return Err(OAuthError::access_denied("User denied the authorization request"));
+        };
+
+        return Ok(Json(ConsentDecisionResponse { redirect_url }));
+    }
+
+    // Get redirect_uri before approving (since approve_consent consumes the pending auth)
+    let pending_info = state
+        .oauth_server_service
+        .get_pending_authorization(id, user.user_id)
+        .await
+        .map_err(OAuthError::from)?
+        .ok_or_else(|| OAuthError::invalid_request("Pending authorization not found"))?;
+
+    let redirect_uri = pending_info.redirect_uri;
+
+    // User approved - process consent
+    let result = state
+        .oauth_server_service
+        .approve_consent(user.user_id, id, body.scopes)
+        .await
+        .map_err(OAuthError::from)?;
+
+    match result {
+        AuthorizeResult::Success { code, state: s } => {
+            // Build full redirect URL with code
+            let mut redirect_url = redirect_uri;
+            redirect_url.push_str(if redirect_url.contains('?') { "&" } else { "?" });
+            redirect_url.push_str(&format!("code={}", urlencoding::encode(&code)));
+            if let Some(st) = s {
+                redirect_url.push_str(&format!("&state={}", urlencoding::encode(&st)));
+            }
+
+            Ok(Json(ConsentDecisionResponse { redirect_url }))
+        }
+        AuthorizeResult::NeedsConsent { .. } => {
+            // This shouldn't happen after approving
+            Err(OAuthError::server_error("Unexpected state after consent"))
+        }
+    }
+}
+
+// =============================================================================
+// Token Endpoint (POST /v1/oauth/token)
+// =============================================================================
+
+/// Form parameters for the token endpoint.
+#[derive(Debug, Deserialize, IntoParams, ToSchema)]
+pub struct TokenRequest {
+    /// Grant type: "authorization_code" or "refresh_token"
+    pub grant_type: String,
+    /// Authorization code (for authorization_code grant)
+    pub code: Option<String>,
+    /// Redirect URI (for authorization_code grant, must match authorize request)
+    pub redirect_uri: Option<String>,
+    /// PKCE code verifier (for authorization_code grant)
+    pub code_verifier: Option<String>,
+    /// Refresh token (for refresh_token grant)
+    pub refresh_token: Option<String>,
+    /// Client ID (alternative to Basic auth)
+    pub client_id: Option<String>,
+    /// Client secret (alternative to Basic auth)
+    pub client_secret: Option<String>,
+}
+
+/// Token response.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TokenResponseBody {
+    pub access_token: String,
+    pub token_type: String,
+    pub expires_in: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
+    pub scope: String,
+}
+
+/// Token endpoint.
+///
+/// Exchanges an authorization code for tokens, or refreshes an access token.
+#[utoipa::path(
+    post,
+    path = "/v1/oauth/token",
+    tag = "OAuth",
+    request_body(content = TokenRequest, content_type = "application/x-www-form-urlencoded"),
+    responses(
+        (status = 200, description = "Token response", body = TokenResponseBody),
+        (status = 400, description = "Invalid request", body = OAuthErrorResponse),
+        (status = 401, description = "Invalid client", body = OAuthErrorResponse),
+    )
+)]
+pub async fn token(
+    State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+    Form(params): Form<TokenRequest>,
+) -> Result<Json<TokenResponseBody>, OAuthError> {
+    // Extract client credentials from either Basic auth header or form params
+    let (client_id, client_secret) = extract_client_credentials(&headers, &params)?;
+
+    let result = match params.grant_type.as_str() {
+        "authorization_code" => {
+            let code = params
+                .code
+                .ok_or_else(|| OAuthError::invalid_request("code is required"))?;
+            let redirect_uri = params
+                .redirect_uri
+                .ok_or_else(|| OAuthError::invalid_request("redirect_uri is required"))?;
+
+            state
+                .oauth_server_service
+                .token_authorization_code(
+                    &client_id,
+                    client_secret.as_deref(),
+                    &code,
+                    &redirect_uri,
+                    params.code_verifier.as_deref(),
+                )
+                .await
+                .map_err(OAuthError::from)?
+        }
+        "refresh_token" => {
+            let refresh_token = params
+                .refresh_token
+                .ok_or_else(|| OAuthError::invalid_request("refresh_token is required"))?;
+
+            state
+                .oauth_server_service
+                .token_refresh(&client_id, client_secret.as_deref(), &refresh_token)
+                .await
+                .map_err(OAuthError::from)?
+        }
+        _ => {
+            return Err(OAuthError::unsupported_grant_type(format!(
+                "Unsupported grant_type: {}",
+                params.grant_type
+            )));
+        }
+    };
+
+    Ok(Json(TokenResponseBody {
+        access_token: result.access_token,
+        token_type: result.token_type,
+        expires_in: result.expires_in,
+        refresh_token: result.refresh_token,
+        scope: result.scope,
+    }))
+}
+
+/// Extract client credentials from Authorization header (Basic) or form parameters.
+fn extract_client_credentials(
+    headers: &axum::http::HeaderMap,
+    params: &TokenRequest,
+) -> Result<(String, Option<String>), OAuthError> {
+    // Try Basic auth header first
+    if let Some(auth_header) = headers.get(header::AUTHORIZATION) {
+        let auth_str = auth_header
+            .to_str()
+            .map_err(|_| OAuthError::invalid_client("Invalid Authorization header"))?;
+
+        if let Some(basic_creds) = auth_str.strip_prefix("Basic ") {
+            let decoded = STANDARD
+                .decode(basic_creds)
+                .map_err(|_| OAuthError::invalid_client("Invalid Basic auth encoding"))?;
+
+            let decoded_str = String::from_utf8(decoded)
+                .map_err(|_| OAuthError::invalid_client("Invalid Basic auth encoding"))?;
+
+            let parts: Vec<&str> = decoded_str.splitn(2, ':').collect();
+            if parts.len() != 2 {
+                return Err(OAuthError::invalid_client("Invalid Basic auth format"));
+            }
+
+            return Ok((
+                urlencoding::decode(parts[0])
+                    .map_err(|_| OAuthError::invalid_client("Invalid client_id encoding"))?
+                    .into_owned(),
+                if parts[1].is_empty() {
+                    None
+                } else {
+                    Some(
+                        urlencoding::decode(parts[1])
+                            .map_err(|_| OAuthError::invalid_client("Invalid client_secret encoding"))?
+                            .into_owned(),
+                    )
+                },
+            ));
+        }
+    }
+
+    // Fall back to form parameters
+    let client_id = params
+        .client_id
+        .clone()
+        .ok_or_else(|| OAuthError::invalid_client("client_id is required"))?;
+
+    Ok((client_id, params.client_secret.clone()))
+}
+
+// =============================================================================
+// Router
+// =============================================================================
+
+/// Create the OAuth server router.
+///
+/// Note: The authorize and consent endpoints require authentication (session cookie).
+/// The token endpoint does not require user authentication (uses client credentials).
+pub fn create_oauth_server_router() -> Router<AppState> {
+    Router::new()
+        // Token endpoint - no user auth required, uses client credentials
+        .route("/token", post(token))
+}
+
+/// Create routes that require user authentication.
+pub fn create_oauth_server_auth_router() -> Router<AppState> {
+    Router::new()
+        .route("/authorize", get(authorize))
+        .route("/consent/{id}", get(get_consent).post(post_consent))
+}

--- a/crates/api/src/routes/projects.rs
+++ b/crates/api/src/routes/projects.rs
@@ -1,0 +1,493 @@
+//! Project and OAuth Client management routes
+
+use axum::{
+    extract::{Path, State},
+    routing::{delete, get, post, put},
+    Extension, Json, Router,
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::{error::ApiError, middleware::AuthenticatedUser, state::AppState};
+use services::auth::oauth_ports::{CreateOAuthClient, CreateProject, OAuthClientType, UpdateProject};
+
+// =============================================================================
+// Project Routes
+// =============================================================================
+
+/// Create a new project.
+#[utoipa::path(
+    post,
+    path = "/v1/projects",
+    tag = "Projects",
+    request_body = CreateProjectRequest,
+    responses(
+        (status = 201, description = "Project created", body = ProjectResponse),
+        (status = 400, description = "Invalid request", body = crate::error::ApiErrorResponse),
+    )
+)]
+pub async fn create_project(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Json(body): Json<CreateProjectRequest>,
+) -> Result<Json<ProjectResponse>, ApiError> {
+    let project = state
+        .project_repository
+        .create(CreateProject {
+            owner_id: user.user_id,
+            name: body.name,
+            description: body.description,
+            homepage_url: body.homepage_url,
+            privacy_policy_url: body.privacy_policy_url,
+            terms_url: body.terms_url,
+        })
+        .await
+        .map_err(|e| ApiError::internal_server_error(&e.to_string()))?;
+
+    Ok(Json(ProjectResponse::from(project)))
+}
+
+/// List user's projects.
+#[utoipa::path(
+    get,
+    path = "/v1/projects",
+    tag = "Projects",
+    responses(
+        (status = 200, description = "List of projects", body = Vec<ProjectResponse>),
+    )
+)]
+pub async fn list_projects(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+) -> Result<Json<Vec<ProjectResponse>>, ApiError> {
+    let projects = state
+        .project_repository
+        .list_by_owner(user.user_id)
+        .await
+        .map_err(|e| ApiError::internal_server_error(&e.to_string()))?;
+
+    Ok(Json(projects.into_iter().map(ProjectResponse::from).collect()))
+}
+
+/// Get a project by ID.
+#[utoipa::path(
+    get,
+    path = "/v1/projects/{id}",
+    tag = "Projects",
+    params(
+        ("id" = Uuid, Path, description = "Project ID")
+    ),
+    responses(
+        (status = 200, description = "Project details", body = ProjectResponse),
+        (status = 404, description = "Project not found"),
+    )
+)]
+pub async fn get_project(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<ProjectResponse>, ApiError> {
+    let project = state
+        .project_repository
+        .get_by_id(id)
+        .await
+        .map_err(|e| ApiError::internal_server_error(&e.to_string()))?
+        .ok_or_else(|| ApiError::not_found("Project not found"))?;
+
+    // Verify ownership
+    if project.owner_id != user.user_id {
+        return Err(ApiError::forbidden("You don't own this project"));
+    }
+
+    Ok(Json(ProjectResponse::from(project)))
+}
+
+/// Update a project.
+#[utoipa::path(
+    put,
+    path = "/v1/projects/{id}",
+    tag = "Projects",
+    params(
+        ("id" = Uuid, Path, description = "Project ID")
+    ),
+    request_body = UpdateProjectRequest,
+    responses(
+        (status = 200, description = "Project updated", body = ProjectResponse),
+        (status = 404, description = "Project not found"),
+    )
+)]
+pub async fn update_project(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<UpdateProjectRequest>,
+) -> Result<Json<ProjectResponse>, ApiError> {
+    // Verify ownership
+    let existing = state
+        .project_repository
+        .get_by_id(id)
+        .await
+        .map_err(|e| ApiError::internal_server_error(&e.to_string()))?
+        .ok_or_else(|| ApiError::not_found("Project not found"))?;
+
+    if existing.owner_id != user.user_id {
+        return Err(ApiError::forbidden("You don't own this project"));
+    }
+
+    let project = state
+        .project_repository
+        .update(
+            id,
+            UpdateProject {
+                name: body.name,
+                description: body.description,
+                homepage_url: body.homepage_url,
+                privacy_policy_url: body.privacy_policy_url,
+                terms_url: body.terms_url,
+            },
+        )
+        .await
+        .map_err(|e| ApiError::internal_server_error(&e.to_string()))?
+        .ok_or_else(|| ApiError::not_found("Project not found"))?;
+
+    Ok(Json(ProjectResponse::from(project)))
+}
+
+/// Delete a project.
+#[utoipa::path(
+    delete,
+    path = "/v1/projects/{id}",
+    tag = "Projects",
+    params(
+        ("id" = Uuid, Path, description = "Project ID")
+    ),
+    responses(
+        (status = 204, description = "Project deleted"),
+        (status = 404, description = "Project not found"),
+    )
+)]
+pub async fn delete_project(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Path(id): Path<Uuid>,
+) -> Result<(), ApiError> {
+    // Verify ownership
+    let existing = state
+        .project_repository
+        .get_by_id(id)
+        .await
+        .map_err(|e| ApiError::internal_server_error(&e.to_string()))?
+        .ok_or_else(|| ApiError::not_found("Project not found"))?;
+
+    if existing.owner_id != user.user_id {
+        return Err(ApiError::forbidden("You don't own this project"));
+    }
+
+    state
+        .project_repository
+        .delete(id)
+        .await
+        .map_err(|e| ApiError::internal_server_error(&e.to_string()))?;
+
+    Ok(())
+}
+
+// =============================================================================
+// OAuth Client Routes
+// =============================================================================
+
+/// Create an OAuth client for a project.
+#[utoipa::path(
+    post,
+    path = "/v1/projects/{project_id}/clients",
+    tag = "OAuth Clients",
+    params(
+        ("project_id" = Uuid, Path, description = "Project ID")
+    ),
+    request_body = CreateOAuthClientRequest,
+    responses(
+        (status = 201, description = "OAuth client created", body = OAuthClientResponse),
+        (status = 400, description = "Invalid request", body = crate::error::ApiErrorResponse),
+    )
+)]
+pub async fn create_oauth_client(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Path(project_id): Path<Uuid>,
+    Json(body): Json<CreateOAuthClientRequest>,
+) -> Result<Json<OAuthClientResponse>, ApiError> {
+    // Verify project ownership
+    let project = state
+        .project_repository
+        .get_by_id(project_id)
+        .await
+        .map_err(|e| ApiError::internal_server_error(&e.to_string()))?
+        .ok_or_else(|| ApiError::not_found("Project not found"))?;
+
+    if project.owner_id != user.user_id {
+        return Err(ApiError::forbidden("You don't own this project"));
+    }
+
+    // Parse client_type from string
+    let client_type = OAuthClientType::from_str(&body.client_type)
+        .ok_or_else(|| ApiError::bad_request("Invalid client_type. Must be 'confidential' or 'public'"))?;
+
+    // Generate client_id and optionally hash client_secret
+    let client_id = format!("client_{}", Uuid::new_v4().simple());
+    let client_secret_hash = body.client_secret.as_ref().map(|secret| {
+        use sha2::{Sha256, Digest};
+        let mut hasher = Sha256::new();
+        hasher.update(secret.as_bytes());
+        format!("{:x}", hasher.finalize())
+    });
+
+    let client = state
+        .oauth_client_repository
+        .create(CreateOAuthClient {
+            project_id,
+            client_id,
+            client_secret_hash,
+            client_type,
+            redirect_uris: body.redirect_uris,
+            allowed_scopes: body.allowed_scopes,
+        })
+        .await
+        .map_err(|e| ApiError::internal_server_error(&e.to_string()))?;
+
+    Ok(Json(OAuthClientResponse::from(client)))
+}
+
+/// List OAuth clients for a project.
+#[utoipa::path(
+    get,
+    path = "/v1/projects/{project_id}/clients",
+    tag = "OAuth Clients",
+    params(
+        ("project_id" = Uuid, Path, description = "Project ID")
+    ),
+    responses(
+        (status = 200, description = "List of OAuth clients", body = Vec<OAuthClientResponse>),
+    )
+)]
+pub async fn list_oauth_clients(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Path(project_id): Path<Uuid>,
+) -> Result<Json<Vec<OAuthClientResponse>>, ApiError> {
+    // Verify project ownership
+    let project = state
+        .project_repository
+        .get_by_id(project_id)
+        .await
+        .map_err(|e| ApiError::internal_server_error(&e.to_string()))?
+        .ok_or_else(|| ApiError::not_found("Project not found"))?;
+
+    if project.owner_id != user.user_id {
+        return Err(ApiError::forbidden("You don't own this project"));
+    }
+
+    let clients = state
+        .oauth_client_repository
+        .list_by_project(project_id)
+        .await
+        .map_err(|e| ApiError::internal_server_error(&e.to_string()))?;
+
+    Ok(Json(clients.into_iter().map(OAuthClientResponse::from).collect()))
+}
+
+/// List authorized projects (projects whose OAuth clients the user has granted access to).
+#[utoipa::path(
+    get,
+    path = "/v1/authorized-projects",
+    tag = "Projects",
+    responses(
+        (status = 200, description = "List of authorized projects", body = Vec<AuthorizedProjectResponse>),
+    )
+)]
+pub async fn list_authorized_projects(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+) -> Result<Json<Vec<AuthorizedProjectResponse>>, ApiError> {
+    let grants = state
+        .access_grant_repository
+        .list_by_user(user.user_id)
+        .await
+        .map_err(|e| ApiError::internal_server_error(&e.to_string()))?;
+
+    let mut authorized_projects = Vec::new();
+
+    for grant in grants {
+        // Get the OAuth client
+        if let Ok(Some(client)) = state
+            .oauth_client_repository
+            .get_by_client_id(&grant.client_id)
+            .await
+        {
+            // Get the project
+            if let Ok(Some(project)) = state
+                .project_repository
+                .get_by_id(client.project_id)
+                .await
+            {
+                authorized_projects.push(AuthorizedProjectResponse {
+                    project_id: project.id,
+                    project_name: project.name,
+                    project_description: project.description,
+                    client_id: client.client_id,
+                    scopes: grant.scopes,
+                    granted_at: grant.created_at,
+                });
+            }
+        }
+    }
+
+    Ok(Json(authorized_projects))
+}
+
+/// Revoke access to an authorized app.
+#[utoipa::path(
+    delete,
+    path = "/v1/authorized-projects/{client_id}",
+    tag = "Projects",
+    params(
+        ("client_id" = String, Path, description = "OAuth Client ID to revoke")
+    ),
+    responses(
+        (status = 204, description = "Access revoked"),
+        (status = 404, description = "Grant not found"),
+    )
+)]
+pub async fn revoke_authorized_project(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Path(client_id): Path<String>,
+) -> Result<(), ApiError> {
+    let revoked = state
+        .access_grant_repository
+        .revoke(user.user_id, &client_id)
+        .await
+        .map_err(|e| ApiError::internal_server_error(&e.to_string()))?;
+
+    if !revoked {
+        return Err(ApiError::not_found("Grant not found"));
+    }
+
+    Ok(())
+}
+
+// =============================================================================
+// DTOs
+// =============================================================================
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateProjectRequest {
+    pub name: String,
+    pub description: Option<String>,
+    pub homepage_url: Option<String>,
+    pub privacy_policy_url: Option<String>,
+    pub terms_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct UpdateProjectRequest {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub homepage_url: Option<String>,
+    pub privacy_policy_url: Option<String>,
+    pub terms_url: Option<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ProjectResponse {
+    pub id: Uuid,
+    pub owner_id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    pub homepage_url: Option<String>,
+    pub privacy_policy_url: Option<String>,
+    pub terms_url: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<services::auth::oauth_ports::Project> for ProjectResponse {
+    fn from(p: services::auth::oauth_ports::Project) -> Self {
+        Self {
+            id: p.id,
+            owner_id: p.owner_id.into_uuid(),
+            name: p.name,
+            description: p.description,
+            homepage_url: p.homepage_url,
+            privacy_policy_url: p.privacy_policy_url,
+            terms_url: p.terms_url,
+            created_at: p.created_at.to_rfc3339(),
+            updated_at: p.updated_at.to_rfc3339(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateOAuthClientRequest {
+    /// Client type: "confidential" or "public"
+    pub client_type: String,
+    pub client_secret: Option<String>,
+    pub redirect_uris: Vec<String>,
+    pub allowed_scopes: Vec<String>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct OAuthClientResponse {
+    pub id: Uuid,
+    pub project_id: Uuid,
+    pub client_id: String,
+    pub client_type: String,
+    pub redirect_uris: Vec<String>,
+    pub allowed_scopes: Vec<String>,
+    pub created_at: String,
+    pub revoked_at: Option<String>,
+}
+
+impl From<services::auth::oauth_ports::OAuthClient> for OAuthClientResponse {
+    fn from(c: services::auth::oauth_ports::OAuthClient) -> Self {
+        Self {
+            id: c.id,
+            project_id: c.project_id,
+            client_id: c.client_id,
+            client_type: format!("{:?}", c.client_type),
+            redirect_uris: c.redirect_uris,
+            allowed_scopes: c.allowed_scopes,
+            created_at: c.created_at.to_rfc3339(),
+            revoked_at: c.revoked_at.map(|dt| dt.to_rfc3339()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AuthorizedProjectResponse {
+    pub project_id: Uuid,
+    pub project_name: String,
+    pub project_description: Option<String>,
+    pub client_id: String,
+    pub scopes: Vec<String>,
+    pub granted_at: chrono::DateTime<chrono::Utc>,
+}
+
+// =============================================================================
+// Router
+// =============================================================================
+
+pub fn create_project_router() -> Router<AppState> {
+    Router::new()
+        .route("/projects", post(create_project).get(list_projects))
+        .route(
+            "/projects/{id}",
+            get(get_project).put(update_project).delete(delete_project),
+        )
+        .route(
+            "/projects/{project_id}/clients",
+            post(create_oauth_client).get(list_oauth_clients),
+        )
+        .route("/authorized-projects", get(list_authorized_projects))
+        .route("/authorized-projects/{client_id}", delete(revoke_authorized_project))
+}

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -34,6 +34,7 @@ pub type ModelSettingsCache = Arc<RwLock<HashMap<String, ModelSettingsCacheEntry
 #[derive(Clone)]
 pub struct AppState {
     pub oauth_service: Arc<dyn services::auth::ports::OAuthService>,
+    pub oauth_server_service: Arc<dyn services::auth::OAuthServerService>,
     pub user_service: Arc<dyn services::user::ports::UserService>,
     pub user_settings_service: Arc<dyn services::user::ports::UserSettingsService>,
     pub model_service: Arc<dyn services::model::ports::ModelService>,
@@ -64,4 +65,10 @@ pub struct AppState {
     pub response_author_repository: Arc<ResponseAuthorRepository>,
     /// Rate limit state for hot-reloadable rate limit configuration
     pub rate_limit_state: crate::middleware::RateLimitState,
+    /// Project repository for managing OAuth projects
+    pub project_repository: Arc<dyn services::auth::oauth_ports::ProjectRepository>,
+    /// OAuth client repository for managing OAuth clients
+    pub oauth_client_repository: Arc<dyn services::auth::oauth_ports::OAuthClientRepository>,
+    /// Access grant repository for tracking user authorizations
+    pub access_grant_repository: Arc<dyn services::auth::oauth_ports::AccessGrantRepository>,
 }

--- a/crates/api/tests/common.rs
+++ b/crates/api/tests/common.rs
@@ -78,6 +78,17 @@ pub async fn create_test_server_with_config(test_config: TestServerConfig) -> Te
 
     let user_service = Arc::new(services::user::UserServiceImpl::new(user_repo.clone()));
 
+    // Create OAuth server service
+    let oauth_server_service = Arc::new(services::auth::OAuthServerServiceImpl::new(
+        db.oauth_client_repository(),
+        db.authorization_code_repository(),
+        db.access_token_repository(),
+        db.refresh_token_repository(),
+        db.access_grant_repository(),
+        db.pending_authorization_repository(),
+        db.project_repository(),
+    ));
+
     let user_settings_service = Arc::new(services::user::UserSettingsServiceImpl::new(
         user_settings_repo,
     ));
@@ -147,6 +158,7 @@ pub async fn create_test_server_with_config(test_config: TestServerConfig) -> Te
     // Create application state
     let app_state = AppState {
         oauth_service,
+        oauth_server_service,
         user_service,
         user_settings_service,
         model_service,

--- a/crates/api/tests/oauth_server_tests.rs
+++ b/crates/api/tests/oauth_server_tests.rs
@@ -1,0 +1,248 @@
+//! Integration tests for OAuth 2.0 Authorization Server endpoints.
+
+mod common;
+
+use axum::http::HeaderValue;
+use serde_json::Value;
+use uuid::Uuid;
+
+#[tokio::test]
+async fn test_token_endpoint_missing_grant_type() {
+    let server = common::create_test_server().await;
+
+    // Test that missing grant_type returns error
+    // Axum's Form extractor returns 422 Unprocessable Entity for missing required fields
+    let response = server
+        .post("/v1/oauth/token")
+        .form(&[("client_id", "test")])
+        .await;
+
+    // Accept either 400 (OAuth standard) or 422 (Axum form validation)
+    let status = response.status_code();
+    assert!(
+        status == 400 || status == 422,
+        "Expected 400 or 422, got {}",
+        status
+    );
+}
+
+#[tokio::test]
+async fn test_token_endpoint_unsupported_grant_type() {
+    let server = common::create_test_server().await;
+
+    // Test unsupported grant_type
+    let response = server
+        .post("/v1/oauth/token")
+        .form(&[("grant_type", "password"), ("client_id", "test")])
+        .await;
+
+    assert_eq!(response.status_code(), 400);
+    let body: Value = response.json();
+    assert_eq!(body["error"].as_str(), Some("unsupported_grant_type"));
+}
+
+#[tokio::test]
+async fn test_token_endpoint_invalid_client() {
+    let server = common::create_test_server().await;
+
+    // Test with non-existent client
+    let response = server
+        .post("/v1/oauth/token")
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("client_id", "nonexistent"),
+            ("code", "test"),
+            ("redirect_uri", "http://localhost"),
+        ])
+        .await;
+
+    assert_eq!(response.status_code(), 401);
+    let body: Value = response.json();
+    assert_eq!(body["error"].as_str(), Some("invalid_client"));
+}
+
+#[tokio::test]
+async fn test_token_endpoint_missing_code() {
+    let server = common::create_test_server().await;
+
+    // Test authorization_code grant without code
+    let response = server
+        .post("/v1/oauth/token")
+        .form(&[("grant_type", "authorization_code"), ("client_id", "test")])
+        .await;
+
+    assert_eq!(response.status_code(), 400);
+    let body: Value = response.json();
+    assert_eq!(body["error"].as_str(), Some("invalid_request"));
+    assert!(body["error_description"]
+        .as_str()
+        .unwrap_or("")
+        .contains("code is required"));
+}
+
+#[tokio::test]
+async fn test_token_endpoint_missing_redirect_uri() {
+    let server = common::create_test_server().await;
+
+    // Test authorization_code grant without redirect_uri
+    let response = server
+        .post("/v1/oauth/token")
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("client_id", "test"),
+            ("code", "test_code"),
+        ])
+        .await;
+
+    assert_eq!(response.status_code(), 400);
+    let body: Value = response.json();
+    assert_eq!(body["error"].as_str(), Some("invalid_request"));
+    assert!(body["error_description"]
+        .as_str()
+        .unwrap_or("")
+        .contains("redirect_uri is required"));
+}
+
+#[tokio::test]
+async fn test_token_endpoint_refresh_missing_token() {
+    let server = common::create_test_server().await;
+
+    // Test refresh_token grant without refresh_token
+    let response = server
+        .post("/v1/oauth/token")
+        .form(&[("grant_type", "refresh_token"), ("client_id", "test")])
+        .await;
+
+    assert_eq!(response.status_code(), 400);
+    let body: Value = response.json();
+    assert_eq!(body["error"].as_str(), Some("invalid_request"));
+    assert!(body["error_description"]
+        .as_str()
+        .unwrap_or("")
+        .contains("refresh_token is required"));
+}
+
+#[tokio::test]
+async fn test_authorize_endpoint_requires_auth() {
+    let server = common::create_test_server().await;
+
+    // Test that authorize endpoint requires authentication
+    let response = server
+        .get("/v1/oauth/authorize")
+        .add_query_param("response_type", "code")
+        .add_query_param("client_id", "test")
+        .add_query_param("redirect_uri", "http://localhost:3000/callback")
+        .add_query_param("scope", "memory.read")
+        .await;
+
+    // Should return 401 Unauthorized since no session token
+    assert_eq!(response.status_code(), 401);
+}
+
+#[tokio::test]
+async fn test_authorize_endpoint_invalid_client() {
+    let server = common::create_test_server().await;
+    let token = common::mock_login(&server, "oauth_test@example.com").await;
+
+    // Test with non-existent client
+    let response = server
+        .get("/v1/oauth/authorize")
+        .authorization_bearer(&token)
+        .add_query_param("response_type", "code")
+        .add_query_param("client_id", "nonexistent_client")
+        .add_query_param("redirect_uri", "http://localhost:3000/callback")
+        .add_query_param("scope", "memory.read")
+        .await;
+
+    // Should return error (either 400 or JSON with error)
+    let status = response.status_code();
+    assert!(status == 400 || status == 401);
+    let body: Value = response.json();
+    assert_eq!(body["error"].as_str(), Some("invalid_client"));
+}
+
+#[tokio::test]
+async fn test_authorize_endpoint_unsupported_response_type() {
+    let server = common::create_test_server().await;
+    let token = common::mock_login(&server, "oauth_test2@example.com").await;
+
+    // Test with unsupported response_type (token instead of code)
+    // Since the client doesn't exist, this will fail with invalid_client first
+    // The unsupported_response_type error would only appear if client exists
+    let response = server
+        .get("/v1/oauth/authorize")
+        .authorization_bearer(&token)
+        .add_query_param("response_type", "token")
+        .add_query_param("client_id", "test")
+        .add_query_param("redirect_uri", "http://localhost:3000/callback")
+        .add_query_param("scope", "memory.read")
+        .await;
+
+    // With invalid client, we get a redirect to the redirect_uri with error (302/303)
+    // OR a 400/401 error response. Accept any of these.
+    let status = response.status_code();
+    assert!(
+        status == 302 || status == 303 || status == 400 || status == 401,
+        "Expected 302, 303, 400, or 401, got {}",
+        status
+    );
+}
+
+#[tokio::test]
+async fn test_consent_endpoint_requires_auth() {
+    let server = common::create_test_server().await;
+    let pending_id = Uuid::new_v4();
+
+    // Test that consent GET endpoint requires authentication
+    let response = server
+        .get(&format!("/v1/oauth/consent/{}", pending_id))
+        .await;
+
+    assert_eq!(response.status_code(), 401);
+}
+
+#[tokio::test]
+async fn test_consent_endpoint_not_found() {
+    let server = common::create_test_server().await;
+    let token = common::mock_login(&server, "oauth_consent_test@example.com").await;
+    let pending_id = Uuid::new_v4();
+
+    // Test with non-existent pending authorization
+    let response = server
+        .get(&format!("/v1/oauth/consent/{}", pending_id))
+        .authorization_bearer(&token)
+        .await;
+
+    assert_eq!(response.status_code(), 400);
+    let body: Value = response.json();
+    assert_eq!(body["error"].as_str(), Some("invalid_request"));
+}
+
+#[tokio::test]
+async fn test_token_endpoint_basic_auth() {
+    use base64::Engine;
+    let server = common::create_test_server().await;
+
+    // Test that Basic auth header is parsed correctly
+    // Even though client doesn't exist, it should parse the auth header
+    let credentials = base64::engine::general_purpose::STANDARD.encode("test_client:test_secret");
+
+    let response = server
+        .post("/v1/oauth/token")
+        .add_header(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_str(&format!("Basic {}", credentials)).unwrap(),
+        )
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("code", "test"),
+            ("redirect_uri", "http://localhost"),
+        ])
+        .await;
+
+    // Should fail with invalid_client (not invalid_request for missing client_id)
+    // because the Basic auth was parsed successfully
+    assert_eq!(response.status_code(), 401);
+    let body: Value = response.json();
+    assert_eq!(body["error"].as_str(), Some("invalid_client"));
+}

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -6,11 +6,13 @@ pub mod repositories;
 
 pub use pool::DbPool;
 pub use repositories::{
-    PostgresAnalyticsRepository, PostgresAppConfigRepository, PostgresConversationRepository,
-    PostgresConversationShareRepository, PostgresFileRepository, PostgresModelRepository,
-    PostgresNearNonceRepository, PostgresOAuthRepository, PostgresSessionRepository,
-    PostgresSystemConfigsRepository, PostgresUserRepository, PostgresUserSettingsRepository,
-    ResponseAuthorRepository,
+    PostgresAccessGrantRepository, PostgresAccessTokenRepository, PostgresAnalyticsRepository,
+    PostgresAppConfigRepository, PostgresAuthorizationCodeRepository,
+    PostgresConversationRepository, PostgresConversationShareRepository, PostgresFileRepository,
+    PostgresModelRepository, PostgresNearNonceRepository, PostgresOAuthClientRepository,
+    PostgresOAuthRepository, PostgresPendingAuthorizationRepository, PostgresProjectRepository,
+    PostgresRefreshTokenRepository, PostgresSessionRepository, PostgresSystemConfigsRepository,
+    PostgresUserRepository, PostgresUserSettingsRepository, ResponseAuthorRepository,
 };
 
 use crate::pool::create_pool_with_native_tls;
@@ -37,6 +39,14 @@ pub struct Database {
     analytics_repository: Arc<PostgresAnalyticsRepository>,
     model_repository: Arc<PostgresModelRepository>,
     response_author_repository: Arc<ResponseAuthorRepository>,
+    // OAuth server repositories
+    project_repository: Arc<PostgresProjectRepository>,
+    oauth_client_repository: Arc<PostgresOAuthClientRepository>,
+    authorization_code_repository: Arc<PostgresAuthorizationCodeRepository>,
+    access_token_repository: Arc<PostgresAccessTokenRepository>,
+    refresh_token_repository: Arc<PostgresRefreshTokenRepository>,
+    access_grant_repository: Arc<PostgresAccessGrantRepository>,
+    pending_authorization_repository: Arc<PostgresPendingAuthorizationRepository>,
     cluster_manager: Option<Arc<ClusterManager>>,
 }
 
@@ -58,6 +68,16 @@ impl Database {
         let analytics_repository = Arc::new(PostgresAnalyticsRepository::new(pool.clone()));
         let model_repository = Arc::new(PostgresModelRepository::new(pool.clone()));
         let response_author_repository = Arc::new(ResponseAuthorRepository::new(pool.clone()));
+        // OAuth server repositories
+        let project_repository = Arc::new(PostgresProjectRepository::new(pool.clone()));
+        let oauth_client_repository = Arc::new(PostgresOAuthClientRepository::new(pool.clone()));
+        let authorization_code_repository =
+            Arc::new(PostgresAuthorizationCodeRepository::new(pool.clone()));
+        let access_token_repository = Arc::new(PostgresAccessTokenRepository::new(pool.clone()));
+        let refresh_token_repository = Arc::new(PostgresRefreshTokenRepository::new(pool.clone()));
+        let access_grant_repository = Arc::new(PostgresAccessGrantRepository::new(pool.clone()));
+        let pending_authorization_repository =
+            Arc::new(PostgresPendingAuthorizationRepository::new(pool.clone()));
 
         Self {
             pool,
@@ -74,6 +94,13 @@ impl Database {
             analytics_repository,
             model_repository,
             response_author_repository,
+            project_repository,
+            oauth_client_repository,
+            authorization_code_repository,
+            access_token_repository,
+            refresh_token_repository,
+            access_grant_repository,
+            pending_authorization_repository,
             cluster_manager: None,
         }
     }
@@ -261,5 +288,40 @@ impl Database {
     /// Get the response author repository
     pub fn response_author_repository(&self) -> Arc<ResponseAuthorRepository> {
         self.response_author_repository.clone()
+    }
+
+    /// Get the project repository
+    pub fn project_repository(&self) -> Arc<PostgresProjectRepository> {
+        self.project_repository.clone()
+    }
+
+    /// Get the OAuth client repository
+    pub fn oauth_client_repository(&self) -> Arc<PostgresOAuthClientRepository> {
+        self.oauth_client_repository.clone()
+    }
+
+    /// Get the authorization code repository
+    pub fn authorization_code_repository(&self) -> Arc<PostgresAuthorizationCodeRepository> {
+        self.authorization_code_repository.clone()
+    }
+
+    /// Get the access token repository
+    pub fn access_token_repository(&self) -> Arc<PostgresAccessTokenRepository> {
+        self.access_token_repository.clone()
+    }
+
+    /// Get the refresh token repository
+    pub fn refresh_token_repository(&self) -> Arc<PostgresRefreshTokenRepository> {
+        self.refresh_token_repository.clone()
+    }
+
+    /// Get the access grant repository
+    pub fn access_grant_repository(&self) -> Arc<PostgresAccessGrantRepository> {
+        self.access_grant_repository.clone()
+    }
+
+    /// Get the pending authorization repository
+    pub fn pending_authorization_repository(&self) -> Arc<PostgresPendingAuthorizationRepository> {
+        self.pending_authorization_repository.clone()
     }
 }

--- a/crates/database/src/migrations/sql/V16__oauth_extensions.sql
+++ b/crates/database/src/migrations/sql/V16__oauth_extensions.sql
@@ -1,0 +1,101 @@
+-- OAuth Extensions for Private Memory API
+-- Adds support for third-party OAuth clients, projects, scopes, and user consent
+
+-- Projects: Developer-created applications that access user memory
+CREATE TABLE projects (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    owner_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    homepage_url TEXT,
+    privacy_policy_url TEXT,
+    terms_url TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(owner_id, name)
+);
+
+CREATE INDEX idx_projects_owner ON projects(owner_id);
+
+-- Trigger for projects updated_at
+CREATE TRIGGER update_projects_updated_at
+    BEFORE UPDATE ON projects
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- OAuth Clients: OAuth 2.0 client credentials for projects
+CREATE TABLE oauth_clients (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    project_id UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    client_id VARCHAR(64) NOT NULL UNIQUE,
+    client_secret_hash VARCHAR(64),
+    client_type VARCHAR(20) NOT NULL,
+    redirect_uris TEXT[] NOT NULL,
+    allowed_scopes TEXT[] NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    revoked_at TIMESTAMPTZ,
+    CONSTRAINT valid_client_type CHECK (client_type IN ('confidential', 'public'))
+);
+
+CREATE INDEX idx_oauth_clients_project ON oauth_clients(project_id);
+CREATE INDEX idx_oauth_clients_client_id ON oauth_clients(client_id);
+
+-- Authorization Codes: Short-lived codes for OAuth code flow
+CREATE TABLE oauth_authorization_codes (
+    code VARCHAR(64) PRIMARY KEY,
+    client_id VARCHAR(64) NOT NULL,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    redirect_uri TEXT NOT NULL,
+    scopes TEXT[] NOT NULL,
+    code_challenge VARCHAR(128),
+    code_challenge_method VARCHAR(10),
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_oauth_codes_expires ON oauth_authorization_codes(expires_at);
+CREATE INDEX idx_oauth_codes_client ON oauth_authorization_codes(client_id);
+
+-- Access Tokens: OAuth access tokens (hashed)
+CREATE TABLE oauth_access_tokens (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    token_hash VARCHAR(64) NOT NULL UNIQUE,
+    client_id VARCHAR(64) NOT NULL,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    scopes TEXT[] NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    revoked_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_oauth_access_tokens_user ON oauth_access_tokens(user_id);
+CREATE INDEX idx_oauth_access_tokens_client ON oauth_access_tokens(client_id);
+CREATE INDEX idx_oauth_access_tokens_hash ON oauth_access_tokens(token_hash);
+CREATE INDEX idx_oauth_access_tokens_expires ON oauth_access_tokens(expires_at);
+
+-- Refresh Tokens: Long-lived tokens for obtaining new access tokens
+CREATE TABLE oauth_refresh_tokens (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    token_hash VARCHAR(64) NOT NULL UNIQUE,
+    access_token_id UUID NOT NULL REFERENCES oauth_access_tokens(id) ON DELETE CASCADE,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    revoked_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_oauth_refresh_tokens_hash ON oauth_refresh_tokens(token_hash);
+CREATE INDEX idx_oauth_refresh_tokens_expires ON oauth_refresh_tokens(expires_at);
+
+-- Access Grants: Records user consent (User X granted Client Y these scopes)
+CREATE TABLE oauth_access_grants (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    client_id VARCHAR(64) NOT NULL,
+    scopes TEXT[] NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    revoked_at TIMESTAMPTZ,
+    UNIQUE(user_id, client_id)
+);
+
+CREATE INDEX idx_oauth_grants_user ON oauth_access_grants(user_id);
+CREATE INDEX idx_oauth_grants_client ON oauth_access_grants(client_id);

--- a/crates/database/src/migrations/sql/V17__oauth_server_enhancements.sql
+++ b/crates/database/src/migrations/sql/V17__oauth_server_enhancements.sql
@@ -1,0 +1,31 @@
+-- OAuth Server Enhancements for Authorization Code Flow
+-- Adds pending authorization support and improves refresh token tracking
+
+-- Add user_id/client_id to refresh tokens for direct lookup
+-- This fixes the issue where refresh tokens only link via access_token_id,
+-- which breaks when the access token expires and gets cleaned up
+ALTER TABLE oauth_refresh_tokens
+  ADD COLUMN IF NOT EXISTS user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  ADD COLUMN IF NOT EXISTS client_id VARCHAR(64);
+
+-- Create index for refresh token lookups by user/client
+CREATE INDEX IF NOT EXISTS idx_oauth_refresh_tokens_user ON oauth_refresh_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_oauth_refresh_tokens_client ON oauth_refresh_tokens(client_id);
+
+-- Pending authorizations for consent flow (short-lived, 10 min TTL)
+-- These store the authorization request while the user reviews and approves consent
+CREATE TABLE oauth_pending_authorizations (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    client_id VARCHAR(64) NOT NULL,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    redirect_uri TEXT NOT NULL,
+    scopes TEXT[] NOT NULL,
+    state TEXT,
+    code_challenge VARCHAR(128),
+    code_challenge_method VARCHAR(10),
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_oauth_pending_auth_expires ON oauth_pending_authorizations(expires_at);
+CREATE INDEX idx_oauth_pending_auth_user ON oauth_pending_authorizations(user_id);

--- a/crates/database/src/repositories/mod.rs
+++ b/crates/database/src/repositories/mod.rs
@@ -5,6 +5,7 @@ pub mod conversation_share_repository;
 pub mod file_repository;
 pub mod model_repository;
 pub mod near_nonce_repository;
+pub mod oauth_client_repository;
 pub mod oauth_repository;
 pub mod response_author_repository;
 pub mod session_repository;
@@ -19,6 +20,12 @@ pub use conversation_share_repository::PostgresConversationShareRepository;
 pub use file_repository::PostgresFileRepository;
 pub use model_repository::PostgresModelRepository;
 pub use near_nonce_repository::PostgresNearNonceRepository;
+pub use oauth_client_repository::{
+    PostgresAccessGrantRepository, PostgresAccessTokenRepository,
+    PostgresAuthorizationCodeRepository, PostgresOAuthClientRepository,
+    PostgresPendingAuthorizationRepository, PostgresProjectRepository,
+    PostgresRefreshTokenRepository,
+};
 pub use oauth_repository::PostgresOAuthRepository;
 pub use response_author_repository::ResponseAuthorRepository;
 pub use session_repository::PostgresSessionRepository;

--- a/crates/database/src/repositories/oauth_client_repository.rs
+++ b/crates/database/src/repositories/oauth_client_repository.rs
@@ -1,0 +1,796 @@
+//! PostgreSQL implementations for OAuth client and token repositories.
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use crate::pool::DbPool;
+use services::{
+    auth::{
+        AccessGrantRepository, AccessTokenRepository, AuthorizationCodeRepository,
+        CreateAccessToken, CreateAuthorizationCode, CreateOAuthClient, CreatePendingAuthorization,
+        CreateProject, CreateRefreshToken, OAuthAccessGrant, OAuthAccessToken,
+        OAuthAuthorizationCode, OAuthClient, OAuthClientRepository, OAuthClientType,
+        OAuthPendingAuthorization, OAuthRefreshToken, PendingAuthorizationRepository, Project,
+        ProjectRepository, RefreshTokenRepository, UpdateProject, UpsertAccessGrant,
+    },
+    UserId,
+};
+
+// =============================================================================
+// Project Repository
+// =============================================================================
+
+pub struct PostgresProjectRepository {
+    pool: DbPool,
+}
+
+impl PostgresProjectRepository {
+    pub fn new(pool: DbPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl ProjectRepository for PostgresProjectRepository {
+    async fn create(&self, input: CreateProject) -> anyhow::Result<Project> {
+        let client = self.pool.get().await?;
+
+        let row = client
+            .query_one(
+                "INSERT INTO projects (owner_id, name, description, homepage_url, privacy_policy_url, terms_url)
+                 VALUES ($1, $2, $3, $4, $5, $6)
+                 RETURNING id, owner_id, name, description, homepage_url, privacy_policy_url, terms_url, created_at, updated_at",
+                &[
+                    &input.owner_id,
+                    &input.name,
+                    &input.description,
+                    &input.homepage_url,
+                    &input.privacy_policy_url,
+                    &input.terms_url,
+                ],
+            )
+            .await?;
+
+        Ok(Project {
+            id: row.get(0),
+            owner_id: row.get(1),
+            name: row.get(2),
+            description: row.get(3),
+            homepage_url: row.get(4),
+            privacy_policy_url: row.get(5),
+            terms_url: row.get(6),
+            created_at: row.get(7),
+            updated_at: row.get(8),
+        })
+    }
+
+    async fn get_by_id(&self, id: Uuid) -> anyhow::Result<Option<Project>> {
+        let client = self.pool.get().await?;
+
+        let row = client
+            .query_opt(
+                "SELECT id, owner_id, name, description, homepage_url, privacy_policy_url, terms_url, created_at, updated_at
+                 FROM projects WHERE id = $1",
+                &[&id],
+            )
+            .await?;
+
+        Ok(row.map(|r| Project {
+            id: r.get(0),
+            owner_id: r.get(1),
+            name: r.get(2),
+            description: r.get(3),
+            homepage_url: r.get(4),
+            privacy_policy_url: r.get(5),
+            terms_url: r.get(6),
+            created_at: r.get(7),
+            updated_at: r.get(8),
+        }))
+    }
+
+    async fn list_by_owner(&self, owner_id: UserId) -> anyhow::Result<Vec<Project>> {
+        let client = self.pool.get().await?;
+
+        let rows = client
+            .query(
+                "SELECT id, owner_id, name, description, homepage_url, privacy_policy_url, terms_url, created_at, updated_at
+                 FROM projects WHERE owner_id = $1 ORDER BY created_at DESC",
+                &[&owner_id],
+            )
+            .await?;
+
+        Ok(rows
+            .iter()
+            .map(|r| Project {
+                id: r.get(0),
+                owner_id: r.get(1),
+                name: r.get(2),
+                description: r.get(3),
+                homepage_url: r.get(4),
+                privacy_policy_url: r.get(5),
+                terms_url: r.get(6),
+                created_at: r.get(7),
+                updated_at: r.get(8),
+            })
+            .collect())
+    }
+
+    async fn update(&self, id: Uuid, input: UpdateProject) -> anyhow::Result<Option<Project>> {
+        let client = self.pool.get().await?;
+
+        let row = client
+            .query_opt(
+                "UPDATE projects SET
+                    name = COALESCE($2, name),
+                    description = COALESCE($3, description),
+                    homepage_url = COALESCE($4, homepage_url),
+                    privacy_policy_url = COALESCE($5, privacy_policy_url),
+                    terms_url = COALESCE($6, terms_url),
+                    updated_at = NOW()
+                 WHERE id = $1
+                 RETURNING id, owner_id, name, description, homepage_url, privacy_policy_url, terms_url, created_at, updated_at",
+                &[
+                    &id,
+                    &input.name,
+                    &input.description,
+                    &input.homepage_url,
+                    &input.privacy_policy_url,
+                    &input.terms_url,
+                ],
+            )
+            .await?;
+
+        Ok(row.map(|r| Project {
+            id: r.get(0),
+            owner_id: r.get(1),
+            name: r.get(2),
+            description: r.get(3),
+            homepage_url: r.get(4),
+            privacy_policy_url: r.get(5),
+            terms_url: r.get(6),
+            created_at: r.get(7),
+            updated_at: r.get(8),
+        }))
+    }
+
+    async fn delete(&self, id: Uuid) -> anyhow::Result<bool> {
+        let client = self.pool.get().await?;
+
+        let result = client
+            .execute("DELETE FROM projects WHERE id = $1", &[&id])
+            .await?;
+
+        Ok(result > 0)
+    }
+}
+
+// =============================================================================
+// OAuth Client Repository
+// =============================================================================
+
+pub struct PostgresOAuthClientRepository {
+    pool: DbPool,
+}
+
+impl PostgresOAuthClientRepository {
+    pub fn new(pool: DbPool) -> Self {
+        Self { pool }
+    }
+}
+
+fn row_to_oauth_client(row: &tokio_postgres::Row) -> OAuthClient {
+    let client_type_str: String = row.get(4);
+    OAuthClient {
+        id: row.get(0),
+        project_id: row.get(1),
+        client_id: row.get(2),
+        client_secret_hash: row.get(3),
+        client_type: OAuthClientType::from_str(&client_type_str).unwrap_or(OAuthClientType::Public),
+        redirect_uris: row.get(5),
+        allowed_scopes: row.get(6),
+        created_at: row.get(7),
+        revoked_at: row.get(8),
+    }
+}
+
+#[async_trait]
+impl OAuthClientRepository for PostgresOAuthClientRepository {
+    async fn create(&self, input: CreateOAuthClient) -> anyhow::Result<OAuthClient> {
+        let client = self.pool.get().await?;
+
+        let row = client
+            .query_one(
+                "INSERT INTO oauth_clients (project_id, client_id, client_secret_hash, client_type, redirect_uris, allowed_scopes)
+                 VALUES ($1, $2, $3, $4, $5, $6)
+                 RETURNING id, project_id, client_id, client_secret_hash, client_type, redirect_uris, allowed_scopes, created_at, revoked_at",
+                &[
+                    &input.project_id,
+                    &input.client_id,
+                    &input.client_secret_hash,
+                    &input.client_type.as_str(),
+                    &input.redirect_uris,
+                    &input.allowed_scopes,
+                ],
+            )
+            .await?;
+
+        Ok(row_to_oauth_client(&row))
+    }
+
+    async fn get_by_client_id(&self, client_id: &str) -> anyhow::Result<Option<OAuthClient>> {
+        let client = self.pool.get().await?;
+
+        let row = client
+            .query_opt(
+                "SELECT id, project_id, client_id, client_secret_hash, client_type, redirect_uris, allowed_scopes, created_at, revoked_at
+                 FROM oauth_clients WHERE client_id = $1",
+                &[&client_id],
+            )
+            .await?;
+
+        Ok(row.map(|r| row_to_oauth_client(&r)))
+    }
+
+    async fn get_by_id(&self, id: Uuid) -> anyhow::Result<Option<OAuthClient>> {
+        let client = self.pool.get().await?;
+
+        let row = client
+            .query_opt(
+                "SELECT id, project_id, client_id, client_secret_hash, client_type, redirect_uris, allowed_scopes, created_at, revoked_at
+                 FROM oauth_clients WHERE id = $1",
+                &[&id],
+            )
+            .await?;
+
+        Ok(row.map(|r| row_to_oauth_client(&r)))
+    }
+
+    async fn list_by_project(&self, project_id: Uuid) -> anyhow::Result<Vec<OAuthClient>> {
+        let client = self.pool.get().await?;
+
+        let rows = client
+            .query(
+                "SELECT id, project_id, client_id, client_secret_hash, client_type, redirect_uris, allowed_scopes, created_at, revoked_at
+                 FROM oauth_clients WHERE project_id = $1 ORDER BY created_at DESC",
+                &[&project_id],
+            )
+            .await?;
+
+        Ok(rows.iter().map(row_to_oauth_client).collect())
+    }
+
+    async fn revoke(&self, client_id: &str) -> anyhow::Result<bool> {
+        let client = self.pool.get().await?;
+
+        let result = client
+            .execute(
+                "UPDATE oauth_clients SET revoked_at = NOW() WHERE client_id = $1 AND revoked_at IS NULL",
+                &[&client_id],
+            )
+            .await?;
+
+        Ok(result > 0)
+    }
+
+    async fn update_secret(&self, client_id: &str, new_secret_hash: String) -> anyhow::Result<bool> {
+        let client = self.pool.get().await?;
+
+        let result = client
+            .execute(
+                "UPDATE oauth_clients SET client_secret_hash = $2 WHERE client_id = $1",
+                &[&client_id, &new_secret_hash],
+            )
+            .await?;
+
+        Ok(result > 0)
+    }
+}
+
+// =============================================================================
+// Authorization Code Repository
+// =============================================================================
+
+pub struct PostgresAuthorizationCodeRepository {
+    pool: DbPool,
+}
+
+impl PostgresAuthorizationCodeRepository {
+    pub fn new(pool: DbPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl AuthorizationCodeRepository for PostgresAuthorizationCodeRepository {
+    async fn create(&self, input: CreateAuthorizationCode) -> anyhow::Result<()> {
+        let client = self.pool.get().await?;
+
+        client
+            .execute(
+                "INSERT INTO oauth_authorization_codes (code, client_id, user_id, redirect_uri, scopes, code_challenge, code_challenge_method, expires_at)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
+                &[
+                    &input.code,
+                    &input.client_id,
+                    &input.user_id,
+                    &input.redirect_uri,
+                    &input.scopes,
+                    &input.code_challenge,
+                    &input.code_challenge_method,
+                    &input.expires_at,
+                ],
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn consume(&self, code: &str) -> anyhow::Result<Option<OAuthAuthorizationCode>> {
+        let mut client = self.pool.get().await?;
+        let transaction = client.transaction().await?;
+
+        // Get and delete in one transaction
+        let row = transaction
+            .query_opt(
+                "DELETE FROM oauth_authorization_codes
+                 WHERE code = $1 AND expires_at > NOW()
+                 RETURNING code, client_id, user_id, redirect_uri, scopes, code_challenge, code_challenge_method, expires_at, created_at",
+                &[&code],
+            )
+            .await?;
+
+        transaction.commit().await?;
+
+        Ok(row.map(|r| OAuthAuthorizationCode {
+            code: r.get(0),
+            client_id: r.get(1),
+            user_id: r.get(2),
+            redirect_uri: r.get(3),
+            scopes: r.get(4),
+            code_challenge: r.get(5),
+            code_challenge_method: r.get(6),
+            expires_at: r.get(7),
+            created_at: r.get(8),
+        }))
+    }
+
+    async fn delete_expired(&self) -> anyhow::Result<u64> {
+        let client = self.pool.get().await?;
+
+        let result = client
+            .execute(
+                "DELETE FROM oauth_authorization_codes WHERE expires_at <= NOW()",
+                &[],
+            )
+            .await?;
+
+        Ok(result)
+    }
+}
+
+// =============================================================================
+// Access Token Repository
+// =============================================================================
+
+pub struct PostgresAccessTokenRepository {
+    pool: DbPool,
+}
+
+impl PostgresAccessTokenRepository {
+    pub fn new(pool: DbPool) -> Self {
+        Self { pool }
+    }
+}
+
+fn row_to_access_token(row: &tokio_postgres::Row) -> OAuthAccessToken {
+    OAuthAccessToken {
+        id: row.get(0),
+        token_hash: row.get(1),
+        client_id: row.get(2),
+        user_id: row.get(3),
+        scopes: row.get(4),
+        expires_at: row.get(5),
+        created_at: row.get(6),
+        revoked_at: row.get(7),
+    }
+}
+
+#[async_trait]
+impl AccessTokenRepository for PostgresAccessTokenRepository {
+    async fn create(&self, input: CreateAccessToken) -> anyhow::Result<OAuthAccessToken> {
+        let client = self.pool.get().await?;
+
+        let row = client
+            .query_one(
+                "INSERT INTO oauth_access_tokens (token_hash, client_id, user_id, scopes, expires_at)
+                 VALUES ($1, $2, $3, $4, $5)
+                 RETURNING id, token_hash, client_id, user_id, scopes, expires_at, created_at, revoked_at",
+                &[
+                    &input.token_hash,
+                    &input.client_id,
+                    &input.user_id,
+                    &input.scopes,
+                    &input.expires_at,
+                ],
+            )
+            .await?;
+
+        Ok(row_to_access_token(&row))
+    }
+
+    async fn get_by_hash(&self, token_hash: &str) -> anyhow::Result<Option<OAuthAccessToken>> {
+        let client = self.pool.get().await?;
+
+        let row = client
+            .query_opt(
+                "SELECT id, token_hash, client_id, user_id, scopes, expires_at, created_at, revoked_at
+                 FROM oauth_access_tokens WHERE token_hash = $1",
+                &[&token_hash],
+            )
+            .await?;
+
+        Ok(row.map(|r| row_to_access_token(&r)))
+    }
+
+    async fn get_by_id(&self, id: Uuid) -> anyhow::Result<Option<OAuthAccessToken>> {
+        let client = self.pool.get().await?;
+
+        let row = client
+            .query_opt(
+                "SELECT id, token_hash, client_id, user_id, scopes, expires_at, created_at, revoked_at
+                 FROM oauth_access_tokens WHERE id = $1",
+                &[&id],
+            )
+            .await?;
+
+        Ok(row.map(|r| row_to_access_token(&r)))
+    }
+
+    async fn list_by_user(&self, user_id: UserId) -> anyhow::Result<Vec<OAuthAccessToken>> {
+        let client = self.pool.get().await?;
+
+        let rows = client
+            .query(
+                "SELECT id, token_hash, client_id, user_id, scopes, expires_at, created_at, revoked_at
+                 FROM oauth_access_tokens WHERE user_id = $1 ORDER BY created_at DESC",
+                &[&user_id],
+            )
+            .await?;
+
+        Ok(rows.iter().map(row_to_access_token).collect())
+    }
+
+    async fn revoke(&self, id: Uuid) -> anyhow::Result<bool> {
+        let client = self.pool.get().await?;
+
+        let result = client
+            .execute(
+                "UPDATE oauth_access_tokens SET revoked_at = NOW() WHERE id = $1 AND revoked_at IS NULL",
+                &[&id],
+            )
+            .await?;
+
+        Ok(result > 0)
+    }
+
+    async fn revoke_by_user_and_client(
+        &self,
+        user_id: UserId,
+        client_id: &str,
+    ) -> anyhow::Result<u64> {
+        let client = self.pool.get().await?;
+
+        let result = client
+            .execute(
+                "UPDATE oauth_access_tokens SET revoked_at = NOW() WHERE user_id = $1 AND client_id = $2 AND revoked_at IS NULL",
+                &[&user_id, &client_id],
+            )
+            .await?;
+
+        Ok(result)
+    }
+
+    async fn delete_expired(&self) -> anyhow::Result<u64> {
+        let client = self.pool.get().await?;
+
+        let result = client
+            .execute(
+                "DELETE FROM oauth_access_tokens WHERE expires_at <= NOW() AND revoked_at IS NOT NULL",
+                &[],
+            )
+            .await?;
+
+        Ok(result)
+    }
+}
+
+// =============================================================================
+// Refresh Token Repository
+// =============================================================================
+
+pub struct PostgresRefreshTokenRepository {
+    pool: DbPool,
+}
+
+impl PostgresRefreshTokenRepository {
+    pub fn new(pool: DbPool) -> Self {
+        Self { pool }
+    }
+}
+
+fn row_to_refresh_token(row: &tokio_postgres::Row) -> OAuthRefreshToken {
+    OAuthRefreshToken {
+        id: row.get(0),
+        token_hash: row.get(1),
+        access_token_id: row.get(2),
+        user_id: row.get(3),
+        client_id: row.get(4),
+        expires_at: row.get(5),
+        created_at: row.get(6),
+        revoked_at: row.get(7),
+    }
+}
+
+#[async_trait]
+impl RefreshTokenRepository for PostgresRefreshTokenRepository {
+    async fn create(&self, input: CreateRefreshToken) -> anyhow::Result<OAuthRefreshToken> {
+        let client = self.pool.get().await?;
+
+        let row = client
+            .query_one(
+                "INSERT INTO oauth_refresh_tokens (token_hash, access_token_id, user_id, client_id, expires_at)
+                 VALUES ($1, $2, $3, $4, $5)
+                 RETURNING id, token_hash, access_token_id, user_id, client_id, expires_at, created_at, revoked_at",
+                &[&input.token_hash, &input.access_token_id, &input.user_id, &input.client_id, &input.expires_at],
+            )
+            .await?;
+
+        Ok(row_to_refresh_token(&row))
+    }
+
+    async fn get_by_hash(&self, token_hash: &str) -> anyhow::Result<Option<OAuthRefreshToken>> {
+        let client = self.pool.get().await?;
+
+        let row = client
+            .query_opt(
+                "SELECT id, token_hash, access_token_id, user_id, client_id, expires_at, created_at, revoked_at
+                 FROM oauth_refresh_tokens WHERE token_hash = $1",
+                &[&token_hash],
+            )
+            .await?;
+
+        Ok(row.map(|r| row_to_refresh_token(&r)))
+    }
+
+    async fn revoke(&self, id: Uuid) -> anyhow::Result<bool> {
+        let client = self.pool.get().await?;
+
+        let result = client
+            .execute(
+                "UPDATE oauth_refresh_tokens SET revoked_at = NOW() WHERE id = $1 AND revoked_at IS NULL",
+                &[&id],
+            )
+            .await?;
+
+        Ok(result > 0)
+    }
+
+    async fn revoke_by_access_token(&self, access_token_id: Uuid) -> anyhow::Result<bool> {
+        let client = self.pool.get().await?;
+
+        let result = client
+            .execute(
+                "UPDATE oauth_refresh_tokens SET revoked_at = NOW() WHERE access_token_id = $1 AND revoked_at IS NULL",
+                &[&access_token_id],
+            )
+            .await?;
+
+        Ok(result > 0)
+    }
+
+    async fn delete_expired(&self) -> anyhow::Result<u64> {
+        let client = self.pool.get().await?;
+
+        let result = client
+            .execute(
+                "DELETE FROM oauth_refresh_tokens WHERE expires_at <= NOW() AND revoked_at IS NOT NULL",
+                &[],
+            )
+            .await?;
+
+        Ok(result)
+    }
+}
+
+// =============================================================================
+// Access Grant Repository
+// =============================================================================
+
+pub struct PostgresAccessGrantRepository {
+    pool: DbPool,
+}
+
+impl PostgresAccessGrantRepository {
+    pub fn new(pool: DbPool) -> Self {
+        Self { pool }
+    }
+}
+
+fn row_to_access_grant(row: &tokio_postgres::Row) -> OAuthAccessGrant {
+    OAuthAccessGrant {
+        id: row.get(0),
+        user_id: row.get(1),
+        client_id: row.get(2),
+        scopes: row.get(3),
+        created_at: row.get(4),
+        revoked_at: row.get(5),
+    }
+}
+
+#[async_trait]
+impl AccessGrantRepository for PostgresAccessGrantRepository {
+    async fn upsert(&self, input: UpsertAccessGrant) -> anyhow::Result<OAuthAccessGrant> {
+        let client = self.pool.get().await?;
+
+        // Upsert: insert or update scopes (merge with existing)
+        let row = client
+            .query_one(
+                "INSERT INTO oauth_access_grants (user_id, client_id, scopes)
+                 VALUES ($1, $2, $3)
+                 ON CONFLICT (user_id, client_id) DO UPDATE SET
+                    scopes = (
+                        SELECT ARRAY(SELECT DISTINCT unnest FROM unnest(oauth_access_grants.scopes || EXCLUDED.scopes))
+                    ),
+                    revoked_at = NULL
+                 RETURNING id, user_id, client_id, scopes, created_at, revoked_at",
+                &[&input.user_id, &input.client_id, &input.scopes],
+            )
+            .await?;
+
+        Ok(row_to_access_grant(&row))
+    }
+
+    async fn get(&self, user_id: UserId, client_id: &str) -> anyhow::Result<Option<OAuthAccessGrant>> {
+        let client = self.pool.get().await?;
+
+        let row = client
+            .query_opt(
+                "SELECT id, user_id, client_id, scopes, created_at, revoked_at
+                 FROM oauth_access_grants WHERE user_id = $1 AND client_id = $2",
+                &[&user_id, &client_id],
+            )
+            .await?;
+
+        Ok(row.map(|r| row_to_access_grant(&r)))
+    }
+
+    async fn list_by_user(&self, user_id: UserId) -> anyhow::Result<Vec<OAuthAccessGrant>> {
+        let client = self.pool.get().await?;
+
+        let rows = client
+            .query(
+                "SELECT id, user_id, client_id, scopes, created_at, revoked_at
+                 FROM oauth_access_grants WHERE user_id = $1 AND revoked_at IS NULL
+                 ORDER BY created_at DESC",
+                &[&user_id],
+            )
+            .await?;
+
+        Ok(rows.iter().map(row_to_access_grant).collect())
+    }
+
+    async fn revoke(&self, user_id: UserId, client_id: &str) -> anyhow::Result<bool> {
+        let client = self.pool.get().await?;
+
+        let result = client
+            .execute(
+                "UPDATE oauth_access_grants SET revoked_at = NOW() WHERE user_id = $1 AND client_id = $2 AND revoked_at IS NULL",
+                &[&user_id, &client_id],
+            )
+            .await?;
+
+        Ok(result > 0)
+    }
+}
+
+// =============================================================================
+// Pending Authorization Repository
+// =============================================================================
+
+pub struct PostgresPendingAuthorizationRepository {
+    pool: DbPool,
+}
+
+impl PostgresPendingAuthorizationRepository {
+    pub fn new(pool: DbPool) -> Self {
+        Self { pool }
+    }
+}
+
+fn row_to_pending_authorization(row: &tokio_postgres::Row) -> OAuthPendingAuthorization {
+    OAuthPendingAuthorization {
+        id: row.get(0),
+        client_id: row.get(1),
+        user_id: row.get(2),
+        redirect_uri: row.get(3),
+        scopes: row.get(4),
+        state: row.get(5),
+        code_challenge: row.get(6),
+        code_challenge_method: row.get(7),
+        expires_at: row.get(8),
+        created_at: row.get(9),
+    }
+}
+
+#[async_trait]
+impl PendingAuthorizationRepository for PostgresPendingAuthorizationRepository {
+    async fn create(&self, input: CreatePendingAuthorization) -> anyhow::Result<OAuthPendingAuthorization> {
+        let client = self.pool.get().await?;
+
+        let row = client
+            .query_one(
+                "INSERT INTO oauth_pending_authorizations (client_id, user_id, redirect_uri, scopes, state, code_challenge, code_challenge_method, expires_at)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                 RETURNING id, client_id, user_id, redirect_uri, scopes, state, code_challenge, code_challenge_method, expires_at, created_at",
+                &[
+                    &input.client_id,
+                    &input.user_id,
+                    &input.redirect_uri,
+                    &input.scopes,
+                    &input.state,
+                    &input.code_challenge,
+                    &input.code_challenge_method,
+                    &input.expires_at,
+                ],
+            )
+            .await?;
+
+        Ok(row_to_pending_authorization(&row))
+    }
+
+    async fn get_by_id(&self, id: Uuid) -> anyhow::Result<Option<OAuthPendingAuthorization>> {
+        let client = self.pool.get().await?;
+
+        let row = client
+            .query_opt(
+                "SELECT id, client_id, user_id, redirect_uri, scopes, state, code_challenge, code_challenge_method, expires_at, created_at
+                 FROM oauth_pending_authorizations WHERE id = $1 AND expires_at > NOW()",
+                &[&id],
+            )
+            .await?;
+
+        Ok(row.map(|r| row_to_pending_authorization(&r)))
+    }
+
+    async fn consume(&self, id: Uuid) -> anyhow::Result<Option<OAuthPendingAuthorization>> {
+        let mut client = self.pool.get().await?;
+        let transaction = client.transaction().await?;
+
+        // Get and delete in one transaction
+        let row = transaction
+            .query_opt(
+                "DELETE FROM oauth_pending_authorizations
+                 WHERE id = $1 AND expires_at > NOW()
+                 RETURNING id, client_id, user_id, redirect_uri, scopes, state, code_challenge, code_challenge_method, expires_at, created_at",
+                &[&id],
+            )
+            .await?;
+
+        transaction.commit().await?;
+
+        Ok(row.map(|r| row_to_pending_authorization(&r)))
+    }
+
+    async fn delete_expired(&self) -> anyhow::Result<u64> {
+        let client = self.pool.get().await?;
+
+        let result = client
+            .execute(
+                "DELETE FROM oauth_pending_authorizations WHERE expires_at <= NOW()",
+                &[],
+            )
+            .await?;
+
+        Ok(result)
+    }
+}

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -37,6 +37,7 @@ rmcp = { version = "0.6", features = [
 hex = "0.4"
 hmac = "0.12"
 sha2 = "0.10"
+base64 = "0.22"
 dstack-sdk = "0.1"
 # OpenTelemetry for metrics
 opentelemetry = { version = "0.31", features = ["metrics"] }

--- a/crates/services/src/auth/mod.rs
+++ b/crates/services/src/auth/mod.rs
@@ -1,7 +1,31 @@
 pub mod near;
+pub mod oauth_ports;
+pub mod oauth_server_service;
+pub mod pkce;
 pub mod ports;
+pub mod scopes;
 pub mod service;
+pub mod tokens;
 
 pub use near::{NearAuthService, NearNonceRepository, SignedMessage};
+pub use oauth_ports::{
+    AccessGrantRepository, AccessTokenRepository, AuthorizationCodeRepository,
+    CreateAccessToken, CreateAuthorizationCode, CreateOAuthClient, CreatePendingAuthorization,
+    CreateProject, CreateRefreshToken, OAuthAccessGrant, OAuthAccessToken,
+    OAuthAuthorizationCode, OAuthClient, OAuthClientRepository, OAuthClientType,
+    OAuthPendingAuthorization, OAuthRefreshToken, PendingAuthorizationRepository, Project,
+    ProjectRepository, RefreshTokenRepository, UpdateProject, UpsertAccessGrant,
+};
+pub use oauth_server_service::{
+    AuthorizeResult, OAuthServerError, OAuthServerService, OAuthServerServiceImpl,
+    PendingAuthorizationInfo, TokenResponse,
+};
+pub use pkce::{generate_code_challenge, verify_pkce, PkceError};
 pub use ports::OAuthService;
+pub use scopes::{validate_scopes, ScopeError, VALID_SCOPES};
 pub use service::OAuthServiceImpl;
+pub use tokens::{
+    generate_access_token, generate_authorization_code, generate_client_id, generate_client_secret,
+    generate_refresh_token, hash_token, AccessTokenId, AuthorizationCode, ClientId, ClientSecret,
+    RefreshTokenId, TokenPrefix,
+};

--- a/crates/services/src/auth/oauth_ports.rs
+++ b/crates/services/src/auth/oauth_ports.rs
@@ -1,0 +1,404 @@
+//! OAuth 2.0 client and token management ports (repository traits).
+//!
+//! These traits define the interface for storing and retrieving OAuth clients,
+//! authorization codes, access tokens, refresh tokens, and user consent grants.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::types::UserId;
+
+/// A developer project that owns OAuth clients.
+#[derive(Debug, Clone)]
+pub struct Project {
+    pub id: Uuid,
+    pub owner_id: UserId,
+    pub name: String,
+    pub description: Option<String>,
+    pub homepage_url: Option<String>,
+    pub privacy_policy_url: Option<String>,
+    pub terms_url: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Input for creating a new project.
+#[derive(Debug, Clone)]
+pub struct CreateProject {
+    pub owner_id: UserId,
+    pub name: String,
+    pub description: Option<String>,
+    pub homepage_url: Option<String>,
+    pub privacy_policy_url: Option<String>,
+    pub terms_url: Option<String>,
+}
+
+/// Input for updating a project.
+#[derive(Debug, Clone, Default)]
+pub struct UpdateProject {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub homepage_url: Option<String>,
+    pub privacy_policy_url: Option<String>,
+    pub terms_url: Option<String>,
+}
+
+/// OAuth client type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OAuthClientType {
+    /// Confidential clients can keep secrets (backend servers).
+    Confidential,
+    /// Public clients cannot keep secrets (SPAs, mobile apps).
+    Public,
+}
+
+impl OAuthClientType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Confidential => "confidential",
+            Self::Public => "public",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "confidential" => Some(Self::Confidential),
+            "public" => Some(Self::Public),
+            _ => None,
+        }
+    }
+}
+
+/// An OAuth 2.0 client registered to a project.
+#[derive(Debug, Clone)]
+pub struct OAuthClient {
+    pub id: Uuid,
+    pub project_id: Uuid,
+    pub client_id: String,
+    pub client_secret_hash: Option<String>,
+    pub client_type: OAuthClientType,
+    pub redirect_uris: Vec<String>,
+    pub allowed_scopes: Vec<String>,
+    pub created_at: DateTime<Utc>,
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+impl OAuthClient {
+    /// Check if this client is currently active (not revoked).
+    pub fn is_active(&self) -> bool {
+        self.revoked_at.is_none()
+    }
+
+    /// Check if a redirect URI is allowed for this client.
+    pub fn is_redirect_uri_allowed(&self, uri: &str) -> bool {
+        self.redirect_uris.iter().any(|allowed| allowed == uri)
+    }
+
+    /// Check if a scope is allowed for this client.
+    pub fn is_scope_allowed(&self, scope: &str) -> bool {
+        self.allowed_scopes.iter().any(|allowed| allowed == scope)
+    }
+}
+
+/// Input for creating a new OAuth client.
+#[derive(Debug, Clone)]
+pub struct CreateOAuthClient {
+    pub project_id: Uuid,
+    pub client_id: String,
+    pub client_secret_hash: Option<String>,
+    pub client_type: OAuthClientType,
+    pub redirect_uris: Vec<String>,
+    pub allowed_scopes: Vec<String>,
+}
+
+/// An OAuth authorization code (short-lived, used once).
+#[derive(Debug, Clone)]
+pub struct OAuthAuthorizationCode {
+    pub code: String,
+    pub client_id: String,
+    pub user_id: UserId,
+    pub redirect_uri: String,
+    pub scopes: Vec<String>,
+    pub code_challenge: Option<String>,
+    pub code_challenge_method: Option<String>,
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Input for creating a new authorization code.
+#[derive(Debug, Clone)]
+pub struct CreateAuthorizationCode {
+    pub code: String,
+    pub client_id: String,
+    pub user_id: UserId,
+    pub redirect_uri: String,
+    pub scopes: Vec<String>,
+    pub code_challenge: Option<String>,
+    pub code_challenge_method: Option<String>,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// An OAuth access token.
+#[derive(Debug, Clone)]
+pub struct OAuthAccessToken {
+    pub id: Uuid,
+    pub token_hash: String,
+    pub client_id: String,
+    pub user_id: UserId,
+    pub scopes: Vec<String>,
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+impl OAuthAccessToken {
+    /// Check if this token is currently valid (not expired and not revoked).
+    pub fn is_valid(&self) -> bool {
+        self.revoked_at.is_none() && self.expires_at > Utc::now()
+    }
+}
+
+/// Input for creating a new access token.
+#[derive(Debug, Clone)]
+pub struct CreateAccessToken {
+    pub token_hash: String,
+    pub client_id: String,
+    pub user_id: UserId,
+    pub scopes: Vec<String>,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// An OAuth refresh token.
+#[derive(Debug, Clone)]
+pub struct OAuthRefreshToken {
+    pub id: Uuid,
+    pub token_hash: String,
+    pub access_token_id: Uuid,
+    pub user_id: Option<UserId>,
+    pub client_id: Option<String>,
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+impl OAuthRefreshToken {
+    /// Check if this token is currently valid (not expired and not revoked).
+    pub fn is_valid(&self) -> bool {
+        self.revoked_at.is_none() && self.expires_at > Utc::now()
+    }
+}
+
+/// Input for creating a new refresh token.
+#[derive(Debug, Clone)]
+pub struct CreateRefreshToken {
+    pub token_hash: String,
+    pub access_token_id: Uuid,
+    pub user_id: UserId,
+    pub client_id: String,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// A user's consent grant to an OAuth client.
+#[derive(Debug, Clone)]
+pub struct OAuthAccessGrant {
+    pub id: Uuid,
+    pub user_id: UserId,
+    pub client_id: String,
+    pub scopes: Vec<String>,
+    pub created_at: DateTime<Utc>,
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+impl OAuthAccessGrant {
+    /// Check if this grant is currently active (not revoked).
+    pub fn is_active(&self) -> bool {
+        self.revoked_at.is_none()
+    }
+
+    /// Check if all requested scopes are covered by this grant.
+    pub fn covers_scopes(&self, requested: &[String]) -> bool {
+        requested.iter().all(|s| self.scopes.contains(s))
+    }
+}
+
+/// Input for creating or updating an access grant.
+#[derive(Debug, Clone)]
+pub struct UpsertAccessGrant {
+    pub user_id: UserId,
+    pub client_id: String,
+    pub scopes: Vec<String>,
+}
+
+// =============================================================================
+// Repository Traits
+// =============================================================================
+
+/// Repository for managing developer projects.
+#[async_trait]
+pub trait ProjectRepository: Send + Sync {
+    /// Create a new project.
+    async fn create(&self, input: CreateProject) -> anyhow::Result<Project>;
+
+    /// Get a project by ID.
+    async fn get_by_id(&self, id: Uuid) -> anyhow::Result<Option<Project>>;
+
+    /// List all projects owned by a user.
+    async fn list_by_owner(&self, owner_id: UserId) -> anyhow::Result<Vec<Project>>;
+
+    /// Update a project.
+    async fn update(&self, id: Uuid, input: UpdateProject) -> anyhow::Result<Option<Project>>;
+
+    /// Delete a project (cascades to clients).
+    async fn delete(&self, id: Uuid) -> anyhow::Result<bool>;
+}
+
+/// Repository for managing OAuth clients.
+#[async_trait]
+pub trait OAuthClientRepository: Send + Sync {
+    /// Create a new OAuth client.
+    async fn create(&self, input: CreateOAuthClient) -> anyhow::Result<OAuthClient>;
+
+    /// Get an OAuth client by its public client_id.
+    async fn get_by_client_id(&self, client_id: &str) -> anyhow::Result<Option<OAuthClient>>;
+
+    /// Get an OAuth client by its internal UUID.
+    async fn get_by_id(&self, id: Uuid) -> anyhow::Result<Option<OAuthClient>>;
+
+    /// List all clients for a project.
+    async fn list_by_project(&self, project_id: Uuid) -> anyhow::Result<Vec<OAuthClient>>;
+
+    /// Revoke a client (soft delete).
+    async fn revoke(&self, client_id: &str) -> anyhow::Result<bool>;
+
+    /// Update the client secret hash (for secret rotation).
+    async fn update_secret(&self, client_id: &str, new_secret_hash: String) -> anyhow::Result<bool>;
+}
+
+/// Repository for managing authorization codes.
+#[async_trait]
+pub trait AuthorizationCodeRepository: Send + Sync {
+    /// Store a new authorization code.
+    async fn create(&self, input: CreateAuthorizationCode) -> anyhow::Result<()>;
+
+    /// Consume an authorization code (retrieve and delete).
+    /// Returns None if the code doesn't exist or is expired.
+    async fn consume(&self, code: &str) -> anyhow::Result<Option<OAuthAuthorizationCode>>;
+
+    /// Delete expired authorization codes (cleanup).
+    async fn delete_expired(&self) -> anyhow::Result<u64>;
+}
+
+/// Repository for managing access tokens.
+#[async_trait]
+pub trait AccessTokenRepository: Send + Sync {
+    /// Create a new access token.
+    async fn create(&self, input: CreateAccessToken) -> anyhow::Result<OAuthAccessToken>;
+
+    /// Get an access token by its hash.
+    async fn get_by_hash(&self, token_hash: &str) -> anyhow::Result<Option<OAuthAccessToken>>;
+
+    /// Get an access token by ID.
+    async fn get_by_id(&self, id: Uuid) -> anyhow::Result<Option<OAuthAccessToken>>;
+
+    /// List all access tokens for a user.
+    async fn list_by_user(&self, user_id: UserId) -> anyhow::Result<Vec<OAuthAccessToken>>;
+
+    /// Revoke an access token.
+    async fn revoke(&self, id: Uuid) -> anyhow::Result<bool>;
+
+    /// Revoke all access tokens for a user-client pair.
+    async fn revoke_by_user_and_client(
+        &self,
+        user_id: UserId,
+        client_id: &str,
+    ) -> anyhow::Result<u64>;
+
+    /// Delete expired tokens (cleanup).
+    async fn delete_expired(&self) -> anyhow::Result<u64>;
+}
+
+/// Repository for managing refresh tokens.
+#[async_trait]
+pub trait RefreshTokenRepository: Send + Sync {
+    /// Create a new refresh token.
+    async fn create(&self, input: CreateRefreshToken) -> anyhow::Result<OAuthRefreshToken>;
+
+    /// Get a refresh token by its hash.
+    async fn get_by_hash(&self, token_hash: &str) -> anyhow::Result<Option<OAuthRefreshToken>>;
+
+    /// Revoke a refresh token.
+    async fn revoke(&self, id: Uuid) -> anyhow::Result<bool>;
+
+    /// Revoke refresh token by access token ID.
+    async fn revoke_by_access_token(&self, access_token_id: Uuid) -> anyhow::Result<bool>;
+
+    /// Delete expired tokens (cleanup).
+    async fn delete_expired(&self) -> anyhow::Result<u64>;
+}
+
+/// Repository for managing user consent grants.
+#[async_trait]
+pub trait AccessGrantRepository: Send + Sync {
+    /// Create or update a user's grant to a client.
+    /// If a grant already exists, the scopes are merged.
+    async fn upsert(&self, input: UpsertAccessGrant) -> anyhow::Result<OAuthAccessGrant>;
+
+    /// Get the grant for a user-client pair.
+    async fn get(&self, user_id: UserId, client_id: &str) -> anyhow::Result<Option<OAuthAccessGrant>>;
+
+    /// List all grants for a user (apps they've authorized).
+    async fn list_by_user(&self, user_id: UserId) -> anyhow::Result<Vec<OAuthAccessGrant>>;
+
+    /// Revoke a grant (user revoking app access).
+    async fn revoke(&self, user_id: UserId, client_id: &str) -> anyhow::Result<bool>;
+}
+
+// =============================================================================
+// Pending Authorization (for consent flow)
+// =============================================================================
+
+/// A pending OAuth authorization request awaiting user consent.
+#[derive(Debug, Clone)]
+pub struct OAuthPendingAuthorization {
+    pub id: Uuid,
+    pub client_id: String,
+    pub user_id: UserId,
+    pub redirect_uri: String,
+    pub scopes: Vec<String>,
+    pub state: Option<String>,
+    pub code_challenge: Option<String>,
+    pub code_challenge_method: Option<String>,
+    pub expires_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Input for creating a new pending authorization.
+#[derive(Debug, Clone)]
+pub struct CreatePendingAuthorization {
+    pub client_id: String,
+    pub user_id: UserId,
+    pub redirect_uri: String,
+    pub scopes: Vec<String>,
+    pub state: Option<String>,
+    pub code_challenge: Option<String>,
+    pub code_challenge_method: Option<String>,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// Repository for managing pending authorizations.
+#[async_trait]
+pub trait PendingAuthorizationRepository: Send + Sync {
+    /// Create a new pending authorization.
+    async fn create(&self, input: CreatePendingAuthorization) -> anyhow::Result<OAuthPendingAuthorization>;
+
+    /// Get a pending authorization by ID.
+    async fn get_by_id(&self, id: Uuid) -> anyhow::Result<Option<OAuthPendingAuthorization>>;
+
+    /// Consume (get and delete) a pending authorization.
+    /// Returns None if the authorization doesn't exist or is expired.
+    async fn consume(&self, id: Uuid) -> anyhow::Result<Option<OAuthPendingAuthorization>>;
+
+    /// Delete expired pending authorizations (cleanup).
+    async fn delete_expired(&self) -> anyhow::Result<u64>;
+}

--- a/crates/services/src/auth/oauth_server_service.rs
+++ b/crates/services/src/auth/oauth_server_service.rs
@@ -1,0 +1,676 @@
+//! OAuth 2.0 Authorization Server Service
+//!
+//! Implements the authorization code grant flow per RFC 6749, enabling third-party
+//! applications to access user data with consent.
+
+use async_trait::async_trait;
+use chrono::{Duration, Utc};
+use std::sync::Arc;
+use uuid::Uuid;
+
+use crate::auth::{
+    oauth_ports::{
+        AccessGrantRepository, AccessTokenRepository, AuthorizationCodeRepository,
+        CreateAccessToken, CreateAuthorizationCode, CreatePendingAuthorization,
+        CreateRefreshToken, OAuthClientRepository, OAuthClientType,
+        PendingAuthorizationRepository, RefreshTokenRepository, UpsertAccessGrant,
+    },
+    pkce::{validate_challenge_method, verify_pkce, PkceError, SUPPORTED_CHALLENGE_METHOD},
+    scopes::{has_offline_access, validate_scopes, ScopeError},
+    tokens::{
+        generate_access_token, generate_authorization_code, generate_refresh_token, hash_token,
+        verify_client_secret,
+    },
+};
+use crate::types::UserId;
+
+// Token lifetimes
+const AUTHORIZATION_CODE_LIFETIME_MINUTES: i64 = 10;
+const ACCESS_TOKEN_LIFETIME_MINUTES: i64 = 15;
+const REFRESH_TOKEN_LIFETIME_DAYS: i64 = 30;
+const PENDING_AUTH_LIFETIME_MINUTES: i64 = 10;
+
+/// Result of an authorization request.
+#[derive(Debug)]
+pub enum AuthorizeResult {
+    /// Authorization succeeded, return code to client.
+    Success {
+        code: String,
+        state: Option<String>,
+    },
+    /// User needs to review and approve consent.
+    NeedsConsent {
+        pending_id: Uuid,
+        client_name: String,
+        scopes: Vec<String>,
+    },
+}
+
+/// Token response from the token endpoint.
+#[derive(Debug)]
+pub struct TokenResponse {
+    pub access_token: String,
+    pub token_type: String,
+    pub expires_in: i64,
+    pub refresh_token: Option<String>,
+    pub scope: String,
+}
+
+/// Errors that can occur during OAuth server operations.
+#[derive(Debug, thiserror::Error)]
+pub enum OAuthServerError {
+    #[error("Invalid request: {0}")]
+    InvalidRequest(String),
+
+    #[error("Invalid client: {0}")]
+    InvalidClient(String),
+
+    #[error("Invalid grant: {0}")]
+    InvalidGrant(String),
+
+    #[error("Invalid scope: {0}")]
+    InvalidScope(String),
+
+    #[error("Access denied: {0}")]
+    AccessDenied(String),
+
+    #[error("Server error: {0}")]
+    ServerError(String),
+
+    #[error("Unsupported grant type: {0}")]
+    UnsupportedGrantType(String),
+
+    #[error("PKCE error: {0}")]
+    Pkce(#[from] PkceError),
+
+    #[error("Scope error: {0}")]
+    Scope(#[from] ScopeError),
+}
+
+impl OAuthServerError {
+    /// Get the OAuth error code per RFC 6749.
+    pub fn error_code(&self) -> &'static str {
+        match self {
+            Self::InvalidRequest(_) => "invalid_request",
+            Self::InvalidClient(_) => "invalid_client",
+            Self::InvalidGrant(_) => "invalid_grant",
+            Self::InvalidScope(_) => "invalid_scope",
+            Self::AccessDenied(_) => "access_denied",
+            Self::ServerError(_) => "server_error",
+            Self::UnsupportedGrantType(_) => "unsupported_grant_type",
+            Self::Pkce(_) => "invalid_grant",
+            Self::Scope(_) => "invalid_scope",
+        }
+    }
+}
+
+/// OAuth 2.0 Authorization Server service trait.
+#[async_trait]
+pub trait OAuthServerService: Send + Sync {
+    /// Handle an authorization request (GET /oauth/authorize).
+    ///
+    /// Validates the request and either:
+    /// - Returns a code if the user has already granted consent for these scopes
+    /// - Returns NeedsConsent if user approval is required
+    async fn authorize(
+        &self,
+        user_id: UserId,
+        client_id: &str,
+        redirect_uri: &str,
+        scope: &str,
+        state: Option<&str>,
+        code_challenge: Option<&str>,
+        code_challenge_method: Option<&str>,
+    ) -> Result<AuthorizeResult, OAuthServerError>;
+
+    /// Approve a pending authorization after user consent.
+    async fn approve_consent(
+        &self,
+        user_id: UserId,
+        pending_id: Uuid,
+        approved_scopes: Vec<String>,
+    ) -> Result<AuthorizeResult, OAuthServerError>;
+
+    /// Deny a pending authorization.
+    async fn deny_consent(&self, pending_id: Uuid) -> Result<(), OAuthServerError>;
+
+    /// Exchange an authorization code for tokens (POST /oauth/token, grant_type=authorization_code).
+    async fn token_authorization_code(
+        &self,
+        client_id: &str,
+        client_secret: Option<&str>,
+        code: &str,
+        redirect_uri: &str,
+        code_verifier: Option<&str>,
+    ) -> Result<TokenResponse, OAuthServerError>;
+
+    /// Refresh an access token (POST /oauth/token, grant_type=refresh_token).
+    async fn token_refresh(
+        &self,
+        client_id: &str,
+        client_secret: Option<&str>,
+        refresh_token: &str,
+    ) -> Result<TokenResponse, OAuthServerError>;
+
+    /// Get pending authorization details for consent UI.
+    async fn get_pending_authorization(
+        &self,
+        pending_id: Uuid,
+        user_id: UserId,
+    ) -> Result<Option<PendingAuthorizationInfo>, OAuthServerError>;
+}
+
+/// Information about a pending authorization for the consent UI.
+#[derive(Debug)]
+pub struct PendingAuthorizationInfo {
+    pub client_name: String,
+    pub client_id: String,
+    pub scopes: Vec<String>,
+    pub redirect_uri: String,
+}
+
+/// Implementation of the OAuth 2.0 Authorization Server.
+pub struct OAuthServerServiceImpl {
+    client_repo: Arc<dyn OAuthClientRepository>,
+    code_repo: Arc<dyn AuthorizationCodeRepository>,
+    access_token_repo: Arc<dyn AccessTokenRepository>,
+    refresh_token_repo: Arc<dyn RefreshTokenRepository>,
+    grant_repo: Arc<dyn AccessGrantRepository>,
+    pending_auth_repo: Arc<dyn PendingAuthorizationRepository>,
+    project_repo: Arc<dyn crate::auth::oauth_ports::ProjectRepository>,
+}
+
+impl OAuthServerServiceImpl {
+    pub fn new(
+        client_repo: Arc<dyn OAuthClientRepository>,
+        code_repo: Arc<dyn AuthorizationCodeRepository>,
+        access_token_repo: Arc<dyn AccessTokenRepository>,
+        refresh_token_repo: Arc<dyn RefreshTokenRepository>,
+        grant_repo: Arc<dyn AccessGrantRepository>,
+        pending_auth_repo: Arc<dyn PendingAuthorizationRepository>,
+        project_repo: Arc<dyn crate::auth::oauth_ports::ProjectRepository>,
+    ) -> Self {
+        Self {
+            client_repo,
+            code_repo,
+            access_token_repo,
+            refresh_token_repo,
+            grant_repo,
+            pending_auth_repo,
+            project_repo,
+        }
+    }
+
+    /// Validate client credentials for the token endpoint.
+    async fn authenticate_client(
+        &self,
+        client_id: &str,
+        client_secret: Option<&str>,
+    ) -> Result<crate::auth::oauth_ports::OAuthClient, OAuthServerError> {
+        let client = self
+            .client_repo
+            .get_by_client_id(client_id)
+            .await
+            .map_err(|e| OAuthServerError::ServerError(e.to_string()))?
+            .ok_or_else(|| OAuthServerError::InvalidClient("Client not found".to_string()))?;
+
+        if !client.is_active() {
+            return Err(OAuthServerError::InvalidClient(
+                "Client has been revoked".to_string(),
+            ));
+        }
+
+        // Confidential clients must provide valid secret
+        if client.client_type == OAuthClientType::Confidential {
+            let secret = client_secret
+                .ok_or_else(|| OAuthServerError::InvalidClient("Client secret required".to_string()))?;
+
+            let secret_hash = client
+                .client_secret_hash
+                .as_ref()
+                .ok_or_else(|| OAuthServerError::ServerError("Client secret not configured".to_string()))?;
+
+            if !verify_client_secret(secret, secret_hash) {
+                return Err(OAuthServerError::InvalidClient(
+                    "Invalid client credentials".to_string(),
+                ));
+            }
+        }
+
+        Ok(client)
+    }
+
+    /// Get the project name for a client (for consent UI).
+    async fn get_client_name(&self, project_id: Uuid) -> Result<String, OAuthServerError> {
+        let project = self
+            .project_repo
+            .get_by_id(project_id)
+            .await
+            .map_err(|e| OAuthServerError::ServerError(e.to_string()))?
+            .ok_or_else(|| OAuthServerError::ServerError("Project not found".to_string()))?;
+
+        Ok(project.name)
+    }
+
+    /// Issue tokens for a successful authorization.
+    async fn issue_tokens(
+        &self,
+        client_id: &str,
+        user_id: UserId,
+        scopes: &[String],
+        _client_type: OAuthClientType,
+    ) -> Result<TokenResponse, OAuthServerError> {
+        let now = Utc::now();
+        let access_token_expires = now + Duration::minutes(ACCESS_TOKEN_LIFETIME_MINUTES);
+        let refresh_token_expires = now + Duration::days(REFRESH_TOKEN_LIFETIME_DAYS);
+
+        // Generate access token
+        let access_token = generate_access_token();
+        let access_token_hash = access_token.hash();
+
+        let access_token_record = self
+            .access_token_repo
+            .create(CreateAccessToken {
+                token_hash: access_token_hash,
+                client_id: client_id.to_string(),
+                user_id,
+                scopes: scopes.to_vec(),
+                expires_at: access_token_expires,
+            })
+            .await
+            .map_err(|e| OAuthServerError::ServerError(e.to_string()))?;
+
+        // Generate refresh token if offline_access scope was granted
+        let refresh_token = if has_offline_access(scopes) {
+            let refresh_token = generate_refresh_token();
+            let refresh_token_hash = refresh_token.hash();
+
+            self.refresh_token_repo
+                .create(CreateRefreshToken {
+                    token_hash: refresh_token_hash,
+                    access_token_id: access_token_record.id,
+                    user_id,
+                    client_id: client_id.to_string(),
+                    expires_at: refresh_token_expires,
+                })
+                .await
+                .map_err(|e| OAuthServerError::ServerError(e.to_string()))?;
+
+            Some(refresh_token.to_string())
+        } else {
+            None
+        };
+
+        // For public clients, we always rotate refresh tokens on use
+        // The refresh_token field is already set above based on offline_access
+
+        Ok(TokenResponse {
+            access_token: access_token.to_string(),
+            token_type: "Bearer".to_string(),
+            expires_in: ACCESS_TOKEN_LIFETIME_MINUTES * 60,
+            refresh_token,
+            scope: scopes.join(" "),
+        })
+    }
+}
+
+#[async_trait]
+impl OAuthServerService for OAuthServerServiceImpl {
+    async fn authorize(
+        &self,
+        user_id: UserId,
+        client_id: &str,
+        redirect_uri: &str,
+        scope: &str,
+        state: Option<&str>,
+        code_challenge: Option<&str>,
+        code_challenge_method: Option<&str>,
+    ) -> Result<AuthorizeResult, OAuthServerError> {
+        // Validate client exists and is active
+        let client = self
+            .client_repo
+            .get_by_client_id(client_id)
+            .await
+            .map_err(|e| OAuthServerError::ServerError(e.to_string()))?
+            .ok_or_else(|| OAuthServerError::InvalidClient("Client not found".to_string()))?;
+
+        if !client.is_active() {
+            return Err(OAuthServerError::InvalidClient(
+                "Client has been revoked".to_string(),
+            ));
+        }
+
+        // Validate redirect_uri
+        if !client.is_redirect_uri_allowed(redirect_uri) {
+            return Err(OAuthServerError::InvalidRequest(
+                "Invalid redirect_uri".to_string(),
+            ));
+        }
+
+        // Parse and validate scopes
+        let requested_scopes: Vec<String> = scope.split_whitespace().map(String::from).collect();
+        let validated_scopes = validate_scopes(&requested_scopes, &client.allowed_scopes)?;
+
+        // Require PKCE for public clients
+        if client.client_type == OAuthClientType::Public {
+            if code_challenge.is_none() {
+                return Err(OAuthServerError::Pkce(PkceError::ChallengeRequired));
+            }
+        }
+
+        // Validate code_challenge_method if provided
+        if let Some(method) = code_challenge_method {
+            validate_challenge_method(method)?;
+        } else if code_challenge.is_some() {
+            // If challenge is provided but method is not, default to S256
+            // (we'll store S256 as the method)
+        }
+
+        // Check if user has already granted these scopes
+        if let Some(existing_grant) = self
+            .grant_repo
+            .get(user_id, client_id)
+            .await
+            .map_err(|e| OAuthServerError::ServerError(e.to_string()))?
+        {
+            if existing_grant.is_active() && existing_grant.covers_scopes(&validated_scopes) {
+                // User already granted these scopes, issue code directly
+                let code = generate_authorization_code();
+                let code_hash = hash_token(code.as_str());
+
+                self.code_repo
+                    .create(CreateAuthorizationCode {
+                        code: code_hash,
+                        client_id: client_id.to_string(),
+                        user_id,
+                        redirect_uri: redirect_uri.to_string(),
+                        scopes: validated_scopes,
+                        code_challenge: code_challenge.map(String::from),
+                        code_challenge_method: code_challenge
+                            .map(|_| code_challenge_method.unwrap_or(SUPPORTED_CHALLENGE_METHOD).to_string()),
+                        expires_at: Utc::now() + Duration::minutes(AUTHORIZATION_CODE_LIFETIME_MINUTES),
+                    })
+                    .await
+                    .map_err(|e| OAuthServerError::ServerError(e.to_string()))?;
+
+                return Ok(AuthorizeResult::Success {
+                    code: code.0,
+                    state: state.map(String::from),
+                });
+            }
+        }
+
+        // User needs to consent - create pending authorization
+        let pending = self
+            .pending_auth_repo
+            .create(CreatePendingAuthorization {
+                client_id: client_id.to_string(),
+                user_id,
+                redirect_uri: redirect_uri.to_string(),
+                scopes: validated_scopes.clone(),
+                state: state.map(String::from),
+                code_challenge: code_challenge.map(String::from),
+                code_challenge_method: code_challenge
+                    .map(|_| code_challenge_method.unwrap_or(SUPPORTED_CHALLENGE_METHOD).to_string()),
+                expires_at: Utc::now() + Duration::minutes(PENDING_AUTH_LIFETIME_MINUTES),
+            })
+            .await
+            .map_err(|e| OAuthServerError::ServerError(e.to_string()))?;
+
+        let client_name = self.get_client_name(client.project_id).await?;
+
+        Ok(AuthorizeResult::NeedsConsent {
+            pending_id: pending.id,
+            client_name,
+            scopes: validated_scopes,
+        })
+    }
+
+    async fn approve_consent(
+        &self,
+        user_id: UserId,
+        pending_id: Uuid,
+        approved_scopes: Vec<String>,
+    ) -> Result<AuthorizeResult, OAuthServerError> {
+        // Consume the pending authorization (get and delete atomically)
+        let pending = self
+            .pending_auth_repo
+            .consume(pending_id)
+            .await
+            .map_err(|e| OAuthServerError::ServerError(e.to_string()))?
+            .ok_or_else(|| {
+                OAuthServerError::InvalidRequest("Pending authorization not found or expired".to_string())
+            })?;
+
+        // Verify user matches
+        if pending.user_id != user_id {
+            return Err(OAuthServerError::AccessDenied(
+                "User mismatch".to_string(),
+            ));
+        }
+
+        // Verify approved scopes are subset of requested scopes
+        for scope in &approved_scopes {
+            if !pending.scopes.contains(scope) {
+                return Err(OAuthServerError::InvalidScope(format!(
+                    "Scope '{}' was not requested",
+                    scope
+                )));
+            }
+        }
+
+        // Record the user's consent
+        self.grant_repo
+            .upsert(UpsertAccessGrant {
+                user_id,
+                client_id: pending.client_id.clone(),
+                scopes: approved_scopes.clone(),
+            })
+            .await
+            .map_err(|e| OAuthServerError::ServerError(e.to_string()))?;
+
+        // Generate authorization code
+        let code = generate_authorization_code();
+        let code_hash = hash_token(code.as_str());
+
+        self.code_repo
+            .create(CreateAuthorizationCode {
+                code: code_hash,
+                client_id: pending.client_id,
+                user_id,
+                redirect_uri: pending.redirect_uri,
+                scopes: approved_scopes,
+                code_challenge: pending.code_challenge,
+                code_challenge_method: pending.code_challenge_method,
+                expires_at: Utc::now() + Duration::minutes(AUTHORIZATION_CODE_LIFETIME_MINUTES),
+            })
+            .await
+            .map_err(|e| OAuthServerError::ServerError(e.to_string()))?;
+
+        Ok(AuthorizeResult::Success {
+            code: code.0,
+            state: pending.state,
+        })
+    }
+
+    async fn deny_consent(&self, pending_id: Uuid) -> Result<(), OAuthServerError> {
+        // Just consume and discard the pending authorization
+        self.pending_auth_repo
+            .consume(pending_id)
+            .await
+            .map_err(|e| OAuthServerError::ServerError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn token_authorization_code(
+        &self,
+        client_id: &str,
+        client_secret: Option<&str>,
+        code: &str,
+        redirect_uri: &str,
+        code_verifier: Option<&str>,
+    ) -> Result<TokenResponse, OAuthServerError> {
+        // Authenticate client
+        let client = self.authenticate_client(client_id, client_secret).await?;
+
+        // Hash the code to look it up
+        let code_hash = hash_token(code);
+
+        // Consume the authorization code (get and delete atomically)
+        let auth_code = self
+            .code_repo
+            .consume(&code_hash)
+            .await
+            .map_err(|e| OAuthServerError::ServerError(e.to_string()))?
+            .ok_or_else(|| {
+                OAuthServerError::InvalidGrant("Authorization code not found or expired".to_string())
+            })?;
+
+        // Verify client_id matches
+        if auth_code.client_id != client_id {
+            return Err(OAuthServerError::InvalidGrant(
+                "Authorization code was not issued to this client".to_string(),
+            ));
+        }
+
+        // Verify redirect_uri matches
+        if auth_code.redirect_uri != redirect_uri {
+            return Err(OAuthServerError::InvalidGrant(
+                "redirect_uri mismatch".to_string(),
+            ));
+        }
+
+        // Verify PKCE if code_challenge was stored
+        if let Some(challenge) = &auth_code.code_challenge {
+            let verifier = code_verifier
+                .ok_or_else(|| OAuthServerError::InvalidGrant("code_verifier required".to_string()))?;
+
+            verify_pkce(verifier, challenge)?;
+        } else if code_verifier.is_some() {
+            // Code verifier provided but no challenge was stored - this is an error
+            return Err(OAuthServerError::InvalidGrant(
+                "code_verifier provided but no code_challenge was stored".to_string(),
+            ));
+        }
+
+        // Issue tokens
+        self.issue_tokens(
+            client_id,
+            auth_code.user_id,
+            &auth_code.scopes,
+            client.client_type,
+        )
+        .await
+    }
+
+    async fn token_refresh(
+        &self,
+        client_id: &str,
+        client_secret: Option<&str>,
+        refresh_token: &str,
+    ) -> Result<TokenResponse, OAuthServerError> {
+        // Authenticate client
+        let client = self.authenticate_client(client_id, client_secret).await?;
+
+        // Hash the refresh token to look it up
+        let token_hash = hash_token(refresh_token);
+
+        // Get the refresh token
+        let refresh_token_record = self
+            .refresh_token_repo
+            .get_by_hash(&token_hash)
+            .await
+            .map_err(|e| OAuthServerError::ServerError(e.to_string()))?
+            .ok_or_else(|| OAuthServerError::InvalidGrant("Invalid refresh token".to_string()))?;
+
+        // Check if token is valid
+        if !refresh_token_record.is_valid() {
+            return Err(OAuthServerError::InvalidGrant(
+                "Refresh token has expired or been revoked".to_string(),
+            ));
+        }
+
+        // Get user_id and client_id from refresh token record (new fields)
+        // Fall back to looking up via access token if not present (for backwards compatibility)
+        let (user_id, token_client_id, scopes) = if let (Some(uid), Some(cid)) = (
+            refresh_token_record.user_id,
+            refresh_token_record.client_id.as_ref(),
+        ) {
+            // Use the new direct fields - get scopes from the grant
+            let grant = self
+                .grant_repo
+                .get(uid, cid)
+                .await
+                .map_err(|e| OAuthServerError::ServerError(e.to_string()))?
+                .ok_or_else(|| OAuthServerError::InvalidGrant("Grant not found".to_string()))?;
+
+            (uid, cid.clone(), grant.scopes)
+        } else {
+            // Backwards compatibility: look up via access token
+            let access_token = self
+                .access_token_repo
+                .get_by_id(refresh_token_record.access_token_id)
+                .await
+                .map_err(|e| OAuthServerError::ServerError(e.to_string()))?
+                .ok_or_else(|| {
+                    OAuthServerError::InvalidGrant("Associated access token not found".to_string())
+                })?;
+
+            (access_token.user_id, access_token.client_id.clone(), access_token.scopes)
+        };
+
+        // Verify client_id matches
+        if token_client_id != client_id {
+            return Err(OAuthServerError::InvalidGrant(
+                "Refresh token was not issued to this client".to_string(),
+            ));
+        }
+
+        // For public clients, rotate the refresh token (revoke old one)
+        if client.client_type == OAuthClientType::Public {
+            self.refresh_token_repo
+                .revoke(refresh_token_record.id)
+                .await
+                .map_err(|e| OAuthServerError::ServerError(e.to_string()))?;
+        }
+
+        // Issue new tokens
+        self.issue_tokens(client_id, user_id, &scopes, client.client_type)
+            .await
+    }
+
+    async fn get_pending_authorization(
+        &self,
+        pending_id: Uuid,
+        user_id: UserId,
+    ) -> Result<Option<PendingAuthorizationInfo>, OAuthServerError> {
+        let pending = self
+            .pending_auth_repo
+            .get_by_id(pending_id)
+            .await
+            .map_err(|e| OAuthServerError::ServerError(e.to_string()))?;
+
+        let pending = match pending {
+            Some(p) if p.user_id == user_id => p,
+            _ => return Ok(None),
+        };
+
+        // Get client info
+        let client = self
+            .client_repo
+            .get_by_client_id(&pending.client_id)
+            .await
+            .map_err(|e| OAuthServerError::ServerError(e.to_string()))?
+            .ok_or_else(|| OAuthServerError::ServerError("Client not found".to_string()))?;
+
+        let client_name = self.get_client_name(client.project_id).await?;
+
+        Ok(Some(PendingAuthorizationInfo {
+            client_name,
+            client_id: pending.client_id,
+            scopes: pending.scopes,
+            redirect_uri: pending.redirect_uri,
+        }))
+    }
+}

--- a/crates/services/src/auth/pkce.rs
+++ b/crates/services/src/auth/pkce.rs
@@ -1,0 +1,209 @@
+//! PKCE (Proof Key for Code Exchange) implementation per RFC 7636.
+//!
+//! PKCE protects public OAuth clients (SPAs, mobile apps) from authorization code
+//! interception attacks by requiring proof of the original authorization request.
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+/// Errors that can occur during PKCE validation.
+#[derive(Debug, Error)]
+pub enum PkceError {
+    #[error("Code verifier must be between 43 and 128 characters")]
+    InvalidVerifierLength,
+
+    #[error("Code verifier contains invalid characters")]
+    InvalidVerifierCharacters,
+
+    #[error("Code challenge verification failed")]
+    ChallengeMismatch,
+
+    #[error("Unsupported code challenge method: {0}")]
+    UnsupportedMethod(String),
+
+    #[error("Code challenge is required for public clients")]
+    ChallengeRequired,
+}
+
+/// The only supported code challenge method.
+/// We do not support 'plain' method as it provides no security benefit.
+pub const SUPPORTED_CHALLENGE_METHOD: &str = "S256";
+
+/// Verify a PKCE code verifier against a code challenge.
+///
+/// # Arguments
+/// * `code_verifier` - The original random string sent by the client
+/// * `code_challenge` - The challenge stored during authorization (BASE64URL(SHA256(verifier)))
+///
+/// # Returns
+/// * `Ok(())` if verification succeeds
+/// * `Err(PkceError)` if verification fails
+pub fn verify_pkce(code_verifier: &str, code_challenge: &str) -> Result<(), PkceError> {
+    // First validate the verifier format
+    validate_code_verifier(code_verifier)?;
+
+    // S256: BASE64URL(SHA256(code_verifier)) == code_challenge
+    let computed_challenge = generate_code_challenge(code_verifier);
+
+    if computed_challenge == code_challenge {
+        Ok(())
+    } else {
+        Err(PkceError::ChallengeMismatch)
+    }
+}
+
+/// Generate a code challenge from a code verifier using S256 method.
+///
+/// # Arguments
+/// * `code_verifier` - The random string to hash
+///
+/// # Returns
+/// The BASE64URL-encoded SHA256 hash of the verifier (no padding)
+pub fn generate_code_challenge(code_verifier: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(code_verifier.as_bytes());
+    let hash = hasher.finalize();
+    URL_SAFE_NO_PAD.encode(hash)
+}
+
+/// Validate that a code verifier meets RFC 7636 requirements.
+///
+/// Requirements:
+/// - Length: 43-128 characters
+/// - Characters: [A-Z] / [a-z] / [0-9] / "-" / "." / "_" / "~"
+///
+/// # Arguments
+/// * `verifier` - The code verifier to validate
+///
+/// # Returns
+/// * `Ok(())` if valid
+/// * `Err(PkceError)` if invalid
+pub fn validate_code_verifier(verifier: &str) -> Result<(), PkceError> {
+    // RFC 7636: code_verifier = 43*128unreserved
+    if verifier.len() < 43 || verifier.len() > 128 {
+        return Err(PkceError::InvalidVerifierLength);
+    }
+
+    // unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
+    let is_valid_char = |c: char| c.is_ascii_alphanumeric() || "-._~".contains(c);
+
+    if !verifier.chars().all(is_valid_char) {
+        return Err(PkceError::InvalidVerifierCharacters);
+    }
+
+    Ok(())
+}
+
+/// Validate the code challenge method.
+///
+/// Only S256 is supported for security reasons.
+///
+/// # Arguments
+/// * `method` - The method string (should be "S256")
+///
+/// # Returns
+/// * `Ok(())` if method is supported
+/// * `Err(PkceError)` if method is not supported
+pub fn validate_challenge_method(method: &str) -> Result<(), PkceError> {
+    if method == SUPPORTED_CHALLENGE_METHOD {
+        Ok(())
+    } else {
+        Err(PkceError::UnsupportedMethod(method.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_challenge() {
+        // Test vector from RFC 7636 Appendix B
+        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        let expected_challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+        let challenge = generate_code_challenge(verifier);
+        assert_eq!(challenge, expected_challenge);
+    }
+
+    #[test]
+    fn test_verify_pkce_success() {
+        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        let challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+        assert!(verify_pkce(verifier, challenge).is_ok());
+    }
+
+    #[test]
+    fn test_verify_pkce_failure() {
+        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        let wrong_challenge = "wrong_challenge_value_here_abcdefghij";
+
+        assert!(matches!(
+            verify_pkce(verifier, wrong_challenge),
+            Err(PkceError::ChallengeMismatch)
+        ));
+    }
+
+    #[test]
+    fn test_validate_verifier_length() {
+        // Too short (42 chars)
+        let short = "a".repeat(42);
+        assert!(matches!(
+            validate_code_verifier(&short),
+            Err(PkceError::InvalidVerifierLength)
+        ));
+
+        // Minimum valid (43 chars)
+        let min_valid = "a".repeat(43);
+        assert!(validate_code_verifier(&min_valid).is_ok());
+
+        // Maximum valid (128 chars)
+        let max_valid = "a".repeat(128);
+        assert!(validate_code_verifier(&max_valid).is_ok());
+
+        // Too long (129 chars)
+        let long = "a".repeat(129);
+        assert!(matches!(
+            validate_code_verifier(&long),
+            Err(PkceError::InvalidVerifierLength)
+        ));
+    }
+
+    #[test]
+    fn test_validate_verifier_characters() {
+        // Valid characters
+        let valid = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~";
+        // Pad to minimum length
+        let valid_padded = format!("{}{}", valid, "a".repeat(43 - valid.len().min(43)));
+        assert!(validate_code_verifier(&valid_padded).is_ok());
+
+        // Invalid character (space)
+        let invalid_space = format!("{}a b{}", "a".repeat(20), "a".repeat(20));
+        assert!(matches!(
+            validate_code_verifier(&invalid_space),
+            Err(PkceError::InvalidVerifierCharacters)
+        ));
+
+        // Invalid character (special)
+        let invalid_special = format!("{}@{}", "a".repeat(42), "a");
+        assert!(matches!(
+            validate_code_verifier(&invalid_special),
+            Err(PkceError::InvalidVerifierCharacters)
+        ));
+    }
+
+    #[test]
+    fn test_validate_challenge_method() {
+        assert!(validate_challenge_method("S256").is_ok());
+        assert!(matches!(
+            validate_challenge_method("plain"),
+            Err(PkceError::UnsupportedMethod(_))
+        ));
+        assert!(matches!(
+            validate_challenge_method("s256"), // case sensitive
+            Err(PkceError::UnsupportedMethod(_))
+        ));
+    }
+}

--- a/crates/services/src/auth/scopes.rs
+++ b/crates/services/src/auth/scopes.rs
@@ -1,0 +1,228 @@
+//! OAuth scope definitions and validation for the Private Memory API.
+//!
+//! Scopes control what access third-party applications have to user data.
+
+use thiserror::Error;
+
+/// All valid OAuth scopes for the Private Memory API.
+pub const VALID_SCOPES: &[&str] = &[
+    "memory.read",           // Read memories created by this app (app-scoped)
+    "memory.read.all",       // Read all user memories (cross-app, global)
+    "memory.write",          // Write memories (global by design)
+    "files.read",            // Read files uploaded by this app (app-scoped)
+    "files.read.all",        // Read all user files (global)
+    "files.write",           // Upload files (global)
+    "conversations.read",    // Read conversations from this app (app-scoped)
+    "conversations.read.all", // Read all conversations (global)
+    "profile.read",          // Read user profile (name, email)
+    "offline_access",        // Request refresh tokens (meta scope)
+];
+
+/// Errors that can occur during scope validation.
+#[derive(Debug, Error)]
+pub enum ScopeError {
+    #[error("Invalid scope: {0}")]
+    InvalidScope(String),
+
+    #[error("Scope not allowed for this client: {0}")]
+    ScopeNotAllowed(String),
+
+    #[error("No scopes requested")]
+    NoScopes,
+}
+
+/// Check if a scope is valid (exists in the system).
+pub fn is_valid_scope(scope: &str) -> bool {
+    VALID_SCOPES.contains(&scope)
+}
+
+/// Check if a scope grants global access (vs app-scoped access).
+pub fn is_global_scope(scope: &str) -> bool {
+    matches!(
+        scope,
+        "memory.read.all"
+            | "memory.write"
+            | "files.read.all"
+            | "files.write"
+            | "conversations.read.all"
+            | "profile.read"
+            | "offline_access"
+    )
+}
+
+/// Check if a scope is app-scoped (limited to data created by the requesting app).
+pub fn is_app_scoped(scope: &str) -> bool {
+    matches!(scope, "memory.read" | "files.read" | "conversations.read")
+}
+
+/// Validate requested scopes against a client's allowed scopes.
+///
+/// # Arguments
+/// * `requested` - Scopes requested by the client in the authorization request
+/// * `allowed` - Scopes that the client is allowed to request (configured during client registration)
+///
+/// # Returns
+/// * `Ok(Vec<String>)` - The validated scopes (same as requested if all valid)
+/// * `Err(ScopeError)` - If any scope is invalid or not allowed
+pub fn validate_scopes(requested: &[String], allowed: &[String]) -> Result<Vec<String>, ScopeError> {
+    if requested.is_empty() {
+        return Err(ScopeError::NoScopes);
+    }
+
+    for scope in requested {
+        if !VALID_SCOPES.contains(&scope.as_str()) {
+            return Err(ScopeError::InvalidScope(scope.clone()));
+        }
+        if !allowed.contains(scope) {
+            return Err(ScopeError::ScopeNotAllowed(scope.clone()));
+        }
+    }
+
+    Ok(requested.to_vec())
+}
+
+/// Parse a space-separated scope string into a vector of scopes.
+///
+/// # Arguments
+/// * `scope_string` - Space-separated list of scopes (e.g., "memory.read memory.write")
+///
+/// # Returns
+/// A vector of individual scope strings
+pub fn parse_scope_string(scope_string: &str) -> Vec<String> {
+    scope_string
+        .split_whitespace()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Join a vector of scopes into a space-separated string.
+///
+/// # Arguments
+/// * `scopes` - Vector of scope strings
+///
+/// # Returns
+/// A space-separated scope string
+pub fn join_scopes(scopes: &[String]) -> String {
+    scopes.join(" ")
+}
+
+/// Check if a set of scopes includes read access (either app-scoped or global).
+pub fn has_memory_read_access(scopes: &[String]) -> bool {
+    scopes.iter().any(|s| s == "memory.read" || s == "memory.read.all")
+}
+
+/// Check if a set of scopes includes global memory read access.
+pub fn has_global_memory_read(scopes: &[String]) -> bool {
+    scopes.iter().any(|s| s == "memory.read.all")
+}
+
+/// Check if a set of scopes includes memory write access.
+pub fn has_memory_write_access(scopes: &[String]) -> bool {
+    scopes.iter().any(|s| s == "memory.write")
+}
+
+/// Check if a set of scopes requests offline access (refresh tokens).
+pub fn has_offline_access(scopes: &[String]) -> bool {
+    scopes.iter().any(|s| s == "offline_access")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_scopes() {
+        assert!(is_valid_scope("memory.read"));
+        assert!(is_valid_scope("memory.write"));
+        assert!(is_valid_scope("offline_access"));
+        assert!(!is_valid_scope("invalid.scope"));
+        assert!(!is_valid_scope(""));
+    }
+
+    #[test]
+    fn test_global_vs_app_scoped() {
+        assert!(is_app_scoped("memory.read"));
+        assert!(!is_app_scoped("memory.read.all"));
+        assert!(is_global_scope("memory.read.all"));
+        assert!(is_global_scope("memory.write"));
+        assert!(!is_global_scope("memory.read"));
+    }
+
+    #[test]
+    fn test_validate_scopes_success() {
+        let requested = vec!["memory.read".to_string(), "memory.write".to_string()];
+        let allowed = vec![
+            "memory.read".to_string(),
+            "memory.write".to_string(),
+            "profile.read".to_string(),
+        ];
+
+        let result = validate_scopes(&requested, &allowed);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), requested);
+    }
+
+    #[test]
+    fn test_validate_scopes_invalid() {
+        let requested = vec!["memory.read".to_string(), "invalid.scope".to_string()];
+        let allowed = vec!["memory.read".to_string()];
+
+        let result = validate_scopes(&requested, &allowed);
+        assert!(matches!(result, Err(ScopeError::InvalidScope(_))));
+    }
+
+    #[test]
+    fn test_validate_scopes_not_allowed() {
+        let requested = vec!["memory.read".to_string(), "memory.write".to_string()];
+        let allowed = vec!["memory.read".to_string()]; // memory.write not allowed
+
+        let result = validate_scopes(&requested, &allowed);
+        assert!(matches!(result, Err(ScopeError::ScopeNotAllowed(_))));
+    }
+
+    #[test]
+    fn test_validate_scopes_empty() {
+        let requested: Vec<String> = vec![];
+        let allowed = vec!["memory.read".to_string()];
+
+        let result = validate_scopes(&requested, &allowed);
+        assert!(matches!(result, Err(ScopeError::NoScopes)));
+    }
+
+    #[test]
+    fn test_parse_scope_string() {
+        let scopes = parse_scope_string("memory.read memory.write profile.read");
+        assert_eq!(scopes.len(), 3);
+        assert_eq!(scopes[0], "memory.read");
+        assert_eq!(scopes[1], "memory.write");
+        assert_eq!(scopes[2], "profile.read");
+    }
+
+    #[test]
+    fn test_join_scopes() {
+        let scopes = vec![
+            "memory.read".to_string(),
+            "memory.write".to_string(),
+        ];
+        assert_eq!(join_scopes(&scopes), "memory.read memory.write");
+    }
+
+    #[test]
+    fn test_has_memory_access() {
+        let scopes_app = vec!["memory.read".to_string()];
+        let scopes_global = vec!["memory.read.all".to_string()];
+        let scopes_write = vec!["memory.write".to_string()];
+        let scopes_none = vec!["profile.read".to_string()];
+
+        assert!(has_memory_read_access(&scopes_app));
+        assert!(has_memory_read_access(&scopes_global));
+        assert!(!has_memory_read_access(&scopes_write));
+        assert!(!has_memory_read_access(&scopes_none));
+
+        assert!(!has_global_memory_read(&scopes_app));
+        assert!(has_global_memory_read(&scopes_global));
+
+        assert!(has_memory_write_access(&scopes_write));
+        assert!(!has_memory_write_access(&scopes_app));
+    }
+}

--- a/crates/services/src/auth/tokens.rs
+++ b/crates/services/src/auth/tokens.rs
@@ -1,0 +1,329 @@
+//! OAuth token generation and utilities.
+//!
+//! This module provides secure token generation for OAuth 2.0 flows,
+//! including access tokens, refresh tokens, authorization codes, and client credentials.
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+use std::fmt;
+
+/// Token prefixes for easy identification and routing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenPrefix {
+    /// First-party session token (existing system)
+    Session,
+    /// OAuth access token (third-party apps)
+    AccessToken,
+    /// OAuth refresh token
+    RefreshToken,
+}
+
+impl TokenPrefix {
+    /// Get the string prefix for this token type.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TokenPrefix::Session => "pm_st_",
+            TokenPrefix::AccessToken => "pm_at_",
+            TokenPrefix::RefreshToken => "pm_rt_",
+        }
+    }
+
+    /// Detect token type from a token string.
+    pub fn from_token(token: &str) -> Option<Self> {
+        if token.starts_with(Self::Session.as_str()) {
+            Some(Self::Session)
+        } else if token.starts_with(Self::AccessToken.as_str()) {
+            Some(Self::AccessToken)
+        } else if token.starts_with(Self::RefreshToken.as_str()) {
+            Some(Self::RefreshToken)
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Display for TokenPrefix {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// Newtype for OAuth client IDs (public identifier).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientId(pub String);
+
+impl ClientId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ClientId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for ClientId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for ClientId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+/// Newtype for OAuth client secrets (confidential).
+#[derive(Clone)]
+pub struct ClientSecret(String);
+
+impl ClientSecret {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Hash the client secret for storage.
+    pub fn hash(&self) -> String {
+        hash_token(&self.0)
+    }
+}
+
+// Don't leak secrets in debug output
+impl fmt::Debug for ClientSecret {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ClientSecret([REDACTED])")
+    }
+}
+
+/// Newtype for authorization codes.
+#[derive(Debug, Clone)]
+pub struct AuthorizationCode(pub String);
+
+impl AuthorizationCode {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Newtype for access token IDs (the actual token value before hashing).
+#[derive(Clone)]
+pub struct AccessTokenId(String);
+
+impl AccessTokenId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Hash the token for storage.
+    pub fn hash(&self) -> String {
+        hash_token(&self.0)
+    }
+}
+
+impl fmt::Debug for AccessTokenId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "AccessTokenId([REDACTED])")
+    }
+}
+
+impl fmt::Display for AccessTokenId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Newtype for refresh token IDs.
+#[derive(Clone)]
+pub struct RefreshTokenId(String);
+
+impl RefreshTokenId {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Hash the token for storage.
+    pub fn hash(&self) -> String {
+        hash_token(&self.0)
+    }
+}
+
+impl fmt::Debug for RefreshTokenId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RefreshTokenId([REDACTED])")
+    }
+}
+
+impl fmt::Display for RefreshTokenId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Generate cryptographically secure random bytes.
+fn generate_random_bytes(len: usize) -> Vec<u8> {
+    let mut bytes = vec![0u8; len];
+    rand::rng().fill_bytes(&mut bytes);
+    bytes
+}
+
+/// Generate a random hex string of specified byte length.
+fn generate_hex_string(byte_len: usize) -> String {
+    hex::encode(generate_random_bytes(byte_len))
+}
+
+/// Generate a random URL-safe base64 string of specified byte length.
+fn generate_base64_string(byte_len: usize) -> String {
+    URL_SAFE_NO_PAD.encode(generate_random_bytes(byte_len))
+}
+
+/// Hash a token using SHA256 for secure storage.
+///
+/// Tokens are never stored in plain text - only their hashes.
+pub fn hash_token(token: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(token.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+/// Generate a new OAuth client ID.
+///
+/// Format: 32 character hex string (16 bytes of entropy)
+pub fn generate_client_id() -> ClientId {
+    ClientId(generate_hex_string(16))
+}
+
+/// Generate a new OAuth client secret.
+///
+/// Format: 64 character hex string (32 bytes of entropy)
+pub fn generate_client_secret() -> ClientSecret {
+    ClientSecret(generate_hex_string(32))
+}
+
+/// Generate a new authorization code.
+///
+/// Format: 43 character base64url string (32 bytes of entropy)
+pub fn generate_authorization_code() -> AuthorizationCode {
+    AuthorizationCode(generate_base64_string(32))
+}
+
+/// Generate a new access token.
+///
+/// Format: pm_at_ prefix + 43 character base64url string
+pub fn generate_access_token() -> AccessTokenId {
+    let random_part = generate_base64_string(32);
+    AccessTokenId(format!("{}{}", TokenPrefix::AccessToken.as_str(), random_part))
+}
+
+/// Generate a new refresh token.
+///
+/// Format: pm_rt_ prefix + 43 character base64url string
+pub fn generate_refresh_token() -> RefreshTokenId {
+    let random_part = generate_base64_string(32);
+    RefreshTokenId(format!("{}{}", TokenPrefix::RefreshToken.as_str(), random_part))
+}
+
+/// Verify a client secret against its stored hash.
+pub fn verify_client_secret(secret: &str, hash: &str) -> bool {
+    hash_token(secret) == hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_token_prefix_detection() {
+        assert_eq!(
+            TokenPrefix::from_token("pm_st_abc123"),
+            Some(TokenPrefix::Session)
+        );
+        assert_eq!(
+            TokenPrefix::from_token("pm_at_abc123"),
+            Some(TokenPrefix::AccessToken)
+        );
+        assert_eq!(
+            TokenPrefix::from_token("pm_rt_abc123"),
+            Some(TokenPrefix::RefreshToken)
+        );
+        assert_eq!(TokenPrefix::from_token("invalid_token"), None);
+    }
+
+    #[test]
+    fn test_generate_client_id() {
+        let client_id = generate_client_id();
+        assert_eq!(client_id.0.len(), 32);
+        assert!(client_id.0.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_generate_client_secret() {
+        let secret = generate_client_secret();
+        assert_eq!(secret.0.len(), 64);
+        assert!(secret.0.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_generate_authorization_code() {
+        let code = generate_authorization_code();
+        assert_eq!(code.0.len(), 43); // base64url of 32 bytes
+    }
+
+    #[test]
+    fn test_generate_access_token() {
+        let token = generate_access_token();
+        assert!(token.0.starts_with("pm_at_"));
+        assert_eq!(token.0.len(), 6 + 43); // prefix + base64url
+    }
+
+    #[test]
+    fn test_generate_refresh_token() {
+        let token = generate_refresh_token();
+        assert!(token.0.starts_with("pm_rt_"));
+        assert_eq!(token.0.len(), 6 + 43); // prefix + base64url
+    }
+
+    #[test]
+    fn test_hash_token() {
+        let token = "test_token";
+        let hash = hash_token(token);
+
+        // SHA256 produces 64 hex characters
+        assert_eq!(hash.len(), 64);
+        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+
+        // Same input should produce same hash
+        assert_eq!(hash, hash_token(token));
+
+        // Different input should produce different hash
+        assert_ne!(hash, hash_token("different_token"));
+    }
+
+    #[test]
+    fn test_verify_client_secret() {
+        let secret = generate_client_secret();
+        let hash = secret.hash();
+
+        assert!(verify_client_secret(secret.as_str(), &hash));
+        assert!(!verify_client_secret("wrong_secret", &hash));
+    }
+
+    #[test]
+    fn test_uniqueness() {
+        // Generate multiple tokens and ensure they're unique
+        let tokens: Vec<_> = (0..100).map(|_| generate_access_token().0).collect();
+        let unique: std::collections::HashSet<_> = tokens.iter().collect();
+        assert_eq!(tokens.len(), unique.len());
+    }
+
+    #[test]
+    fn test_client_secret_debug_redacted() {
+        let secret = generate_client_secret();
+        let debug_output = format!("{:?}", secret);
+        assert!(debug_output.contains("REDACTED"));
+        assert!(!debug_output.contains(&secret.0));
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   postgres:
     image: postgres:16-alpine
     ports:
-      - "5432:5432"
+      - "5433:5432"
     environment:
       POSTGRES_DB: chat_api
       POSTGRES_USER: postgres

--- a/oauth-test.html
+++ b/oauth-test.html
@@ -1,0 +1,368 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OAuth 2.0 Test Client</title>
+    <style>
+        * { box-sizing: border-box; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; background: #f5f5f5; }
+        h1 { color: #333; }
+        .card { background: white; border-radius: 8px; padding: 20px; margin-bottom: 20px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+        .card h2 { margin-top: 0; color: #555; font-size: 1.1em; }
+        label { display: block; margin-bottom: 5px; font-weight: 500; color: #444; }
+        input, select { width: 100%; padding: 8px 12px; margin-bottom: 15px; border: 1px solid #ddd; border-radius: 4px; font-size: 14px; }
+        button { background: #0066cc; color: white; border: none; padding: 10px 20px; border-radius: 4px; cursor: pointer; font-size: 14px; margin-right: 10px; }
+        button:hover { background: #0052a3; }
+        button.secondary { background: #666; }
+        button.secondary:hover { background: #555; }
+        pre { background: #1e1e1e; color: #d4d4d4; padding: 15px; border-radius: 4px; overflow-x: auto; font-size: 13px; white-space: pre-wrap; word-break: break-all; }
+        .success { color: #2e7d32; }
+        .error { color: #c62828; }
+        .info { background: #e3f2fd; padding: 10px; border-radius: 4px; margin-bottom: 15px; font-size: 13px; }
+        .step { display: inline-block; background: #0066cc; color: white; width: 24px; height: 24px; border-radius: 50%; text-align: center; line-height: 24px; margin-right: 8px; font-size: 12px; }
+    </style>
+</head>
+<body>
+    <h1>OAuth 2.0 Test Client</h1>
+
+    <div class="card">
+        <h2><span class="step">1</span> Configuration</h2>
+        <label>API Base URL</label>
+        <input type="text" id="baseUrl" value="http://localhost:3001">
+
+        <label>Client ID</label>
+        <input type="text" id="clientId" placeholder="Your OAuth client ID">
+
+        <label>Client Secret (for confidential clients)</label>
+        <input type="password" id="clientSecret" placeholder="Leave empty for public clients">
+
+        <label>Redirect URI</label>
+        <input type="text" id="redirectUri" value="http://localhost:3001/oauth-test.html">
+
+        <label>Scopes (space-separated)</label>
+        <input type="text" id="scopes" value="memory.read memory.write">
+    </div>
+
+    <div class="card">
+        <h2><span class="step">2</span> Start Authorization</h2>
+        <div class="info">
+            This will generate a PKCE code verifier/challenge and redirect you to the authorization endpoint.
+            You must be logged in to the API first.
+        </div>
+        <button onclick="startAuth()">Start OAuth Flow</button>
+        <button class="secondary" onclick="startAuthPopup()">Open in Popup</button>
+    </div>
+
+    <div class="card" id="callbackSection" style="display:none;">
+        <h2><span class="step">3</span> Authorization Callback</h2>
+        <div id="callbackResult"></div>
+    </div>
+
+    <div class="card" id="tokenSection" style="display:none;">
+        <h2><span class="step">4</span> Token Exchange</h2>
+        <div id="tokenResult"></div>
+    </div>
+
+    <div class="card" id="refreshSection" style="display:none;">
+        <h2><span class="step">5</span> Refresh Token</h2>
+        <button onclick="refreshToken()">Refresh Access Token</button>
+        <div id="refreshResult"></div>
+    </div>
+
+    <div class="card">
+        <h2>Debug Log</h2>
+        <button class="secondary" onclick="clearLog()">Clear</button>
+        <pre id="log"></pre>
+    </div>
+
+    <script>
+        // PKCE helpers
+        function generateRandomString(length) {
+            const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
+            let result = '';
+            const randomValues = crypto.getRandomValues(new Uint8Array(length));
+            for (let i = 0; i < length; i++) {
+                result += chars[randomValues[i] % chars.length];
+            }
+            return result;
+        }
+
+        async function sha256(plain) {
+            const encoder = new TextEncoder();
+            const data = encoder.encode(plain);
+            return await crypto.subtle.digest('SHA-256', data);
+        }
+
+        function base64urlencode(arrayBuffer) {
+            let str = '';
+            const bytes = new Uint8Array(arrayBuffer);
+            for (let i = 0; i < bytes.byteLength; i++) {
+                str += String.fromCharCode(bytes[i]);
+            }
+            return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        }
+
+        async function generatePKCE() {
+            const verifier = generateRandomString(64);
+            const hashed = await sha256(verifier);
+            const challenge = base64urlencode(hashed);
+            return { verifier, challenge };
+        }
+
+        // Logging
+        function log(message, type = 'info') {
+            const logEl = document.getElementById('log');
+            const timestamp = new Date().toLocaleTimeString();
+            const prefix = type === 'error' ? '❌' : type === 'success' ? '✅' : 'ℹ️';
+            logEl.textContent = `[${timestamp}] ${prefix} ${message}\n` + logEl.textContent;
+        }
+
+        function clearLog() {
+            document.getElementById('log').textContent = '';
+        }
+
+        // Storage helpers
+        function saveToSession(key, value) {
+            sessionStorage.setItem(`oauth_test_${key}`, JSON.stringify(value));
+        }
+
+        function getFromSession(key) {
+            const value = sessionStorage.getItem(`oauth_test_${key}`);
+            return value ? JSON.parse(value) : null;
+        }
+
+        // Start OAuth flow
+        async function startAuth(popup = false) {
+            const baseUrl = document.getElementById('baseUrl').value;
+            const clientId = document.getElementById('clientId').value;
+            const redirectUri = document.getElementById('redirectUri').value;
+            const scopes = document.getElementById('scopes').value;
+
+            if (!clientId) {
+                log('Client ID is required', 'error');
+                return;
+            }
+
+            // Generate PKCE
+            const pkce = await generatePKCE();
+            const state = generateRandomString(32);
+
+            // Save for later
+            saveToSession('pkce_verifier', pkce.verifier);
+            saveToSession('state', state);
+            saveToSession('config', {
+                baseUrl,
+                clientId,
+                clientSecret: document.getElementById('clientSecret').value,
+                redirectUri
+            });
+
+            // Build authorization URL
+            const params = new URLSearchParams({
+                response_type: 'code',
+                client_id: clientId,
+                redirect_uri: redirectUri,
+                scope: scopes,
+                state: state,
+                code_challenge: pkce.challenge,
+                code_challenge_method: 'S256'
+            });
+
+            const authUrl = `${baseUrl}/v1/oauth/authorize?${params}`;
+
+            log(`Starting OAuth flow...`);
+            log(`PKCE Verifier: ${pkce.verifier.substring(0, 20)}...`);
+            log(`PKCE Challenge: ${pkce.challenge}`);
+            log(`State: ${state}`);
+            log(`Auth URL: ${authUrl}`);
+
+            if (popup) {
+                window.open(authUrl, 'oauth', 'width=600,height=700');
+            } else {
+                window.location.href = authUrl;
+            }
+        }
+
+        function startAuthPopup() {
+            startAuth(true);
+        }
+
+        // Handle callback
+        async function handleCallback() {
+            const params = new URLSearchParams(window.location.search);
+            const code = params.get('code');
+            const state = params.get('state');
+            const error = params.get('error');
+            const errorDesc = params.get('error_description');
+
+            if (!code && !error) {
+                return; // Not a callback
+            }
+
+            document.getElementById('callbackSection').style.display = 'block';
+            const resultEl = document.getElementById('callbackResult');
+
+            if (error) {
+                resultEl.innerHTML = `<p class="error">Error: ${error}</p><p>${errorDesc || ''}</p>`;
+                log(`Authorization failed: ${error} - ${errorDesc}`, 'error');
+                return;
+            }
+
+            // Verify state
+            const savedState = getFromSession('state');
+            if (state !== savedState) {
+                resultEl.innerHTML = `<p class="error">State mismatch! Possible CSRF attack.</p>`;
+                log(`State mismatch: expected ${savedState}, got ${state}`, 'error');
+                return;
+            }
+
+            resultEl.innerHTML = `<p class="success">Authorization code received!</p><pre>${code}</pre>`;
+            log(`Received authorization code: ${code.substring(0, 20)}...`, 'success');
+
+            // Clean URL
+            window.history.replaceState({}, document.title, window.location.pathname);
+
+            // Exchange code for token
+            await exchangeCode(code);
+        }
+
+        // Exchange code for token
+        async function exchangeCode(code) {
+            const config = getFromSession('config');
+            const verifier = getFromSession('pkce_verifier');
+
+            if (!config || !verifier) {
+                log('Missing config or PKCE verifier', 'error');
+                return;
+            }
+
+            document.getElementById('tokenSection').style.display = 'block';
+            const resultEl = document.getElementById('tokenResult');
+            resultEl.innerHTML = '<p>Exchanging code for tokens...</p>';
+
+            const body = new URLSearchParams({
+                grant_type: 'authorization_code',
+                code: code,
+                redirect_uri: config.redirectUri,
+                client_id: config.clientId,
+                code_verifier: verifier
+            });
+
+            const headers = {
+                'Content-Type': 'application/x-www-form-urlencoded'
+            };
+
+            // Add Basic auth if client secret provided
+            if (config.clientSecret) {
+                headers['Authorization'] = 'Basic ' + btoa(`${config.clientId}:${config.clientSecret}`);
+            }
+
+            log(`Exchanging code at ${config.baseUrl}/v1/oauth/token`);
+            log(`Code verifier: ${verifier.substring(0, 20)}...`);
+
+            try {
+                const response = await fetch(`${config.baseUrl}/v1/oauth/token`, {
+                    method: 'POST',
+                    headers,
+                    body
+                });
+
+                const data = await response.json();
+
+                if (!response.ok) {
+                    resultEl.innerHTML = `<p class="error">Token exchange failed</p><pre>${JSON.stringify(data, null, 2)}</pre>`;
+                    log(`Token exchange failed: ${data.error} - ${data.error_description}`, 'error');
+                    return;
+                }
+
+                resultEl.innerHTML = `<p class="success">Tokens received!</p><pre>${JSON.stringify(data, null, 2)}</pre>`;
+                log('Token exchange successful!', 'success');
+
+                // Save tokens
+                saveToSession('tokens', data);
+
+                // Show refresh section if we have a refresh token
+                if (data.refresh_token) {
+                    document.getElementById('refreshSection').style.display = 'block';
+                }
+            } catch (err) {
+                resultEl.innerHTML = `<p class="error">Network error: ${err.message}</p>`;
+                log(`Network error: ${err.message}`, 'error');
+            }
+        }
+
+        // Refresh token
+        async function refreshToken() {
+            const config = getFromSession('config');
+            const tokens = getFromSession('tokens');
+
+            if (!config || !tokens?.refresh_token) {
+                log('No refresh token available', 'error');
+                return;
+            }
+
+            const resultEl = document.getElementById('refreshResult');
+            resultEl.innerHTML = '<p>Refreshing token...</p>';
+
+            const body = new URLSearchParams({
+                grant_type: 'refresh_token',
+                refresh_token: tokens.refresh_token,
+                client_id: config.clientId
+            });
+
+            const headers = {
+                'Content-Type': 'application/x-www-form-urlencoded'
+            };
+
+            if (config.clientSecret) {
+                headers['Authorization'] = 'Basic ' + btoa(`${config.clientId}:${config.clientSecret}`);
+            }
+
+            log(`Refreshing token at ${config.baseUrl}/v1/oauth/token`);
+
+            try {
+                const response = await fetch(`${config.baseUrl}/v1/oauth/token`, {
+                    method: 'POST',
+                    headers,
+                    body
+                });
+
+                const data = await response.json();
+
+                if (!response.ok) {
+                    resultEl.innerHTML = `<p class="error">Token refresh failed</p><pre>${JSON.stringify(data, null, 2)}</pre>`;
+                    log(`Token refresh failed: ${data.error} - ${data.error_description}`, 'error');
+                    return;
+                }
+
+                resultEl.innerHTML = `<p class="success">New tokens received!</p><pre>${JSON.stringify(data, null, 2)}</pre>`;
+                log('Token refresh successful!', 'success');
+
+                // Update saved tokens
+                saveToSession('tokens', data);
+            } catch (err) {
+                resultEl.innerHTML = `<p class="error">Network error: ${err.message}</p>`;
+                log(`Network error: ${err.message}`, 'error');
+            }
+        }
+
+        // Initialize
+        window.onload = function() {
+            // Restore config if available
+            const config = getFromSession('config');
+            if (config) {
+                document.getElementById('baseUrl').value = config.baseUrl || 'http://localhost:3001';
+                document.getElementById('clientId').value = config.clientId || '';
+                document.getElementById('clientSecret').value = config.clientSecret || '';
+                document.getElementById('redirectUri').value = config.redirectUri || '';
+            }
+
+            // Handle callback
+            handleCallback();
+
+            log('OAuth test client ready');
+        };
+    </script>
+</body>
+</html>

--- a/scripts/create-test-oauth-client.sql
+++ b/scripts/create-test-oauth-client.sql
@@ -1,0 +1,57 @@
+-- Create a test OAuth client for local development
+-- Run with: docker compose exec -T postgres psql -U postgres -d chat_api < scripts/create-test-oauth-client.sql
+
+-- First, ensure we have a test user
+INSERT INTO users (id, email, name, created_at, updated_at)
+VALUES (
+    '00000000-0000-0000-0000-000000000001',
+    'test@example.com',
+    'Test User',
+    NOW(),
+    NOW()
+) ON CONFLICT (id) DO NOTHING;
+
+-- Create a test project
+INSERT INTO projects (id, owner_id, name, description, created_at, updated_at)
+VALUES (
+    '00000000-0000-0000-0000-000000000002',
+    '00000000-0000-0000-0000-000000000001',
+    'Test OAuth App',
+    'A test OAuth application for development',
+    NOW(),
+    NOW()
+) ON CONFLICT (id) DO NOTHING;
+
+-- Create the OAuth client (public client, no secret needed)
+INSERT INTO oauth_clients (
+    id,
+    project_id,
+    client_id,
+    client_secret_hash,
+    client_type,
+    redirect_uris,
+    allowed_scopes,
+    created_at
+) VALUES (
+    '00000000-0000-0000-0000-000000000003',
+    '00000000-0000-0000-0000-000000000002',
+    'test-client',
+    NULL,  -- Public client, no secret
+    'public',
+    ARRAY['http://localhost:3001/oauth-test.html', 'http://localhost:3000/callback', 'http://127.0.0.1:3001/oauth-test.html'],
+    ARRAY['memory.read', 'memory.write', 'memory.read.all'],
+    NOW()
+) ON CONFLICT (client_id) DO UPDATE SET
+    redirect_uris = EXCLUDED.redirect_uris,
+    allowed_scopes = EXCLUDED.allowed_scopes;
+
+-- Output the created client
+SELECT
+    c.client_id,
+    c.client_type,
+    c.redirect_uris,
+    c.allowed_scopes,
+    p.name as project_name
+FROM oauth_clients c
+JOIN projects p ON c.project_id = p.id
+WHERE c.client_id = 'test-client';


### PR DESCRIPTION
## Summary
This PR adds comprehensive OAuth2 authentication support to the private-memory-api, including:

- **Google OAuth2** - Sign in with Google accounts
- **GitHub OAuth2** - Sign in with GitHub accounts  
- **NEAR Wallet** - Authentication with NEP-413 signature verification
- **Unified Callback Handler** - Single endpoint handles all OAuth provider callbacks
- **Session Management** - Secure session tokens with SHA-256 hashing
- **OAuth State Management** - CSRF protection with time-limited state tokens
- **Account Linking** - Automatic account linking by email address

## Key Features

### Authentication Providers
- Google OAuth2 with email scope
- GitHub OAuth2 with user:email scope
- NEAR Wallet with NEP-413 signature verification

### Database Schema
- `oauth_states` - CSRF protection tokens with expiration
- `oauth_tokens` - Provider access/refresh token storage
- `oauth_accounts` - Links users to OAuth provider accounts
- `oauth_clients` - OAuth application registration (for future OAuth server support)
- Migration files: V16__oauth_extensions.sql, V17__oauth_server_enhancements.sql

### Endpoints
- `POST /v1/auth/google` - Initiate Google OAuth flow
- `POST /v1/auth/github` - Initiate GitHub OAuth flow
- `POST /v1/auth/near` - Authenticate with NEAR wallet signature
- `GET /v1/auth/callback` - Unified OAuth callback handler
- `POST /v1/auth/logout` - End user session

### Architecture
- **Service Layer** - OAuth business logic in `crates/services/src/auth/`
- **Repository Pattern** - Database access through `oauth_client_repository`
- **PKCE Support** - Proof Key for Code Exchange implementation
- **Scope Management** - OAuth scope validation and handling
- **Token Management** - Secure token storage and retrieval

## Testing
- OAuth integration tests in `crates/api/tests/oauth_server_tests.rs`
- Local testing page: `oauth-test.html`
- Test data script: `scripts/create-test-oauth-client.sql`

## Configuration
Environment variables required:
- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`
- `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`
- `NEAR_NETWORK` (optional, defaults to mainnet)

See `docker-compose.yml` for complete configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)