### PR TITLE
chore: update frontend version to v0.2.6

### DIFF
--- a/build-config.toml
+++ b/build-config.toml
@@ -8,7 +8,7 @@
 #   - "main" (branch)
 #   - "v1.2.3" (tag)
 #   - "abc123def456" (commit hash)
-private_chat_frontend_version = "17f45523af0abad30fa4a948c89980b1cc1bcf32" # v0.2.4
+private_chat_frontend_version = "cdb5eeacac029264df09b120f705df3c3d7edf12" # v0.2.6
 
 # PostHog key and host for the private-chat frontend
 posthog_key = "phc_glaMeuuO1gLFSB2U9y27MchidXEmSnFOQLB8cceyVSb"


### PR DESCRIPTION
Update frontend version to [private chat v0.2.6](https://github.com/nearai/private-chat/releases/tag/v0.2.6)