### PR TITLE
refactor: agent manager infra system configs

### DIFF
--- a/crates/api/src/bin/task_worker.rs
+++ b/crates/api/src/bin/task_worker.rs
@@ -227,7 +227,6 @@ async fn main() -> anyhow::Result<()> {
         config.agent.nearai_api_url.clone(),
         system_configs_service as Arc<dyn services::system_configs::ports::SystemConfigsService>,
         config.agent.channel_relay_url.clone(),
-        config.agent.non_tee_agent_url_pattern.clone(),
     ));
 
     let aws_config = api::tasks::load_aws_sdk_config(region).await;

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -198,7 +198,6 @@ async fn main() -> anyhow::Result<()> {
         system_configs_service.clone()
             as Arc<dyn services::system_configs::ports::SystemConfigsService>,
         config.agent.channel_relay_url.clone(),
-        config.agent.non_tee_agent_url_pattern.clone(),
     ));
 
     // Initialize agent proxy service

--- a/crates/api/tests/common.rs
+++ b/crates/api/tests/common.rs
@@ -194,7 +194,6 @@ pub async fn create_test_server_and_db(
         system_configs_service.clone()
             as Arc<dyn services::system_configs::ports::SystemConfigsService>,
         config.agent.channel_relay_url.clone(),
-        config.agent.non_tee_agent_url_pattern.clone(),
     ));
 
     // Initialize subscription service for testing

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -372,23 +372,24 @@ fn default_nearai_api_url() -> String {
         .unwrap_or_else(|_| "https://private.near.ai/v1".to_string())
 }
 
