### PR TITLE
fix: missed plan downgrade at invoice.created event

### DIFF
--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -521,6 +521,26 @@ impl SubscriptionServiceImpl {
         Utc::now() >= check_from
     }
 
+    /// True when Stripe reports an earlier period end than we stored at downgrade scheduling time.
+    /// In that case the pending downgrade intent is considered stale and marked `missed`.
+    fn is_backward_period_drift(
+        current_period_end: chrono::DateTime<Utc>,
+        expected_period_end: chrono::DateTime<Utc>,
+    ) -> bool {
+        current_period_end < expected_period_end
+    }
+
+    /// Eligible to call Stripe to apply the pending downgrade: still on the "from" price and
+    /// period end has reached or passed the expected boundary (including forward drift at renewal).
+    fn should_attempt_pending_downgrade_apply(
+        current_price_id: &str,
+        from_price_id: &str,
+        current_period_end: chrono::DateTime<Utc>,
+        expected_period_end: chrono::DateTime<Utc>,
+    ) -> bool {
+        current_price_id == from_price_id && current_period_end >= expected_period_end
+    }
+
     async fn try_apply_pending_downgrade_in_txn(
         &self,
         txn: &tokio_postgres::Transaction<'_>,
@@ -598,7 +618,7 @@ impl SubscriptionServiceImpl {
         // Stripe can advance `current_period_end` by the time `invoice.created` fires at
         // renewal. Treat only backward drift as a terminal mismatch; forward drift should
         // still allow applying the pending downgrade.
-        if current_model.current_period_end < expected_period_end {
+        if Self::is_backward_period_drift(current_model.current_period_end, expected_period_end) {
             Self::mark_downgrade_terminal(&mut current_model, DowngradeIntentStatus::Missed);
             let updated = self
                 .subscription_repo
@@ -608,7 +628,12 @@ impl SubscriptionServiceImpl {
             return Ok(Some(updated));
         }
 
-        if current_model.price_id == from_price_id {
+        if Self::should_attempt_pending_downgrade_apply(
+            &current_model.price_id,
+            &from_price_id,
+            current_model.current_period_end,
+            expected_period_end,
+        ) {
             let plans = self.get_subscription_plans().await?;
             let target_plan_name =
                 resolve_plan_name_from_config(&pending.provider, &target_price_id, &plans)
@@ -2890,6 +2915,59 @@ mod tests {
         assert_eq!(
             sub.pending_downgrade_status,
             Some(DowngradeIntentStatus::Applied)
+        );
+    }
+
+    #[test]
+    fn test_pending_downgrade_backward_period_drift_marks_missed_predicate() {
+        let expected = Utc::now();
+        assert!(SubscriptionServiceImpl::is_backward_period_drift(
+            expected - Duration::seconds(1),
+            expected
+        ));
+        assert!(!SubscriptionServiceImpl::is_backward_period_drift(
+            expected, expected
+        ));
+        assert!(!SubscriptionServiceImpl::is_backward_period_drift(
+            expected + Duration::seconds(1),
+            expected
+        ));
+    }
+
+    #[test]
+    fn test_pending_downgrade_apply_predicate_allows_forward_period_end_drift() {
+        let expected = Utc::now();
+        assert!(
+            SubscriptionServiceImpl::should_attempt_pending_downgrade_apply(
+                "price_pro",
+                "price_pro",
+                expected + Duration::seconds(1),
+                expected
+            )
+        );
+        assert!(
+            SubscriptionServiceImpl::should_attempt_pending_downgrade_apply(
+                "price_pro",
+                "price_pro",
+                expected,
+                expected
+            )
+        );
+        assert!(
+            !SubscriptionServiceImpl::should_attempt_pending_downgrade_apply(
+                "price_basic",
+                "price_pro",
+                expected + Duration::seconds(1),
+                expected
+            )
+        );
+        assert!(
+            !SubscriptionServiceImpl::should_attempt_pending_downgrade_apply(
+                "price_pro",
+                "price_pro",
+                expected - Duration::seconds(1),
+                expected
+            )
         );
     }
 


### PR DESCRIPTION
## Summary
Fixes pending downgrade handling during Stripe renewal webhooks so downgrades are not incorrectly marked as `missed` when `invoice.created` arrives with an already advanced `current_period_end`.
### What changed
- Updated downgrade mismatch logic in `chat-api/crates/services/src/subscription/service.rs`:
  - Previously: any `current_period_end != expected_period_end` marked downgrade as `missed`.
  - Now: only `current_period_end < expected_period_end` is treated as terminal mismatch.
- Relaxed apply condition:
  - Previously required both `price_id == from_price_id` and exact period-end equality.
  - Now requires `price_id == from_price_id` only, allowing downgrade application when Stripe has rolled period end forward at renewal.
### Why
During `invoice.created` for `subscription_cycle`, Stripe may already report the next billing period's end. Exact equality against the stored expected period end is too strict and can cause false `missed` outcomes, leaving users on Pro unexpectedly.
### Impact
- Prevents false-negative downgrade application at cycle boundary.
- Keeps downgrade intent flow robust against Stripe renewal timing.
- Existing behavior for true stale/backward mismatches is preserved.
## Test plan
- [x] Run targeted unit test:
  - `cargo test -p services test_should_check_pending_downgrade_window -- --nocapture`
- [ ] Reproduce downgrade-at-renewal scenario in staging with Stripe test clock:
  - Set pending downgrade (Pro -> Basic)
  - Trigger renewal (`invoice.created`)
  - Verify DB no longer lands in `pending_downgrade_status = missed` due solely to forward period-end drift
  - Verify subscription is transitioned to target downgraded price