### PR TITLE
feat(admin): subscription repair API

### DIFF
--- a/crates/api/src/models.rs
+++ b/crates/api/src/models.rs
@@ -1232,6 +1232,42 @@ fn default_limit() -> i64 {
     20
 }
 
+/// Request to fully replace one existing subscription row (admin repair only)
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct AdminReplaceSubscriptionRequest {
+    /// User ID owning the subscription row
+    pub user_id: UserId,
+    /// Payment provider (e.g. "stripe")
+    pub provider: String,
+    /// Raw customer identifier stored in the subscriptions table
+    pub customer_id: String,
+    /// Raw provider price identifier
+    pub price_id: String,
+    /// Raw subscription status string
+    pub status: String,
+    /// Subscription period end date/time
+    pub current_period_end: chrono::DateTime<chrono::Utc>,
+    /// Whether cancellation is scheduled for period end
+    pub cancel_at_period_end: bool,
+    /// Original row creation timestamp to preserve
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Target price_id for a deferred downgrade intent
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pending_downgrade_target_price_id: Option<String>,
+    /// Original price_id when the downgrade intent was created
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pending_downgrade_from_price_id: Option<String>,
+    /// Expected period end when the downgrade will be evaluated
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pending_downgrade_expected_period_end: Option<chrono::DateTime<chrono::Utc>>,
+    /// Last downgrade intent status
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pending_downgrade_status: Option<services::subscription::ports::DowngradeIntentStatus>,
+    /// Timestamp when the downgrade intent was last changed
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pending_downgrade_updated_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
 /// Request to set a user's subscription (admin only)
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct AdminSetSubscriptionRequest {

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -866,13 +866,14 @@ pub async fn admin_replace_subscription(
 
     let subscription = app_state
         .subscription_service
-        .admin_replace_subscription(admin.user_id, subscription_id, replacement)
+        .admin_replace_subscription(admin.user_id, subscription_id.clone(), replacement)
         .await
         .map_err(|e| {
             tracing::error!(
-                "Failed to replace subscription row: admin_user_id={}, error={}",
-                admin.user_id,
-                e
+                admin_user_id = %admin.user_id,
+                subscription_id = %subscription_id,
+                error = %e,
+                "Failed to replace subscription row"
             );
             match e {
                 services::subscription::ports::SubscriptionError::SubscriptionNotFound => {

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -819,6 +819,80 @@ pub async fn admin_cancel_user_subscriptions(
     })))
 }
 
+/// Admin endpoint: Fully replace one existing subscription row (privileged repair only)
+///
+/// This endpoint exists only for manual admin data repair. It intentionally performs no
+/// subscription business validation beyond admin authentication and direct database constraints.
+/// It updates exactly one existing `subscriptions` row selected by `subscription_id`, does not
+/// create/delete rows, and relies on a full before/after audit log for accountability.
+#[utoipa::path(
+    put,
+    path = "/v1/admin/subscriptions/{subscription_id}",
+    tag = "Admin",
+    params(
+        ("subscription_id" = String, Path, description = "Subscription row ID")
+    ),
+    request_body = AdminReplaceSubscriptionRequest,
+    responses(
+        (status = 200, description = "Subscription row replaced successfully", body = services::subscription::ports::Subscription),
+        (status = 401, description = "Unauthorized", body = crate::error::ApiErrorResponse),
+        (status = 403, description = "Forbidden - Admin access required", body = crate::error::ApiErrorResponse),
+        (status = 404, description = "Subscription row not found", body = crate::error::ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = crate::error::ApiErrorResponse)
+    ),
+    security(("session_token" = []))
+)]
+pub async fn admin_replace_subscription(
+    State(app_state): State<AppState>,
+    Extension(admin): Extension<AuthenticatedUser>,
+    Path(subscription_id): Path<String>,
+    Json(request): Json<AdminReplaceSubscriptionRequest>,
+) -> Result<Json<services::subscription::ports::Subscription>, ApiError> {
+    tracing::info!(
+        "Admin replacing subscription row: admin_user_id={}, subscription_id={}",
+        admin.user_id,
+        subscription_id
+    );
+
+    let subscription = services::subscription::ports::Subscription {
+        subscription_id,
+        user_id: request.user_id,
+        provider: request.provider,
+        customer_id: request.customer_id,
+        price_id: request.price_id,
+        status: request.status,
+        current_period_end: request.current_period_end,
+        cancel_at_period_end: request.cancel_at_period_end,
+        created_at: request.created_at,
+        updated_at: chrono::Utc::now(),
+        pending_downgrade_target_price_id: request.pending_downgrade_target_price_id,
+        pending_downgrade_from_price_id: request.pending_downgrade_from_price_id,
+        pending_downgrade_expected_period_end: request.pending_downgrade_expected_period_end,
+        pending_downgrade_status: request.pending_downgrade_status,
+        pending_downgrade_updated_at: request.pending_downgrade_updated_at,
+    };
+
+    let subscription = app_state
+        .subscription_service
+        .admin_replace_subscription(admin.user_id, subscription)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "Failed to replace subscription row: admin_user_id={}, error={}",
+                admin.user_id,
+                e
+            );
+            match e {
+                services::subscription::ports::SubscriptionError::SubscriptionNotFound => {
+                    ApiError::not_found("Subscription not found")
+                }
+                _ => ApiError::internal_server_error("Failed to replace subscription row"),
+            }
+        })?;
+
+    Ok(Json(subscription))
+}
+
 /// List subscriptions (admin)
 ///
 /// Returns paginated raw subscription rows for internal operations and debugging.
