### PR TITLE
feat: return price of subscription plans

### DIFF
--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -886,16 +886,18 @@ async fn test_list_plans_returns_configured_plans() {
     let admin_email = "test_list_plans@admin.org";
     let admin_token = mock_login(&server, admin_email).await;
 
-    // Configure subscription plans with private_assistant_instances and monthly_tokens
+    // Configure subscription plans with price, agent_instances, and monthly_tokens
     let config_body = json!({
         "subscription_plans": {
             "starter": {
                 "providers": { "stripe": { "price_id": "price_starter_789" } },
+                "price": 999,
                 "agent_instances": { "max": 1 },
                 "monthly_tokens": { "max": 500_000 }
             },
             "premium": {
                 "providers": { "stripe": { "price_id": "price_premium_012" } },
+                "price": 1999,
                 "agent_instances": { "max": 5 },
                 "monthly_tokens": { "max": 5_000_000 }
             }
@@ -956,6 +958,11 @@ async fn test_list_plans_returns_configured_plans() {
         match name {
             "starter" => {
                 assert_eq!(
+                    plan.get("price").and_then(|p| p.as_i64()),
+                    Some(999),
+                    "Starter plan should have price = 999 cents ($9.99)"
+                );
+                assert_eq!(
                     plan.get("agent_instances")
                         .and_then(|d| d.get("max"))
                         .and_then(|m| m.as_u64()),
@@ -971,6 +978,11 @@ async fn test_list_plans_returns_configured_plans() {
                 );
             }
             "premium" => {
+                assert_eq!(
+                    plan.get("price").and_then(|p| p.as_i64()),
+                    Some(1999),
+                    "Premium plan should have price = 1999 cents ($19.99)"
+                );
                 assert_eq!(
                     plan.get("agent_instances")
                         .and_then(|d| d.get("max"))

--- a/crates/services/src/subscription/ports.rs
+++ b/crates/services/src/subscription/ports.rs
@@ -215,6 +215,9 @@ pub trait PaymentWebhookRepository: Send + Sync {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubscriptionPlan {
     pub name: String,
+    /// Plan price in cents (e.g. 999 for $9.99, 0 for free)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price: Option<i64>,
     /// Free trial period in days before first charge
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial_period_days: Option<u32>,

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -388,11 +388,13 @@ impl SubscriptionService for SubscriptionServiceImpl {
             .into_keys()
             .map(|name| {
                 let plan_config = subscription_plans.get(&name);
+                let price = plan_config.and_then(|c| c.price);
                 let agent_instances = plan_config.and_then(|c| c.agent_instances.clone());
                 let monthly_tokens = plan_config.and_then(|c| c.monthly_tokens.clone());
                 let trial_period_days = plan_config.and_then(|c| c.trial_period_days);
                 SubscriptionPlan {
                     name,
+                    price,
                     trial_period_days,
                     agent_instances,
                     monthly_tokens,


### PR DESCRIPTION
Include `price` into [/v1/subscriptions/plans](https://private-chat-stg.near.ai/docs/#/Subscriptions/list_plans)