-fn default_non_tee_agent_url() -> String {
-    std::env::var("NON_TEE_AGENT_URL").unwrap_or_else(|_| "claws".to_string())
-}
-
 /// A single agent manager endpoint with its URL and bearer token
 #[derive(Clone, serde::Deserialize)]
 pub struct AgentManager {
     pub url: String,
     pub token: String,
     /// Whether this manager is non-TEE (true) or TEE (false)
-    /// Set at construction time based on infrastructure mode
+    /// Preferred long-term source of truth is system configs.
     #[serde(default)]
     pub is_non_tee: bool,
 }
 
 impl AgentManager {
-    /// Get the effective is_non_tee value based on explicit configuration
+    #[inline]
+    pub fn is_tee(&self) -> bool {
+        !self.is_non_tee
+    }
+
+    /// Backward-compatible helper for call sites still using non-TEE naming.
     pub fn get_is_non_tee(&self) -> bool {
         self.is_non_tee
     }
@@ -399,7 +400,7 @@ impl std::fmt::Debug for AgentManager {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AgentManager")
             .field("url", &self.url)
-            .field("is_non_tee", &self.get_is_non_tee())
+            .field("tee", &self.is_tee())
             .field("token", &"[REDACTED]")
             .finish()
     }
@@ -423,10 +424,6 @@ pub struct AgentConfig {
     /// signing secret instead of the former shared CHANNEL_RELAY_SIGNING_SECRET.
     #[serde(default)]
     pub channel_relay_url: Option<String>,
-    /// URL pattern to identify non-TEE compose-api endpoints for instance type detection
-    /// Configurable via NON_TEE_AGENT_URL environment variable (defaults to "claws")
-    #[serde(default = "default_non_tee_agent_url")]
-    pub non_tee_agent_url_pattern: String,
 }
 
 /// Split a comma-separated env var value into non-empty trimmed entries.
@@ -440,38 +437,10 @@ fn split_csv(value: &str) -> Vec<String> {
 
 impl Default for AgentConfig {
     fn default() -> Self {
-        // Load managers from both TEE and non-TEE configurations
-        // This supports mixed environments with both manager types available
-        // Manager type is determined dynamically from URL pattern, not from this setting
+        // Load managers from a single consistent env configuration.
+        // TEE/non-TEE classification is controlled by system configs.
         let mut managers: Vec<AgentManager> = Vec::new();
 
-        // Load TEE managers from AGENT_MANAGER_URLS_TEE
-        if let Ok(urls_raw) = std::env::var("AGENT_MANAGER_URLS_TEE") {
-            let urls = split_csv(&urls_raw);
-            if !urls.is_empty() {
-                let tokens_raw = std::env::var("AGENT_MANAGER_TOKENS_TEE").unwrap_or_default();
-                let tokens = split_csv(&tokens_raw);
-                if urls.len() != tokens.len() {
-                    panic!(
-                        "AGENT_MANAGER_URLS_TEE has {} entries but AGENT_MANAGER_TOKENS_TEE has {} — they must match",
-                        urls.len(),
-                        tokens.len()
-                    );
-                }
-                let tee_mgrs: Vec<AgentManager> = urls
-                    .into_iter()
-                    .zip(tokens)
-                    .map(|(url, token)| AgentManager {
-                        url,
-                        token,
-                        is_non_tee: false,
-                    })
-                    .collect();
-                managers.extend(tee_mgrs);
-            }
-        }
-
-        // Load non-TEE managers from AGENT_MANAGER_URLS
         if let Ok(urls_raw) = std::env::var("AGENT_MANAGER_URLS") {
             let urls = split_csv(&urls_raw);
             if !urls.is_empty() {
@@ -484,7 +453,7 @@ impl Default for AgentConfig {
                         tokens.len()
                     );
                 }
-                let non_tee_mgrs: Vec<AgentManager> = urls
+                let parsed_mgrs: Vec<AgentManager> = urls
                     .into_iter()
                     .zip(tokens)
                     .map(|(url, token)| AgentManager {
@@ -493,7 +462,7 @@ impl Default for AgentConfig {
                         is_non_tee: true,
                     })
                     .collect();
-                managers.extend(non_tee_mgrs);
+                managers.extend(parsed_mgrs);
             }
         }
 
@@ -519,7 +488,6 @@ impl Default for AgentConfig {
                 .map(|url| url.trim_end_matches('/').to_string() + "/v1")
                 .unwrap_or_else(|_| "https://private.near.ai/v1".to_string()),
             channel_relay_url: std::env::var("CHANNEL_RELAY_URL").ok(),
-            non_tee_agent_url_pattern: default_non_tee_agent_url(),
         }
     }
 }
@@ -1013,8 +981,6 @@ mod tests {
         std::env::remove_var("INSTANCE_DEFAULT_STORAGE_SIZE");
         std::env::remove_var("AGENT_MANAGER_URLS");
         std::env::remove_var("AGENT_MANAGER_TOKENS");
-        std::env::remove_var("AGENT_MANAGER_URLS_TEE");
-        std::env::remove_var("AGENT_MANAGER_TOKENS_TEE");
 
         let config = AgentConfig::default();
 
@@ -1028,8 +994,6 @@ mod tests {
         // Clean up any leftover env vars from other tests
         std::env::remove_var("AGENT_MANAGER_URLS");
         std::env::remove_var("AGENT_MANAGER_TOKENS");
-        std::env::remove_var("AGENT_MANAGER_URLS_TEE");
-        std::env::remove_var("AGENT_MANAGER_TOKENS_TEE");
 
         // Non-TEE mode: NON_TEE_INFRA=true
         std::env::set_var("NON_TEE_INFRA", "true");
@@ -1044,8 +1008,6 @@ mod tests {
         std::env::remove_var("AGENT_DOMAIN");
         std::env::remove_var("AGENT_MANAGER_URLS");
         std::env::remove_var("AGENT_MANAGER_TOKENS");
-        std::env::remove_var("AGENT_MANAGER_URLS_TEE");
-        std::env::remove_var("AGENT_MANAGER_TOKENS_TEE");
     }
 
     #[test]
@@ -1054,8 +1016,6 @@ mod tests {
         // Clean up any leftover env vars from other tests
         std::env::remove_var("AGENT_MANAGER_URLS");
         std::env::remove_var("AGENT_MANAGER_TOKENS");
-        std::env::remove_var("AGENT_MANAGER_URLS_TEE");
-        std::env::remove_var("AGENT_MANAGER_TOKENS_TEE");
 
         // Non-TEE mode with defaults
         std::env::set_var("NON_TEE_INFRA", "true");
@@ -1072,8 +1032,6 @@ mod tests {
         std::env::remove_var("NON_TEE_INFRA");
         std::env::remove_var("AGENT_MANAGER_URLS");
         std::env::remove_var("AGENT_MANAGER_TOKENS");
-        std::env::remove_var("AGENT_MANAGER_URLS_TEE");
-        std::env::remove_var("AGENT_MANAGER_TOKENS_TEE");
     }
 
     #[test]
@@ -1105,8 +1063,6 @@ mod tests {
         // Clean up any leftover env vars from previous tests (especially from panicking tests)
         std::env::remove_var("AGENT_MANAGER_URLS");
         std::env::remove_var("AGENT_MANAGER_TOKENS");
-        std::env::remove_var("AGENT_MANAGER_URLS_TEE");
-        std::env::remove_var("AGENT_MANAGER_TOKENS_TEE");
         let config = Config::from_env();
 
         // Verify infrastructure config is part of Config struct
@@ -1122,8 +1078,6 @@ mod tests {
         // Clean up any leftover env vars from other tests
         std::env::remove_var("AGENT_MANAGER_URLS");
         std::env::remove_var("AGENT_MANAGER_TOKENS");
-        std::env::remove_var("AGENT_MANAGER_URLS_TEE");
-        std::env::remove_var("AGENT_MANAGER_TOKENS_TEE");
 
         std::env::set_var("NON_TEE_INFRA", "true");
         std::env::set_var("AGENT_DOMAIN", "production.dev");

--- a/crates/services/src/agent/service.rs
+++ b/crates/services/src/agent/service.rs
@@ -266,9 +266,6 @@ pub struct AgentServiceImpl {
     system_configs_service: Arc<dyn SystemConfigsService>,
     /// Channel-relay URL for provisioning relay config to IronClaw instances
     channel_relay_url: Option<String>,
-    /// URL pattern to identify non-TEE manager endpoints (e.g., "claws")
-    /// Used to determine instance type when routing to managers
-    non_tee_agent_url_pattern: String,
 }
 
 /// Static helper: Fetch instance details from Agent API GET /instances/{name}.
@@ -334,6 +331,16 @@ impl ManagerType {
 }
 
 impl AgentServiceImpl {
+    fn manager_is_non_tee_with_configs(configs: &SystemConfigs, manager: &AgentManager) -> bool {
+        let from_system_configs = configs
+            .agent_hosting
+            .as_ref()
+            .and_then(|h| h.manager_tee_by_url.as_ref())
+            .and_then(|m| m.get(&manager.url))
+            .map(|tee| !*tee);
+        from_system_configs.unwrap_or_else(|| manager.get_is_non_tee())
+    }
+
     /// Generate a random credential (hex-encoded random bytes)
     fn generate_random_credential(len: usize) -> String {
         use rand::Rng;
@@ -348,7 +355,6 @@ impl AgentServiceImpl {
         nearai_api_url: String,
         system_configs_service: Arc<dyn SystemConfigsService>,
         channel_relay_url: Option<String>,
-        non_tee_agent_url_pattern: String,
     ) -> Self {
         // Validate required configuration
         if managers.is_empty() {
@@ -379,7 +385,6 @@ impl AgentServiceImpl {
             nearai_api_url,
             system_configs_service,
             channel_relay_url,
-            non_tee_agent_url_pattern,
         }
     }
 
@@ -473,7 +478,7 @@ impl AgentServiceImpl {
         let available_managers: Vec<_> = self
             .managers
             .iter()
-            .filter(|mgr| is_non_tee == mgr.get_is_non_tee())
+            .filter(|mgr| is_non_tee == Self::manager_is_non_tee_with_configs(&configs, mgr))
             .collect();
 
         if available_managers.is_empty() {
@@ -580,64 +585,8 @@ impl AgentServiceImpl {
             return Err(anyhow!("No agent managers configured"));
         }
 
-        // Use first available manager as fallback, but try to match manager type if stored URL exists
-        // This ensures instances created as TEE don't accidentally get routed to non-TEE managers
-        let fallback_manager = if let Some(ref stored_url) = instance.agent_api_base_url {
-            // Determine expected manager type based on URL pattern:
-            // - Non-TEE: URLs containing the configured non_tee_agent_url_pattern (e.g., "claws")
-            // - TEE: all other URLs (TEE compose-api / manager hostnames)
-            let expected_is_non_tee = stored_url.contains(&self.non_tee_agent_url_pattern);
-
-            // Find a manager of the matching type
-            if let Some(matching_mgr) = self.managers.iter().find(|m| {
-                if expected_is_non_tee {
-                    m.get_is_non_tee()
-                } else {
-                    !m.get_is_non_tee()
-                }
-            }) {
-                tracing::info!(
-                    "resolve_manager: Stored URL {} not found, using fallback {} (expected manager type: non_tee={})",
-                    stored_url,
-                    matching_mgr.url,
-                    expected_is_non_tee
-                );
-                matching_mgr
-            } else {
-                // No matching type available - fail rather than silently use wrong type
-                // This prevents instances from being incorrectly routed to managers of a different authentication type
-                let expected_type = if expected_is_non_tee {
-                    "non-TEE"
-                } else {
-                    "TEE"
-                };
-                let available_types = self
-                    .managers
-                    .iter()
-                    .map(|m| if m.get_is_non_tee() { "non-TEE" } else { "TEE" })
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                tracing::error!(
-                    "resolve_manager: Instance was created on {} manager but no {} manager is available. Available types: [{}], instance_id={}",
-                    expected_type,
-                    expected_type,
-                    available_types,
-                    instance.id
-                );
-                return Err(anyhow!(
-                    "Instance was created on {} manager but no {} manager is available",
-                    expected_type,
-                    expected_type
-                ));
-            }
-        } else {
-            // No stored URL, just use first manager
-            tracing::info!(
-                "resolve_manager: No stored URL, using first available manager: {}",
-                self.managers[0].url
-            );
-            &self.managers[0]
-        };
+        // No URL-based type inference fallback: use first configured manager.
+        let fallback_manager = &self.managers[0];
 
         tracing::info!(
             "resolve_manager: Using fallback manager: {} for instance_id={}",
@@ -5133,8 +5082,7 @@ mod tests {
             managers,
             "https://nearai.test/v1".to_string(),
             configs,
-            None,                // channel_relay_url
-            "claws".to_string(), // non_tee_agent_url_pattern
+            None, // channel_relay_url
         )
     }
 
@@ -6899,7 +6847,6 @@ mod tests {
                 "https://nearai.example.com/v1".to_string(),
                 Arc::new(MockSystemConfigsService::no_config()),
                 None,
-                "claws".to_string(), // non_tee_agent_url_pattern
             );
 
             // Verify TEE mode behavior:
@@ -6980,7 +6927,6 @@ mod tests {
                 "https://nearai.example.com/v1".to_string(),
                 Arc::new(MockSystemConfigsService::no_config()),
                 None,
-                "claws".to_string(), // non_tee_agent_url_pattern
             );
 
             // Verify non-TEE mode behavior:
@@ -7874,7 +7820,6 @@ mod tests {
             "https://nearai.example.com/v1".to_string(),
             configs,
             None,
-            "claws".to_string(), // non_tee_agent_url_pattern
         );
 
         // Verify TEE mode configuration: manager is TEE
@@ -7898,7 +7843,6 @@ mod tests {
             "https://nearai.example.com/v1".to_string(),
             configs,
             None,
-            "claws".to_string(), // non_tee_agent_url_pattern
         );
 
         // Verify non-TEE mode configuration: manager is non-TEE

--- a/crates/services/src/system_configs/ports.rs
+++ b/crates/services/src/system_configs/ports.rs
@@ -259,6 +259,11 @@ pub struct AgentHostingConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub new_agent_with_non_tee_infra: Option<bool>,
 
+    /// Per-manager infrastructure mode keyed by manager URL.
+    /// `tee=true` means classic/TEE manager; `tee=false` means crabshack/non-TEE manager.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manager_tee_by_url: Option<HashMap<String, bool>>,
+
     #[serde(default, skip_serializing_if = "AgentHostingCrabshackConfig::is_empty")]
     pub crabshack: AgentHostingCrabshackConfig,
 }
@@ -272,6 +277,8 @@ impl<'de> Deserialize<'de> for AgentHostingConfig {
         struct AgentHostingConfigDe {
             #[serde(default)]
             new_agent_with_non_tee_infra: Option<bool>,
+            #[serde(default)]
+            manager_tee_by_url: Option<HashMap<String, bool>>,
             #[serde(default)]
             crabshack: Option<AgentHostingCrabshackConfig>,
             #[serde(default)]
@@ -311,6 +318,7 @@ impl<'de> Deserialize<'de> for AgentHostingConfig {
 
         Ok(AgentHostingConfig {
             new_agent_with_non_tee_infra: h.new_agent_with_non_tee_infra,
+            manager_tee_by_url: h.manager_tee_by_url,
             crabshack,
         })
     }
@@ -380,6 +388,7 @@ impl Default for SystemConfigs {
             }),
             agent_hosting: Some(AgentHostingConfig {
                 new_agent_with_non_tee_infra: Some(false),
+                manager_tee_by_url: None,
                 crabshack: AgentHostingCrabshackConfig::default(),
             }),
         }
@@ -406,6 +415,7 @@ fn merge_agent_hosting_config(
         new_agent_with_non_tee_infra: partial
             .new_agent_with_non_tee_infra
             .or(base.new_agent_with_non_tee_infra),
+        manager_tee_by_url: partial.manager_tee_by_url.or(base.manager_tee_by_url),
         crabshack: AgentHostingCrabshackConfig {
             ironclaw_image: merge_opt_override(
                 base.crabshack.ironclaw_image,


### PR DESCRIPTION
## Summary

- Refactored `chat-api` manager configuration to use a single manager env source: `AGENT_MANAGER_URLS` + `AGENT_MANAGER_TOKENS`.
- Removed split env loading for TEE-specific manager vars (`AGENT_MANAGER_URLS_TEE` / `AGENT_MANAGER_TOKENS_TEE`) from config parsing.
- Removed URL-pattern-based manager type inference from `AgentServiceImpl` (dropped `non_tee_agent_url_pattern` wiring and fallback logic based on URL substring matching).
- Updated `AgentServiceImpl::new(...)` call sites and tests to match the new constructor shape.
- Added optional system config field `agent_hosting.manager_tee_by_url` (`manager_url -> tee: bool`) and used it in manager selection with fallback to existing manager metadata.
- Kept the refactor build-safe: `cargo check -p api` passes and edited files have no lint errors.

## Why

- This reduces hidden behavior from URL naming conventions and moves toward explicit manager capability metadata.
- It also enforces a consistent manager env naming model, which makes deployment config less confusing and easier to maintain.

## Notes / Follow-ups

- Naming migration is only partially done in this PR: several internal symbols still use `non_tee` terminology.
- Fallback manager resolution now avoids URL inference, but still uses first-manager fallback when stored URL is stale; persisting explicit manager kind per instance would make this safer.
- Cross-repo contract/UI naming updates are intentionally out of scope for this change.

## Test Plan

- [x] `cargo check -p api`
- [x] Validate no lints in touched files
- [ ] (Optional) Add/expand tests to assert manager selection behavior using `agent_hosting.manager_tee_by_url`
- [ ] (Optional) Add migration path for explicit persisted manager kind on instances