### PR TITLE
chore: update frontend version to v0.1.11

### DIFF
--- a/build-config.toml
+++ b/build-config.toml
@@ -8,7 +8,7 @@
 #   - "main" (branch)
 #   - "v1.2.3" (tag)
 #   - "abc123def456" (commit hash)
-private_chat_frontend_version = "5c3b26982eeb834792795ffd6b3bf7225d4d722f" # v0.1.11-dev
+private_chat_frontend_version = "641e9fa11d6b50fab77c693ee058e4458d638c68" # v0.1.11
 
 # PostHog key and host for the private-chat frontend
 posthog_key = "phc_glaMeuuO1gLFSB2U9y27MchidXEmSnFOQLB8cceyVSb"


### PR DESCRIPTION
private chat frontend v0.1.11: https://github.com/nearai/private-chat/releases/tag/v0.1.11