### PR TITLE
fix: stripe webhook processing

### DIFF
--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -127,7 +127,6 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
                         current_period_end, cancel_at_period_end, created_at, updated_at
                  FROM subscriptions
                  WHERE user_id = $1 AND status IN ('active', 'trialing')
-                   AND current_period_end > NOW()
                  ORDER BY created_at DESC
                  LIMIT 1",
                 &[&user_id],

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -696,15 +696,9 @@ impl SubscriptionService for SubscriptionServiceImpl {
                     tracing::error!("Webhook signature verification failed: error={}", e);
                     return Err(SubscriptionError::WebhookVerificationFailed(e.to_string()));
                 }
-                // Payload parse error - return 400 immediately instead of continuing to JSON parse
-                WebhookError::BadParse(parse_err) => {
-                    tracing::warn!(
-                        "Webhook payload parse failed (invalid Stripe event structure): error={}",
-                        parse_err
-                    );
-                    return Err(SubscriptionError::WebhookVerificationFailed(
-                        parse_err.to_string(),
-                    ));
+                // Parsing error - signature is OK, we can continue
+                WebhookError::BadParse(_) => {
+                    tracing::debug!("Webhook event parsing failed (signature OK): error={}", e);
                 }
             }
         } else {


### PR DESCRIPTION
Fixes:

1. Ignore `async-stripe` webhook `BadParse` error, which blocks webhook processing
2. Only verify `active` status to avoid corner cases when subscription ends but webhook is not yet invoked.
