### PR TITLE
chore: update private chat frontend to v0.2.0 dev version

### DIFF
--- a/build-config.toml
+++ b/build-config.toml
@@ -8,7 +8,7 @@
 #   - "main" (branch)
 #   - "v1.2.3" (tag)
 #   - "abc123def456" (commit hash)
-private_chat_frontend_version = "5353664990bfa21712c15884cd06e523ac047eba" # v0.1.13
+private_chat_frontend_version = "3b487faa7b9a5717911254aa670ddc3b562475ed" # v0.2.0-dev
 
 # PostHog key and host for the private-chat frontend
 posthog_key = "phc_glaMeuuO1gLFSB2U9y27MchidXEmSnFOQLB8cceyVSb"


### PR DESCRIPTION
Update to the latest private-chat frontend: https://github.com/nearai/private-chat/commit/3b487faa7b9a5717911254aa670ddc3b562475ed