@@ -2696,6 +2770,10 @@ pub fn create_admin_router() -> Router<AppState> {
             post(admin_set_user_subscription).delete(admin_cancel_user_subscriptions),
         )
         .route("/subscriptions", get(admin_list_subscriptions))
+        .route(
+            "/subscriptions/{subscription_id}",
+            axum::routing::put(admin_replace_subscription),
+        )
         .route("/models", get(list_models).patch(batch_upsert_models))
         .route("/models/{model_id}", delete(delete_model))
         .route("/vpc/revoke", post(revoke_vpc_credentials))

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -848,14 +848,7 @@ pub async fn admin_replace_subscription(
     Path(subscription_id): Path<String>,
     Json(request): Json<AdminReplaceSubscriptionRequest>,
 ) -> Result<Json<services::subscription::ports::Subscription>, ApiError> {
-    tracing::info!(
-        "Admin replacing subscription row: admin_user_id={}, subscription_id={}",
-        admin.user_id,
-        subscription_id
-    );
-
-    let subscription = services::subscription::ports::Subscription {
-        subscription_id,
+    let replacement = services::subscription::ports::SubscriptionReplacement {
         user_id: request.user_id,
         provider: request.provider,
         customer_id: request.customer_id,
@@ -864,7 +857,6 @@ pub async fn admin_replace_subscription(
         current_period_end: request.current_period_end,
         cancel_at_period_end: request.cancel_at_period_end,
         created_at: request.created_at,
-        updated_at: chrono::Utc::now(),
         pending_downgrade_target_price_id: request.pending_downgrade_target_price_id,
         pending_downgrade_from_price_id: request.pending_downgrade_from_price_id,
         pending_downgrade_expected_period_end: request.pending_downgrade_expected_period_end,
@@ -874,7 +866,7 @@ pub async fn admin_replace_subscription(
 
     let subscription = app_state
         .subscription_service
-        .admin_replace_subscription(admin.user_id, subscription)
+        .admin_replace_subscription(admin.user_id, subscription_id, replacement)
         .await
         .map_err(|e| {
             tracing::error!(

--- a/crates/api/tests/common.rs
+++ b/crates/api/tests/common.rs
@@ -434,8 +434,11 @@ pub async fn insert_test_subscription_with_provider_and_price(
         .execute(
             "INSERT INTO subscriptions (
                 subscription_id, user_id, provider, customer_id, price_id, status,
-                current_period_end, cancel_at_period_end
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                current_period_end, cancel_at_period_end,
+                pending_downgrade_target_price_id, pending_downgrade_from_price_id,
+                pending_downgrade_expected_period_end, pending_downgrade_status,
+                pending_downgrade_updated_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NULL, NULL, NULL, NULL, NULL)
             ON CONFLICT (subscription_id) DO UPDATE SET
                 price_id = EXCLUDED.price_id,
                 cancel_at_period_end = EXCLUDED.cancel_at_period_end,

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use api::routes::api::SUBSCRIPTION_REQUIRED_ERROR_MESSAGE;
-use chrono::{Duration, TimeZone, Utc};
+use chrono::{Duration, TimeZone, Timelike, Utc};
 use common::{
     cleanup_user_agent_instances, cleanup_user_subscriptions, clear_subscription_plans,
     create_test_server, create_test_server_and_db, insert_test_agent_instances,
@@ -2238,7 +2238,9 @@ async fn test_admin_replace_subscription_success_updates_only_target_row() {
     let other_updated_before: chrono::DateTime<Utc> = other_row.get("updated_at");
 
     let replacement_period_end = Utc::now() + Duration::days(30);
-    let pending_updated_at = Utc::now() - Duration::hours(3);
+    let pending_updated_at = (Utc::now() - Duration::hours(3))
+        .with_nanosecond(((Utc::now() - Duration::hours(3)).timestamp_subsec_micros()) * 1_000)
+        .expect("valid microsecond timestamp");
     let admin_token = mock_login(&server, "replace_sub_success@admin.org").await;
 
     let response = server

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -2068,6 +2068,386 @@ async fn test_admin_set_subscription_success() {
 
 #[tokio::test]
 #[serial(subscription_tests)]
+async fn test_admin_replace_subscription_requires_admin() {
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
+
+    let user_email = "replace_sub_requires_admin@example.com";
+    cleanup_user_subscriptions(&db, user_email).await;
+    insert_test_subscription(&server, &db, user_email, false).await;
+
+    let user = db
+        .user_repository()
+        .get_user_by_email(user_email)
+        .await
+        .expect("get user")
+        .expect("user should exist");
+
+    let client = db.pool().get().await.expect("get pool client");
+    let row = client
+        .query_one(
+            "SELECT subscription_id, provider, customer_id, price_id, status, current_period_end, cancel_at_period_end, created_at,
+                    pending_downgrade_target_price_id, pending_downgrade_from_price_id,
+                    pending_downgrade_expected_period_end, pending_downgrade_status, pending_downgrade_updated_at
+             FROM subscriptions WHERE user_id = $1 LIMIT 1",
+            &[&user.id],
+        )
+        .await
+        .expect("load subscription row");
+
+    let subscription_id: String = row.get("subscription_id");
+    let current_period_end: chrono::DateTime<Utc> = row.get("current_period_end");
+    let created_at: chrono::DateTime<Utc> = row.get("created_at");
+
+    let user_token = mock_login(&server, user_email).await;
+    let response = server
+        .put(&format!("/v1/admin/subscriptions/{subscription_id}"))
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {user_token}")).unwrap(),
+        )
+        .json(&json!({
+            "user_id": user.id,
+            "provider": row.get::<_, String>("provider"),
+            "customer_id": row.get::<_, String>("customer_id"),
+            "price_id": row.get::<_, String>("price_id"),
+            "status": row.get::<_, String>("status"),
+            "current_period_end": current_period_end,
+            "cancel_at_period_end": row.get::<_, bool>("cancel_at_period_end"),
+            "created_at": created_at,
+            "pending_downgrade_target_price_id": row.get::<_, Option<String>>("pending_downgrade_target_price_id"),
+            "pending_downgrade_from_price_id": row.get::<_, Option<String>>("pending_downgrade_from_price_id"),
+            "pending_downgrade_expected_period_end": row.get::<_, Option<chrono::DateTime<Utc>>>("pending_downgrade_expected_period_end"),
+            "pending_downgrade_status": row.get::<_, Option<String>>("pending_downgrade_status"),
+            "pending_downgrade_updated_at": row.get::<_, Option<chrono::DateTime<Utc>>>("pending_downgrade_updated_at")
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 403);
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn test_admin_replace_subscription_requires_auth() {
+    let (server, _db) = create_test_server_and_db(TestServerConfig::default()).await;
+
+    let response = server
+        .put("/v1/admin/subscriptions/sub_missing")
+        .json(&json!({
+            "user_id": services::UserId::nil(),
+            "provider": "stripe",
+            "customer_id": "cus_test",
+            "price_id": "price_test_basic",
+            "status": "active",
+            "current_period_end": Utc::now(),
+            "cancel_at_period_end": false,
+            "created_at": Utc::now(),
+            "pending_downgrade_target_price_id": null,
+            "pending_downgrade_from_price_id": null,
+            "pending_downgrade_expected_period_end": null,
+            "pending_downgrade_status": null,
+            "pending_downgrade_updated_at": null
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 401);
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn test_admin_replace_subscription_not_found() {
+    let (server, _db) = create_test_server_and_db(TestServerConfig::default()).await;
+    let admin_token = mock_login(&server, "replace_sub_not_found@admin.org").await;
+
+    let response = server
+        .put("/v1/admin/subscriptions/sub_missing")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {admin_token}")).unwrap(),
+        )
+        .json(&json!({
+            "user_id": services::UserId::nil(),
+            "provider": "stripe",
+            "customer_id": "cus_test",
+            "price_id": "price_test_basic",
+            "status": "active",
+            "current_period_end": Utc::now(),
+            "cancel_at_period_end": false,
+            "created_at": Utc::now(),
+            "pending_downgrade_target_price_id": null,
+            "pending_downgrade_from_price_id": null,
+            "pending_downgrade_expected_period_end": null,
+            "pending_downgrade_status": null,
+            "pending_downgrade_updated_at": null
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 404);
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn test_admin_replace_subscription_success_updates_only_target_row() {
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
+
+    let target_email = "replace_sub_target@example.com";
+    let other_email = "replace_sub_other@example.com";
+    cleanup_user_subscriptions(&db, target_email).await;
+    cleanup_user_subscriptions(&db, other_email).await;
+    insert_test_subscription(&server, &db, target_email, false).await;
+    insert_test_subscription(&server, &db, other_email, false).await;
+
+    let target_user = db
+        .user_repository()
+        .get_user_by_email(target_email)
+        .await
+        .expect("get target user")
+        .expect("target user should exist");
+    let other_user = db
+        .user_repository()
+        .get_user_by_email(other_email)
+        .await
+        .expect("get other user")
+        .expect("other user should exist");
+
+    let client = db.pool().get().await.expect("get pool client");
+    let target_row = client
+        .query_one(
+            "SELECT subscription_id, provider, customer_id, price_id, status, current_period_end, cancel_at_period_end, created_at, updated_at,
+                    pending_downgrade_target_price_id, pending_downgrade_from_price_id,
+                    pending_downgrade_expected_period_end, pending_downgrade_status, pending_downgrade_updated_at
+             FROM subscriptions WHERE user_id = $1 LIMIT 1",
+            &[&target_user.id],
+        )
+        .await
+        .expect("load target row");
+    let other_row = client
+        .query_one(
+            "SELECT subscription_id, price_id, status, cancel_at_period_end, updated_at
+             FROM subscriptions WHERE user_id = $1 LIMIT 1",
+            &[&other_user.id],
+        )
+        .await
+        .expect("load other row");
+
+    let subscription_id: String = target_row.get("subscription_id");
+    let previous_updated_at: chrono::DateTime<Utc> = target_row.get("updated_at");
+    let other_subscription_id: String = other_row.get("subscription_id");
+    let other_price_id_before: String = other_row.get("price_id");
+    let other_status_before: String = other_row.get("status");
+    let other_cancel_before: bool = other_row.get("cancel_at_period_end");
+    let other_updated_before: chrono::DateTime<Utc> = other_row.get("updated_at");
+
+    let replacement_period_end = Utc::now() + Duration::days(30);
+    let pending_updated_at = Utc::now() - Duration::hours(3);
+    let admin_token = mock_login(&server, "replace_sub_success@admin.org").await;
+
+    let response = server
+        .put(&format!("/v1/admin/subscriptions/{subscription_id}"))
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {admin_token}")).unwrap(),
+        )
+        .json(&json!({
+            "user_id": target_user.id,
+            "provider": "stripe",
+            "customer_id": "cus_manual_override",
+            "price_id": "price_manual_override",
+            "status": "past_due",
+            "current_period_end": replacement_period_end,
+            "cancel_at_period_end": true,
+            "created_at": target_row.get::<_, chrono::DateTime<Utc>>("created_at"),
+            "pending_downgrade_target_price_id": "price_manual_target",
+            "pending_downgrade_from_price_id": "price_manual_from",
+            "pending_downgrade_expected_period_end": replacement_period_end,
+            "pending_downgrade_status": "pending",
+            "pending_downgrade_updated_at": pending_updated_at
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 200);
+    let body: serde_json::Value = response.json();
+    assert_eq!(
+        body["subscription_id"].as_str(),
+        Some(subscription_id.as_str())
+    );
+    assert_eq!(body["customer_id"].as_str(), Some("cus_manual_override"));
+    assert_eq!(body["price_id"].as_str(), Some("price_manual_override"));
+    assert_eq!(body["status"].as_str(), Some("past_due"));
+    assert_eq!(body["cancel_at_period_end"].as_bool(), Some(true));
+    assert_eq!(body["pending_downgrade_status"].as_str(), Some("pending"));
+    let response_pending_updated_at = body["pending_downgrade_updated_at"]
+        .as_str()
+        .expect("response should include pending_downgrade_updated_at")
+        .parse::<chrono::DateTime<Utc>>()
+        .expect("pending_downgrade_updated_at should be valid RFC3339");
+    assert_eq!(response_pending_updated_at, pending_updated_at);
+
+    let updated_target_row = client
+        .query_one(
+            "SELECT subscription_id, customer_id, price_id, status, current_period_end, cancel_at_period_end, updated_at,
+                    pending_downgrade_target_price_id, pending_downgrade_from_price_id,
+                    pending_downgrade_expected_period_end, pending_downgrade_status, pending_downgrade_updated_at
+             FROM subscriptions WHERE subscription_id = $1",
+            &[&subscription_id],
+        )
+        .await
+        .expect("reload target row");
+
+    assert_eq!(
+        updated_target_row.get::<_, String>("customer_id"),
+        "cus_manual_override"
+    );
+    assert_eq!(
+        updated_target_row.get::<_, String>("price_id"),
+        "price_manual_override"
+    );
+    assert_eq!(updated_target_row.get::<_, String>("status"), "past_due");
+    assert!(updated_target_row.get::<_, bool>("cancel_at_period_end"));
+    assert_eq!(
+        updated_target_row.get::<_, Option<String>>("pending_downgrade_target_price_id"),
+        Some("price_manual_target".to_string())
+    );
+    assert_eq!(
+        updated_target_row.get::<_, Option<String>>("pending_downgrade_from_price_id"),
+        Some("price_manual_from".to_string())
+    );
+    assert_eq!(
+        updated_target_row.get::<_, Option<String>>("pending_downgrade_status"),
+        Some("pending".to_string())
+    );
+    assert_eq!(
+        updated_target_row.get::<_, Option<chrono::DateTime<Utc>>>("pending_downgrade_updated_at"),
+        Some(pending_updated_at)
+    );
+    assert!(
+        updated_target_row.get::<_, chrono::DateTime<Utc>>("updated_at") >= previous_updated_at,
+        "updated_at should be set by DB trigger"
+    );
+
+    let updated_other_row = client
+        .query_one(
+            "SELECT subscription_id, price_id, status, cancel_at_period_end, updated_at
+             FROM subscriptions WHERE subscription_id = $1",
+            &[&other_subscription_id],
+        )
+        .await
+        .expect("reload other row");
+
+    assert_eq!(
+        updated_other_row.get::<_, String>("price_id"),
+        other_price_id_before
+    );
+    assert_eq!(
+        updated_other_row.get::<_, String>("status"),
+        other_status_before
+    );
+    assert_eq!(
+        updated_other_row.get::<_, bool>("cancel_at_period_end"),
+        other_cancel_before
+    );
+    assert_eq!(
+        updated_other_row.get::<_, chrono::DateTime<Utc>>("updated_at"),
+        other_updated_before
+    );
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn test_admin_replace_subscription_can_move_row_to_another_user() {
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
+
+    let source_email = "replace_sub_move_source@example.com";
+    let target_email = "replace_sub_move_target@example.com";
+    cleanup_user_subscriptions(&db, source_email).await;
+    cleanup_user_subscriptions(&db, target_email).await;
+    insert_test_subscription(&server, &db, source_email, false).await;
+    let _ = mock_login(&server, target_email).await;
+
+    let source_user = db
+        .user_repository()
+        .get_user_by_email(source_email)
+        .await
+        .expect("get source user")
+        .expect("source user should exist");
+    let target_user = db
+        .user_repository()
+        .get_user_by_email(target_email)
+        .await
+        .expect("get target user")
+        .expect("target user should exist");
+
+    let client = db.pool().get().await.expect("get pool client");
+    let row = client
+        .query_one(
+            "SELECT subscription_id, provider, customer_id, price_id, status, current_period_end, cancel_at_period_end, created_at
+             FROM subscriptions WHERE user_id = $1 LIMIT 1",
+            &[&source_user.id],
+        )
+        .await
+        .expect("load source row");
+    let subscription_id: String = row.get("subscription_id");
+
+    let admin_token = mock_login(&server, "replace_sub_move@admin.org").await;
+    let response = server
+        .put(&format!("/v1/admin/subscriptions/{subscription_id}"))
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {admin_token}")).unwrap(),
+        )
+        .json(&json!({
+            "user_id": target_user.id,
+            "provider": row.get::<_, String>("provider"),
+            "customer_id": row.get::<_, String>("customer_id"),
+            "price_id": row.get::<_, String>("price_id"),
+            "status": row.get::<_, String>("status"),
+            "current_period_end": row.get::<_, chrono::DateTime<Utc>>("current_period_end"),
+            "cancel_at_period_end": row.get::<_, bool>("cancel_at_period_end"),
+            "created_at": row.get::<_, chrono::DateTime<Utc>>("created_at"),
+            "pending_downgrade_target_price_id": null,
+            "pending_downgrade_from_price_id": null,
+            "pending_downgrade_expected_period_end": null,
+            "pending_downgrade_status": null,
+            "pending_downgrade_updated_at": null
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 200);
+
+    let moved_row = client
+        .query_one(
+            "SELECT user_id FROM subscriptions WHERE subscription_id = $1",
+            &[&subscription_id],
+        )
+        .await
+        .expect("reload moved row");
+    assert_eq!(
+        moved_row.get::<_, services::UserId>("user_id"),
+        target_user.id
+    );
+
+    let source_count: i64 = client
+        .query_one(
+            "SELECT COUNT(*) FROM subscriptions WHERE user_id = $1",
+            &[&source_user.id],
+        )
+        .await
+        .expect("count source rows")
+        .get(0);
+    let target_count: i64 = client
+        .query_one(
+            "SELECT COUNT(*) FROM subscriptions WHERE user_id = $1",
+            &[&target_user.id],
+        )
+        .await
+        .expect("count target rows")
+        .get(0);
+
+    assert_eq!(source_count, 0);
+    assert_eq!(target_count, 1);
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
 async fn test_admin_cancel_subscription_requires_admin() {
     let (server, _db) = create_test_server_and_db(TestServerConfig::default()).await;
 

--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -21,8 +21,16 @@ fn row_to_subscription(row: &tokio_postgres::Row) -> Subscription {
         pending_downgrade_status: row
             .get::<_, Option<String>>("pending_downgrade_status")
             .and_then(|v| v.parse::<DowngradeIntentStatus>().ok()),
+        pending_downgrade_updated_at: row.get("pending_downgrade_updated_at"),
     }
 }
+
+const SUBSCRIPTION_COLUMNS: &str =
+    "subscription_id, user_id, provider, customer_id, price_id, status,
+       current_period_end, cancel_at_period_end, created_at, updated_at,
+       pending_downgrade_target_price_id, pending_downgrade_from_price_id,
+       pending_downgrade_expected_period_end, pending_downgrade_status,
+       pending_downgrade_updated_at";
 
 pub struct PostgresSubscriptionRepository {
     pool: DbPool,
@@ -105,7 +113,8 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
                  RETURNING subscription_id, user_id, provider, customer_id, price_id, status,
                            current_period_end, cancel_at_period_end, created_at, updated_at,
                            pending_downgrade_target_price_id, pending_downgrade_from_price_id,
-                           pending_downgrade_expected_period_end, pending_downgrade_status",
+                           pending_downgrade_expected_period_end, pending_downgrade_status,
+                           pending_downgrade_updated_at",
                 &[
                     &subscription.subscription_id,
                     &subscription.user_id,
@@ -149,13 +158,12 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
 
         let rows = client
             .query(
-                "SELECT subscription_id, user_id, provider, customer_id, price_id, status,
-                        current_period_end, cancel_at_period_end, created_at, updated_at,
-                        pending_downgrade_target_price_id, pending_downgrade_from_price_id,
-                        pending_downgrade_expected_period_end, pending_downgrade_status
+                &format!(
+                    "SELECT {SUBSCRIPTION_COLUMNS}
                  FROM subscriptions
                  WHERE user_id = $1
-                 ORDER BY created_at DESC",
+                 ORDER BY created_at DESC"
+                ),
                 &[&user_id],
             )
             .await?;
@@ -176,14 +184,13 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
 
         let row = client
             .query_opt(
-                "SELECT subscription_id, user_id, provider, customer_id, price_id, status,
-                        current_period_end, cancel_at_period_end, created_at, updated_at,
-                        pending_downgrade_target_price_id, pending_downgrade_from_price_id,
-                        pending_downgrade_expected_period_end, pending_downgrade_status
+                &format!(
+                    "SELECT {SUBSCRIPTION_COLUMNS}
                  FROM subscriptions
                  WHERE user_id = $1 AND status IN ('active', 'trialing')
                  ORDER BY created_at DESC
-                 LIMIT 1",
+                 LIMIT 1"
+                ),
                 &[&user_id],
             )
             .await?;
@@ -232,14 +239,13 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
 
         let rows = client
             .query(
-                "SELECT subscription_id, user_id, provider, customer_id, price_id, status,
-                        current_period_end, cancel_at_period_end, created_at, updated_at,
-                        pending_downgrade_target_price_id, pending_downgrade_from_price_id,
-                        pending_downgrade_expected_period_end, pending_downgrade_status
+                &format!(
+                    "SELECT {SUBSCRIPTION_COLUMNS}
                  FROM subscriptions
                  WHERE ($1::uuid IS NULL OR user_id = $1)
                  ORDER BY created_at DESC
-                 LIMIT $2 OFFSET $3",
+                 LIMIT $2 OFFSET $3"
+                ),
                 &[&user_id, &limit, &offset],
             )
             .await?;
@@ -257,13 +263,12 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
 
         let rows = client
             .query(
-                "SELECT subscription_id, user_id, provider, customer_id, price_id, status,
-                        current_period_end, cancel_at_period_end, created_at, updated_at,
-                        pending_downgrade_target_price_id, pending_downgrade_from_price_id,
-                        pending_downgrade_expected_period_end, pending_downgrade_status
+                &format!(
+                    "SELECT {SUBSCRIPTION_COLUMNS}
                  FROM subscriptions
                  WHERE user_id = $1 AND status IN ('active', 'trialing')
-                 ORDER BY current_period_end DESC",
+                 ORDER BY current_period_end DESC"
+                ),
                 &[&user_id],
             )
             .await?;
@@ -318,15 +323,14 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
         let pending_status = DowngradeIntentStatus::Pending.as_str();
         let row = txn
             .query_opt(
-                "SELECT subscription_id, user_id, provider, customer_id, price_id, status,
-                        current_period_end, cancel_at_period_end, created_at, updated_at,
-                        pending_downgrade_target_price_id, pending_downgrade_from_price_id,
-                        pending_downgrade_expected_period_end, pending_downgrade_status
+                &format!(
+                    "SELECT {SUBSCRIPTION_COLUMNS}
                  FROM subscriptions
                  WHERE subscription_id = $1
                    AND status IN ('active', 'trialing')
                    AND pending_downgrade_status = $2
-                 FOR UPDATE SKIP LOCKED",
+                 FOR UPDATE SKIP LOCKED"
+                ),
                 &[&subscription_id, &pending_status],
             )
             .await?;
@@ -346,6 +350,79 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
             )
             .await?;
         Ok(row.map(|r| r.get(0)))
+    }
+
+    async fn get_subscription_for_update(
+        &self,
+        txn: &tokio_postgres::Transaction<'_>,
+        subscription_id: &str,
+    ) -> anyhow::Result<Option<Subscription>> {
+        let row = txn
+            .query_opt(
+                &format!(
+                    "SELECT {SUBSCRIPTION_COLUMNS}
+                 FROM subscriptions
+                 WHERE subscription_id = $1
+                 FOR UPDATE"
+                ),
+                &[&subscription_id],
+            )
+            .await?;
+        Ok(row.as_ref().map(row_to_subscription))
+    }
+
+    async fn replace_subscription(
+        &self,
+        txn: &tokio_postgres::Transaction<'_>,
+        subscription: Subscription,
+    ) -> anyhow::Result<Option<Subscription>> {
+        let pending_downgrade_status = subscription
+            .pending_downgrade_status
+            .map(DowngradeIntentStatus::as_str);
+
+        let row = txn
+            .query_opt(
+                "UPDATE subscriptions
+                 SET user_id = $2,
+                     provider = $3,
+                     customer_id = $4,
+                     price_id = $5,
+                     status = $6,
+                     current_period_end = $7,
+                     cancel_at_period_end = $8,
+                     created_at = $9,
+                     pending_downgrade_target_price_id = $10,
+                     pending_downgrade_from_price_id = $11,
+                     pending_downgrade_expected_period_end = $12,
+                     pending_downgrade_status = $13,
+                     pending_downgrade_updated_at = $14,
+                     updated_at = NOW()
+                 WHERE subscription_id = $1
+                 RETURNING subscription_id, user_id, provider, customer_id, price_id, status,
+                           current_period_end, cancel_at_period_end, created_at, updated_at,
+                           pending_downgrade_target_price_id, pending_downgrade_from_price_id,
+                           pending_downgrade_expected_period_end, pending_downgrade_status,
+                           pending_downgrade_updated_at",
+                &[
+                    &subscription.subscription_id,
+                    &subscription.user_id,
+                    &subscription.provider,
+                    &subscription.customer_id,
+                    &subscription.price_id,
+                    &subscription.status,
+                    &subscription.current_period_end,
+                    &subscription.cancel_at_period_end,
+                    &subscription.created_at,
+                    &subscription.pending_downgrade_target_price_id,
+                    &subscription.pending_downgrade_from_price_id,
+                    &subscription.pending_downgrade_expected_period_end,
+                    &pending_downgrade_status,
+                    &subscription.pending_downgrade_updated_at,
+                ],
+            )
+            .await?;
+
+        Ok(row.as_ref().map(row_to_subscription))
     }
 
     async fn clear_pending_downgrade(

--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -1,6 +1,8 @@
 use crate::pool::DbPool;
 use async_trait::async_trait;
-use services::subscription::ports::{DowngradeIntentStatus, Subscription, SubscriptionRepository};
+use services::subscription::ports::{
+    DowngradeIntentStatus, Subscription, SubscriptionReplacement, SubscriptionRepository,
+};
 use services::UserId;
 
 fn row_to_subscription(row: &tokio_postgres::Row) -> Subscription {
@@ -374,9 +376,10 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
     async fn replace_subscription(
         &self,
         txn: &tokio_postgres::Transaction<'_>,
-        subscription: Subscription,
+        subscription_id: &str,
+        replacement: SubscriptionReplacement,
     ) -> anyhow::Result<Option<Subscription>> {
-        let pending_downgrade_status = subscription
+        let pending_downgrade_status = replacement
             .pending_downgrade_status
             .map(DowngradeIntentStatus::as_str);
 
@@ -404,20 +407,20 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
                            pending_downgrade_expected_period_end, pending_downgrade_status,
                            pending_downgrade_updated_at",
                 &[
-                    &subscription.subscription_id,
-                    &subscription.user_id,
-                    &subscription.provider,
-                    &subscription.customer_id,
-                    &subscription.price_id,
-                    &subscription.status,
-                    &subscription.current_period_end,
-                    &subscription.cancel_at_period_end,
-                    &subscription.created_at,
-                    &subscription.pending_downgrade_target_price_id,
-                    &subscription.pending_downgrade_from_price_id,
-                    &subscription.pending_downgrade_expected_period_end,
+                    &subscription_id,
+                    &replacement.user_id,
+                    &replacement.provider,
+                    &replacement.customer_id,
+                    &replacement.price_id,
+                    &replacement.status,
+                    &replacement.current_period_end,
+                    &replacement.cancel_at_period_end,
+                    &replacement.created_at,
+                    &replacement.pending_downgrade_target_price_id,
+                    &replacement.pending_downgrade_from_price_id,
+                    &replacement.pending_downgrade_expected_period_end,
                     &pending_downgrade_status,
-                    &subscription.pending_downgrade_updated_at,
+                    &replacement.pending_downgrade_updated_at,
                 ],
             )
             .await?;

--- a/crates/services/src/subscription/ports.rs
+++ b/crates/services/src/subscription/ports.rs
@@ -65,6 +65,8 @@ pub struct Subscription {
     pub pending_downgrade_expected_period_end: Option<DateTime<Utc>>,
     /// Last downgrade intent status.
     pub pending_downgrade_status: Option<DowngradeIntentStatus>,
+    /// Timestamp when the downgrade intent was last changed.
+    pub pending_downgrade_updated_at: Option<DateTime<Utc>>,
 }
 
 /// API response model with plan name resolved from price_id
@@ -181,6 +183,8 @@ pub enum SubscriptionError {
     TestClockNotAllowedForExistingCustomer,
     /// No pending downgrade to cancel (same plan requested but no pending downgrade exists)
     NoPendingDowngrade,
+    /// No subscription row found for the requested subscription_id.
+    SubscriptionNotFound,
 }
 
 impl fmt::Display for SubscriptionError {
@@ -240,6 +244,9 @@ impl fmt::Display for SubscriptionError {
             }
             Self::NoPendingDowngrade => {
                 write!(f, "No pending downgrade to cancel")
+            }
+            Self::SubscriptionNotFound => {
+                write!(f, "Subscription not found")
             }
         }
     }
@@ -334,6 +341,22 @@ pub trait SubscriptionRepository: Send + Sync {
         txn: &tokio_postgres::Transaction<'_>,
         subscription_id: &str,
     ) -> anyhow::Result<Option<String>>;
+
+    /// Fetch a subscription row with a row lock (FOR UPDATE).
+    /// Returns None if the subscription does not exist.
+    async fn get_subscription_for_update(
+        &self,
+        txn: &tokio_postgres::Transaction<'_>,
+        subscription_id: &str,
+    ) -> anyhow::Result<Option<Subscription>>;
+
+    /// Replace exactly one existing subscription row selected by subscription_id.
+    /// Returns None if the row does not exist.
+    async fn replace_subscription(
+        &self,
+        txn: &tokio_postgres::Transaction<'_>,
+        subscription: Subscription,
+    ) -> anyhow::Result<Option<Subscription>>;
 
     /// Unconditionally clear all pending-downgrade fields for a subscription.
     /// Used when an upgrade or explicit cancellation makes the pending intent obsolete.
@@ -556,6 +579,13 @@ pub trait SubscriptionService: Send + Sync {
         limit: i64,
         offset: i64,
     ) -> Result<(Vec<Subscription>, i64), SubscriptionError>;
+
+    /// Admin only: Fully replace exactly one existing subscription row by subscription_id.
+    async fn admin_replace_subscription(
+        &self,
+        admin_user_id: UserId,
+        subscription: Subscription,
+    ) -> Result<Subscription, SubscriptionError>;
 
     /// Create checkout session for purchasing credits. Returns checkout URL.
     async fn create_credit_purchase_checkout(

--- a/crates/services/src/subscription/ports.rs
+++ b/crates/services/src/subscription/ports.rs
@@ -69,6 +69,24 @@ pub struct Subscription {
     pub pending_downgrade_updated_at: Option<DateTime<Utc>>,
 }
 
+/// Admin repair payload for replacing one existing subscription row.
+#[derive(Debug, Clone)]
+pub struct SubscriptionReplacement {
+    pub user_id: UserId,
+    pub provider: String,
+    pub customer_id: String,
+    pub price_id: String,
+    pub status: String,
+    pub current_period_end: DateTime<Utc>,
+    pub cancel_at_period_end: bool,
+    pub created_at: DateTime<Utc>,
+    pub pending_downgrade_target_price_id: Option<String>,
+    pub pending_downgrade_from_price_id: Option<String>,
+    pub pending_downgrade_expected_period_end: Option<DateTime<Utc>>,
+    pub pending_downgrade_status: Option<DowngradeIntentStatus>,
+    pub pending_downgrade_updated_at: Option<DateTime<Utc>>,
+}
+
 /// API response model with plan name resolved from price_id
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -355,7 +373,8 @@ pub trait SubscriptionRepository: Send + Sync {
     async fn replace_subscription(
         &self,
         txn: &tokio_postgres::Transaction<'_>,
-        subscription: Subscription,
+        subscription_id: &str,
+        replacement: SubscriptionReplacement,
     ) -> anyhow::Result<Option<Subscription>>;
 
     /// Unconditionally clear all pending-downgrade fields for a subscription.
@@ -584,7 +603,8 @@ pub trait SubscriptionService: Send + Sync {
     async fn admin_replace_subscription(
         &self,
         admin_user_id: UserId,
-        subscription: Subscription,
+        subscription_id: String,
+        replacement: SubscriptionReplacement,
     ) -> Result<Subscription, SubscriptionError>;
 
     /// Create checkout session for purchasing credits. Returns checkout URL.

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1,8 +1,8 @@
 use super::ports::{
     BillingPeriod, ChangePlanOutcome, CreditsRepository, CreditsSummary, DowngradeIntentStatus,
     PaymentWebhookRepository, StripeCustomerRepository, Subscription, SubscriptionError,
-    SubscriptionPlan, SubscriptionRepository, SubscriptionService, SubscriptionWithPlan,
-    DEFAULT_MONTHLY_TOKEN_LIMIT,
+    SubscriptionPlan, SubscriptionReplacement, SubscriptionRepository, SubscriptionService,
+    SubscriptionWithPlan, DEFAULT_MONTHLY_TOKEN_LIMIT,
 };
 use crate::agent::ports::AgentRepository;
 use crate::agent::ports::AgentService;
@@ -2527,9 +2527,9 @@ impl SubscriptionService for SubscriptionServiceImpl {
     async fn admin_replace_subscription(
         &self,
         admin_user_id: UserId,
-        subscription: Subscription,
+        subscription_id: String,
+        replacement: SubscriptionReplacement,
     ) -> Result<Subscription, SubscriptionError> {
-        let subscription_id = subscription.subscription_id.clone();
         tracing::info!(
             "Admin replacing subscription row: admin_user_id={}, subscription_id={}",
             admin_user_id,
@@ -2555,7 +2555,7 @@ impl SubscriptionService for SubscriptionServiceImpl {
 
         let after = self
             .subscription_repo
-            .replace_subscription(&txn, subscription)
+            .replace_subscription(&txn, &subscription_id, replacement)
             .await
             .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?
             .ok_or(SubscriptionError::SubscriptionNotFound)?;

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -438,6 +438,7 @@ impl SubscriptionServiceImpl {
             pending_downgrade_from_price_id: None,
             pending_downgrade_expected_period_end: None,
             pending_downgrade_status: None,
+            pending_downgrade_updated_at: None,
         })
     }
 
@@ -2436,6 +2437,7 @@ impl SubscriptionService for SubscriptionServiceImpl {
             pending_downgrade_from_price_id: None,
             pending_downgrade_expected_period_end: None,
             pending_downgrade_status: None,
+            pending_downgrade_updated_at: None,
         };
 
         // Upsert subscription in transaction
@@ -2518,6 +2520,70 @@ impl SubscriptionService for SubscriptionServiceImpl {
             .list_subscriptions(user_id, limit, offset)
             .await
             .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))
+    }
+
+    /// Admin-only raw subscription row override. This endpoint intentionally bypasses business
+    /// validation and relies on admin auth plus full before/after audit logging.
+    async fn admin_replace_subscription(
+        &self,
+        admin_user_id: UserId,
+        subscription: Subscription,
+    ) -> Result<Subscription, SubscriptionError> {
+        let subscription_id = subscription.subscription_id.clone();
+        tracing::info!(
+            "Admin replacing subscription row: admin_user_id={}, subscription_id={}",
+            admin_user_id,
+            subscription_id
+        );
+
+        let mut client = self
+            .db_pool
+            .get()
+            .await
+            .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
+        let txn = client
+            .transaction()
+            .await
+            .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
+
+        let before = self
+            .subscription_repo
+            .get_subscription_for_update(&txn, &subscription_id)
+            .await
+            .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?
+            .ok_or(SubscriptionError::SubscriptionNotFound)?;
+
+        let after = self
+            .subscription_repo
+            .replace_subscription(&txn, subscription)
+            .await
+            .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?
+            .ok_or(SubscriptionError::SubscriptionNotFound)?;
+
+        let before_json = serde_json::to_string(&before)
+            .map_err(|e| SubscriptionError::InternalError(e.to_string()))?;
+        let after_json = serde_json::to_string(&after)
+            .map_err(|e| SubscriptionError::InternalError(e.to_string()))?;
+
+        txn.commit()
+            .await
+            .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
+
+        self.invalidate_credit_limit_cache(before.user_id).await;
+        if after.user_id != before.user_id {
+            self.invalidate_credit_limit_cache(after.user_id).await;
+        }
+
+        // Intentionally log full before/after row snapshots for this privileged repair endpoint.
+        tracing::warn!(
+            "Admin overrode subscription row: admin_user_id={}, subscription_id={}, before={}, after={}",
+            admin_user_id,
+            subscription_id,
+            before_json,
+            after_json
+        );
+
+        Ok(after)
     }
 
     async fn create_credit_purchase_checkout(
@@ -2787,6 +2853,7 @@ mod tests {
             pending_downgrade_from_price_id: None,
             pending_downgrade_expected_period_end: None,
             pending_downgrade_status: None,
+            pending_downgrade_updated_at: None,
         }
     }
 

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -2560,14 +2560,14 @@ impl SubscriptionService for SubscriptionServiceImpl {
             .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?
             .ok_or(SubscriptionError::SubscriptionNotFound)?;
 
+        txn.commit()
+            .await
+            .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
+
         let before_json = serde_json::to_string(&before)
             .map_err(|e| SubscriptionError::InternalError(e.to_string()))?;
         let after_json = serde_json::to_string(&after)
             .map_err(|e| SubscriptionError::InternalError(e.to_string()))?;
-
-        txn.commit()
-            .await
-            .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
 
         self.invalidate_credit_limit_cache(before.user_id).await;
         if after.user_id != before.user_id {
@@ -2576,11 +2576,11 @@ impl SubscriptionService for SubscriptionServiceImpl {
 
         // Intentionally log full before/after row snapshots for this privileged repair endpoint.
         tracing::warn!(
-            "Admin overrode subscription row: admin_user_id={}, subscription_id={}, before={}, after={}",
-            admin_user_id,
-            subscription_id,
-            before_json,
-            after_json
+            admin_user_id = %admin_user_id,
+            subscription_id = %subscription_id,
+            before = %before_json,
+            after = %after_json,
+            "Admin overrode subscription row"
         );
 
         Ok(after)


### PR DESCRIPTION
## Summary
- add an admin-only `PUT /v1/admin/subscriptions/{subscription_id}` endpoint for privileged single-row subscription repair without plan/provider business validation
- log the acting admin, target subscription row, and full before/after snapshots, and fix `pending_downgrade_updated_at` coverage so the row model matches the database
- add integration coverage for auth, not found, exact-one-row replacement, downgrade field round-trip, and moving a row to another user

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --features test -- -D warnings`
- [x] `cargo test --features test --test subscriptions_tests --no-run`
- [x] `cargo test --features test --test subscriptions_tests test_admin_replace_subscription -- --nocapture`