### PR TITLE
chore: update frontend version to v0.2.4

### DIFF
--- a/build-config.toml
+++ b/build-config.toml
@@ -8,7 +8,7 @@
 #   - "main" (branch)
 #   - "v1.2.3" (tag)
 #   - "abc123def456" (commit hash)
-private_chat_frontend_version = "3b487faa7b9a5717911254aa670ddc3b562475ed" # v0.2.0
+private_chat_frontend_version = "78248628d59fb2ff4f6f29efcb1a14fe651fdcd3" # v0.2.4
 
 # PostHog key and host for the private-chat frontend
 posthog_key = "phc_glaMeuuO1gLFSB2U9y27MchidXEmSnFOQLB8cceyVSb"


### PR DESCRIPTION
private chat v0.2.4: https://github.com/nearai/private-chat/releases/tag/v0.2.4