### PR TITLE
fix: return 429 for email otp rate limits and block users with no active subscriptions

### DIFF
--- a/crates/api/src/error.rs
+++ b/crates/api/src/error.rs
@@ -71,11 +71,6 @@ impl ApiError {
         Self::new(StatusCode::CONFLICT, "conflict", message)
     }
 
-    /// 429 Too Many Requests
-    pub fn too_many_requests(message: impl Into<String>) -> Self {
-        Self::new(StatusCode::TOO_MANY_REQUESTS, "too_many_requests", message)
-    }
-
     /// 422 Unprocessable Entity
     pub fn unprocessable_entity(message: impl Into<String>) -> Self {
         Self::new(
@@ -83,6 +78,11 @@ impl ApiError {
             "unprocessable_entity",
             message,
         )
+    }
+
+    /// 429 Too Many Requests
+    pub fn too_many_requests(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::TOO_MANY_REQUESTS, "too_many_requests", message)
     }
 
     /// 500 Internal Server Error

--- a/crates/api/src/error.rs
+++ b/crates/api/src/error.rs
@@ -71,6 +71,11 @@ impl ApiError {
         Self::new(StatusCode::CONFLICT, "conflict", message)
     }
 
+    /// 429 Too Many Requests
+    pub fn too_many_requests(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::TOO_MANY_REQUESTS, "too_many_requests", message)
+    }
+
     /// 422 Unprocessable Entity
     pub fn unprocessable_entity(message: impl Into<String>) -> Self {
         Self::new(

--- a/crates/api/src/middleware/subscription.rs
+++ b/crates/api/src/middleware/subscription.rs
@@ -27,10 +27,6 @@ struct SubscriptionErrorResponse {
 const SUBSCRIPTION_REQUIRED_ERROR_MESSAGE: &str =
     "Active subscription required. Please subscribe to continue.";
 
-/// Error message when email-only user is on a free-priced plan
-const EMAIL_ONLY_FREE_PLAN_ERROR_MESSAGE: &str =
-    "Email-only accounts require a paid subscription to access LLM APIs.";
-
 /// Error message when credit limit is exceeded
 const CREDIT_LIMIT_EXCEEDED_MESSAGE: &str = "Credit limit exceeded.";
 
@@ -81,19 +77,6 @@ pub async fn subscription_middleware(
                 StatusCode::FORBIDDEN,
                 Json(SubscriptionErrorResponse {
                     error: SUBSCRIPTION_REQUIRED_ERROR_MESSAGE.to_string(),
-                }),
-            )
-                .into_response())
-        }
-        Err(SubscriptionError::EmailOnlyFreePlanNotAllowed) => {
-            tracing::info!(
-                "Blocked proxy access for user_id={}: email-only account on free-priced plan",
-                user.user_id
-            );
-            Err((
-                StatusCode::FORBIDDEN,
-                Json(SubscriptionErrorResponse {
-                    error: EMAIL_ONLY_FREE_PLAN_ERROR_MESSAGE.to_string(),
                 }),
             )
                 .into_response())

--- a/crates/api/src/routes/oauth.rs
+++ b/crates/api/src/routes/oauth.rs
@@ -230,8 +230,11 @@ fn email_verify_error_to_api_error(error: VerifyEmailCodeError) -> ApiError {
         VerifyEmailCodeError::Misconfigured => {
             ApiError::service_unavailable("Email authentication is not fully configured")
         }
-        VerifyEmailCodeError::InvalidOrExpired | VerifyEmailCodeError::RateLimited => {
+        VerifyEmailCodeError::InvalidOrExpired => {
             ApiError::unauthorized("Invalid or expired verification code")
+        }
+        VerifyEmailCodeError::RateLimited => {
+            ApiError::too_many_requests("Too many verification attempts. Please try again later")
         }
         VerifyEmailCodeError::Internal(err) => {
             tracing::error!("Email verification failed: {}", err);
@@ -252,7 +255,7 @@ fn request_email_code_error_to_api_error(error: RequestEmailCodeError) -> ApiErr
             ApiError::unprocessable_entity("Human verification failed")
         }
         RequestEmailCodeError::RateLimited => ApiError::too_many_requests(
-            "Too many verification code requests. Please try again later.",
+            "Too many verification code requests. Please try again later",
         ),
         RequestEmailCodeError::Internal(err) => {
             tracing::error!("Email code request failed: {}", err);
@@ -393,8 +396,8 @@ pub struct NearAuthResponse {
     responses(
         (status = 204, description = "Verification code requested"),
         (status = 400, description = "Invalid email format", body = crate::error::ApiErrorResponse),
-        (status = 429, description = "Too many verification code requests", body = crate::error::ApiErrorResponse),
         (status = 422, description = "Human verification failed", body = crate::error::ApiErrorResponse),
+        (status = 429, description = "Too many verification code requests", body = crate::error::ApiErrorResponse),
         (status = 503, description = "Email authentication unavailable", body = crate::error::ApiErrorResponse),
         (status = 500, description = "Internal server error", body = crate::error::ApiErrorResponse)
     )
@@ -439,6 +442,7 @@ pub async fn request_email_code(
         (status = 200, description = "Successfully authenticated", body = crate::models::EmailAuthResponse),
         (status = 400, description = "Invalid request format", body = crate::error::ApiErrorResponse),
         (status = 401, description = "Invalid or expired verification code", body = crate::error::ApiErrorResponse),
+        (status = 429, description = "Too many verification attempts", body = crate::error::ApiErrorResponse),
         (status = 503, description = "Email authentication unavailable", body = crate::error::ApiErrorResponse)
     )
 )]

--- a/crates/api/src/routes/oauth.rs
+++ b/crates/api/src/routes/oauth.rs
@@ -251,6 +251,9 @@ fn request_email_code_error_to_api_error(error: RequestEmailCodeError) -> ApiErr
         RequestEmailCodeError::HumanVerificationFailed => {
             ApiError::unprocessable_entity("Human verification failed")
         }
+        RequestEmailCodeError::RateLimited => ApiError::too_many_requests(
+            "Too many verification code requests. Please try again later.",
+        ),
         RequestEmailCodeError::Internal(err) => {
             tracing::error!("Email code request failed: {}", err);
             ApiError::internal_server_error("Failed to request verification code")
@@ -390,6 +393,7 @@ pub struct NearAuthResponse {
     responses(
         (status = 204, description = "Verification code requested"),
         (status = 400, description = "Invalid email format", body = crate::error::ApiErrorResponse),
+        (status = 429, description = "Too many verification code requests", body = crate::error::ApiErrorResponse),
         (status = 422, description = "Human verification failed", body = crate::error::ApiErrorResponse),
         (status = 503, description = "Email authentication unavailable", body = crate::error::ApiErrorResponse),
         (status = 500, description = "Internal server error", body = crate::error::ApiErrorResponse)

--- a/crates/api/tests/completions_tests.rs
+++ b/crates/api/tests/completions_tests.rs
@@ -9,7 +9,7 @@ use chrono::Duration;
 use common::{
     clear_subscription_plans, create_test_server, create_test_server_and_db,
     create_test_server_with_config, insert_test_subscription, mock_login,
-    restrictive_rate_limit_config, TestServerConfig,
+    restrictive_rate_limit_config, set_subscription_plans, TestServerConfig,
 };
 use futures::future::join_all;
 use serde_json::json;
@@ -973,6 +973,15 @@ async fn test_image_edits_near_balance_skipped_when_no_near_linked_account() {
 #[tokio::test]
 async fn test_chat_completions_block_non_public_model() {
     let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": {
+                "providers": { "stripe": { "price_id": "price_test_basic" } }
+            }
+        }),
+    )
+    .await;
 
     // Use an admin account to configure model settings
     let admin_email = "chat-completions-visibility-non-public-admin@admin.org";
@@ -1278,6 +1287,15 @@ async fn test_chat_completions_auto_model_forwards_with_substituted_model() {
         ..Default::default()
     })
     .await;
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": {
+                "providers": { "stripe": { "price_id": "price_test_basic" } }
+            }
+        }),
+    )
+    .await;
     let email = "chat-completions-auto-forward@example.com";
     let token = mock_login(&server, email).await;
     insert_test_subscription(&server, &db, email, false).await;
@@ -1361,6 +1379,15 @@ async fn test_chat_completions_auto_model_preserves_client_params() {
         proxy_base_url: Some(mock_upstream.uri()),
         ..Default::default()
     })
+    .await;
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": {
+                "providers": { "stripe": { "price_id": "price_test_basic" } }
+            }
+        }),
+    )
     .await;
     let email = "chat-completions-auto-preserve@example.com";
     let token = mock_login(&server, email).await;

--- a/crates/api/tests/completions_tests.rs
+++ b/crates/api/tests/completions_tests.rs
@@ -8,7 +8,8 @@ use axum_test::TestServer;
 use chrono::Duration;
 use common::{
     clear_subscription_plans, create_test_server, create_test_server_and_db,
-    create_test_server_with_config, mock_login, restrictive_rate_limit_config, TestServerConfig,
+    create_test_server_with_config, insert_test_subscription, mock_login,
+    restrictive_rate_limit_config, TestServerConfig,
 };
 use futures::future::join_all;
 use serde_json::json;
@@ -179,8 +180,15 @@ async fn test_chat_completions_rate_limit_per_user_isolation() {
 /// Test concurrent requests rate limiting for /v1/chat/completions
 #[tokio::test]
 async fn test_chat_completions_concurrent_requests_rate_limited() {
-    let server = Arc::new(create_rate_limited_test_server().await);
-    let token = Arc::new(mock_login(&server, "chat-completions-concurrent@example.com").await);
+    let (server, db) = create_test_server_and_db(TestServerConfig {
+        rate_limit_config: Some(restrictive_rate_limit_config()),
+        ..Default::default()
+    })
+    .await;
+    let email = "chat-completions-concurrent@example.com";
+    let token = Arc::new(mock_login(&server, email).await);
+    insert_test_subscription(&server, &db, email, false).await;
+    let server = Arc::new(server);
 
     let request_body = json!({
         "model": "gpt-4o",
@@ -303,6 +311,7 @@ async fn test_chat_completions_cost_limit_blocks_request_when_usage_exceeds_limi
 
     let email = "chat-completions-cost-limit@example.com";
     let token = mock_login(&server, email).await;
+    insert_test_subscription(&server, &db, email, false).await;
 
     let user = db
         .user_repository()
@@ -963,11 +972,12 @@ async fn test_image_edits_near_balance_skipped_when_no_near_linked_account() {
 /// Requests with a model whose settings are non-public should be blocked with 403 for /v1/chat/completions.
 #[tokio::test]
 async fn test_chat_completions_block_non_public_model() {
-    let server = create_test_server().await;
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 
     // Use an admin account to configure model settings
     let admin_email = "chat-completions-visibility-non-public-admin@admin.org";
     let admin_token = mock_login(&server, admin_email).await;
+    insert_test_subscription(&server, &db, admin_email, false).await;
 
     // Explicitly create a non-public model via admin API
     let batch_body = json!({
@@ -1030,11 +1040,12 @@ async fn test_chat_completions_block_non_public_model() {
 /// Requests with a model whose settings are public should be allowed (not blocked by 403) for /v1/chat/completions.
 #[tokio::test]
 async fn test_chat_completions_allow_public_model() {
-    let server = create_test_server().await;
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 
     // Use an admin account to configure model settings
     let admin_email = "chat-completions-visibility-public-admin@admin.org";
     let admin_token = mock_login(&server, admin_email).await;
+    insert_test_subscription(&server, &db, admin_email, false).await;
 
     // Mark the model as public via admin API
     let batch_body = json!({
@@ -1093,7 +1104,7 @@ async fn test_chat_completions_allow_public_model() {
 /// the proxy should inject a system message with the model system_prompt.
 #[tokio::test]
 async fn test_chat_completions_injects_system_prompt_when_system_message_missing() {
-    let server = create_test_server().await;
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 
     // Use an admin account to configure model settings (public + system_prompt)
     let admin_email = "chat-completions-system-prompt-no-system-admin@admin.org";
@@ -1129,6 +1140,7 @@ async fn test_chat_completions_injects_system_prompt_when_system_message_missing
     // Now send a chat completions request WITHOUT system message
     let user_email = "chat-completions-system-prompt-no-system-user@example.com";
     let user_token = mock_login(&server, user_email).await;
+    insert_test_subscription(&server, &db, user_email, false).await;
 
     let body = json!({
         "model": "test-chat-completions-system-prompt-model-1",
@@ -1162,7 +1174,7 @@ async fn test_chat_completions_injects_system_prompt_when_system_message_missing
 /// the proxy should prepend the model system_prompt to the existing system message content.
 #[tokio::test]
 async fn test_chat_completions_prepends_system_prompt_when_system_message_present() {
-    let server = create_test_server().await;
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 
     // Use an admin account to configure model settings (public + system_prompt)
     let admin_email = "chat-completions-system-prompt-with-system-admin@admin.org";
@@ -1198,6 +1210,7 @@ async fn test_chat_completions_prepends_system_prompt_when_system_message_presen
     // Now send a chat completions request WITH client system message
     let user_email = "chat-completions-system-prompt-with-system-user@example.com";
     let user_token = mock_login(&server, user_email).await;
+    insert_test_subscription(&server, &db, user_email, false).await;
 
     let body = json!({
         "model": "test-chat-completions-system-prompt-model-2",
@@ -1260,12 +1273,14 @@ async fn test_chat_completions_auto_model_forwards_with_substituted_model() {
         .await;
 
     // Create test server pointing at mock upstream
-    let server = create_test_server_with_config(TestServerConfig {
+    let (server, db) = create_test_server_and_db(TestServerConfig {
         proxy_base_url: Some(mock_upstream.uri()),
         ..Default::default()
     })
     .await;
-    let token = mock_login(&server, "chat-completions-auto-forward@example.com").await;
+    let email = "chat-completions-auto-forward@example.com";
+    let token = mock_login(&server, email).await;
+    insert_test_subscription(&server, &db, email, false).await;
 
     let response = server
         .post("/v1/chat/completions")
@@ -1342,12 +1357,14 @@ async fn test_chat_completions_auto_model_preserves_client_params() {
         .mount(&mock_upstream)
         .await;
 
-    let server = create_test_server_with_config(TestServerConfig {
+    let (server, db) = create_test_server_and_db(TestServerConfig {
         proxy_base_url: Some(mock_upstream.uri()),
         ..Default::default()
     })
     .await;
-    let token = mock_login(&server, "chat-completions-auto-preserve@example.com").await;
+    let email = "chat-completions-auto-preserve@example.com";
+    let token = mock_login(&server, email).await;
+    insert_test_subscription(&server, &db, email, false).await;
 
     // Client provides custom temperature and max_tokens, but not top_p
     let response = server
@@ -1395,9 +1412,11 @@ async fn test_chat_completions_auto_model_preserves_client_params() {
 /// Requests without a `model` field should be allowed (no 403 from visibility logic) for /v1/chat/completions.
 #[tokio::test]
 async fn test_chat_completions_allow_without_model_field() {
-    let server = create_test_server().await;
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 
-    let token = mock_login(&server, "chat-completions-visibility-no-model@example.com").await;
+    let email = "chat-completions-visibility-no-model@example.com";
+    let token = mock_login(&server, email).await;
+    insert_test_subscription(&server, &db, email, false).await;
 
     // No `model` field in body
     let body = json!({

--- a/crates/api/tests/email_auth_tests.rs
+++ b/crates/api/tests/email_auth_tests.rs
@@ -668,7 +668,12 @@ async fn test_request_email_code_rate_limit_skips_creating_additional_challenge(
     assert_eq!(first.status_code(), 204);
 
     let second = request_email_code(&server, &email, &ip).await;
-    assert_eq!(second.status_code(), 204);
+    assert_eq!(second.status_code(), 429);
+    let body: serde_json::Value = second.json();
+    assert_eq!(
+        body.get("message").and_then(|v| v.as_str()),
+        Some("Too many verification code requests. Please try again later.")
+    );
 
     let client = db.pool().get().await.expect("db client");
     let row = client
@@ -680,6 +685,56 @@ async fn test_request_email_code_rate_limit_skips_creating_additional_challenge(
         .expect("count challenges");
     let challenge_count: i64 = row.get(0);
     assert_eq!(challenge_count, 1);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_request_email_code_ip_rate_limit_returns_429() {
+    let resend = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/emails"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": "email_ip_limit" })))
+        .mount(&resend)
+        .await;
+    mount_turnstile_success(&resend).await;
+
+    set_email_auth_env();
+    std::env::set_var("EMAIL_OTP_REQUESTS_PER_IP_PER_HOUR", "1");
+
+    let (server, db) = create_test_server_and_db(TestServerConfig {
+        email_resend_base_url: Some(resend.uri()),
+        email_auth_enabled: Some(true),
+        ..Default::default()
+    })
+    .await;
+
+    let first_email = unique_email("email-auth-ip-request-limit-first");
+    let second_email = unique_email("email-auth-ip-request-limit-second");
+    let ip = unique_ip();
+    cleanup_email_auth_state(&db, &first_email).await;
+    cleanup_email_auth_state(&db, &second_email).await;
+
+    let first = request_email_code(&server, &first_email, &ip).await;
+    assert_eq!(first.status_code(), 204);
+
+    let second = request_email_code(&server, &second_email, &ip).await;
+    assert_eq!(second.status_code(), 429);
+    let body: serde_json::Value = second.json();
+    assert_eq!(
+        body.get("message").and_then(|v| v.as_str()),
+        Some("Too many verification code requests. Please try again later.")
+    );
+
+    let client = db.pool().get().await.expect("db client");
+    let row = client
+        .query_one(
+            "SELECT COUNT(*)::bigint FROM email_verification_challenges WHERE email = $1",
+            &[&second_email],
+        )
+        .await
+        .expect("count challenges for rate-limited email");
+    let challenge_count: i64 = row.get(0);
+    assert_eq!(challenge_count, 0);
 }
 
 #[tokio::test]

--- a/crates/api/tests/email_auth_tests.rs
+++ b/crates/api/tests/email_auth_tests.rs
@@ -672,7 +672,7 @@ async fn test_request_email_code_rate_limit_skips_creating_additional_challenge(
     let body: serde_json::Value = second.json();
     assert_eq!(
         body.get("message").and_then(|v| v.as_str()),
-        Some("Too many verification code requests. Please try again later.")
+        Some("Too many verification code requests. Please try again later")
     );
 
     let client = db.pool().get().await.expect("db client");
@@ -722,7 +722,7 @@ async fn test_request_email_code_ip_rate_limit_returns_429() {
     let body: serde_json::Value = second.json();
     assert_eq!(
         body.get("message").and_then(|v| v.as_str()),
-        Some("Too many verification code requests. Please try again later.")
+        Some("Too many verification code requests. Please try again later")
     );
 
     let client = db.pool().get().await.expect("db client");
@@ -822,7 +822,12 @@ async fn test_verify_email_code_rate_limit_blocks_after_failed_attempt() {
     assert_eq!(wrong_response.status_code(), 401);
 
     let blocked_response = verify_email_code(&server, &email, "123456", &ip).await;
-    assert_eq!(blocked_response.status_code(), 401);
+    assert_eq!(blocked_response.status_code(), 429);
+    let body: serde_json::Value = blocked_response.json();
+    assert_eq!(
+        body.get("message").and_then(|v| v.as_str()),
+        Some("Too many verification attempts. Please try again later")
+    );
 
     let client = db.pool().get().await.expect("db client");
     let row = client

--- a/crates/api/tests/model_allowlist_tests.rs
+++ b/crates/api/tests/model_allowlist_tests.rs
@@ -1,5 +1,6 @@
 mod common;
 
+use api::routes::api::SUBSCRIPTION_REQUIRED_ERROR_MESSAGE;
 use bytes::Bytes;
 use common::{
     cleanup_user_subscriptions, create_test_server, create_test_server_and_db,
@@ -106,7 +107,7 @@ async fn test_no_subscription_free_plan_allowed_models_blocks_even_listed_model(
     let body: serde_json::Value = response.json();
     assert_eq!(
         body.get("error").and_then(|value| value.as_str()),
-        Some("Active subscription required. Please subscribe to continue.")
+        Some(SUBSCRIPTION_REQUIRED_ERROR_MESSAGE)
     );
 }
 
@@ -166,7 +167,7 @@ async fn test_no_subscription_free_plan_allowed_models_blocks_unlisted_model() {
     let body: serde_json::Value = response.json();
     assert_eq!(
         body.get("error").and_then(|value| value.as_str()),
-        Some("Active subscription required. Please subscribe to continue.")
+        Some(SUBSCRIPTION_REQUIRED_ERROR_MESSAGE)
     );
 }
 
@@ -762,7 +763,7 @@ async fn test_model_allowlist_resolves_non_stripe_provider_subscription() {
 
 #[tokio::test]
 #[serial(model_allowlist_tests)]
-async fn test_model_allowlist_allows_unmatched_active_plan_for_both_endpoints() {
+async fn test_model_allowlist_internal_resolution_error_returns_json_500_for_both_endpoints() {
     ensure_stripe_env_for_gating();
     let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 
@@ -795,15 +796,16 @@ async fn test_model_allowlist_allows_unmatched_active_plan_for_both_endpoints() 
         }))
         .await;
 
-    assert_ne!(
-        chat_response.status_code(),
-        403,
-        "Chat completions should allow users with an active subscription even when the plan is not in current config"
-    );
-    assert_ne!(
+    assert_eq!(
         chat_response.status_code(),
         500,
-        "Unmatched active subscription plans should not surface as internal errors"
+        "Chat completions should surface plan resolution failures as internal errors"
+    );
+    let chat_body: serde_json::Value = chat_response.json();
+    assert_eq!(
+        chat_body,
+        json!({ "error": "Failed to validate model access" }),
+        "Chat completions should return the shared JSON error body"
     );
 
     let responses_response = server
@@ -818,15 +820,16 @@ async fn test_model_allowlist_allows_unmatched_active_plan_for_both_endpoints() 
         }))
         .await;
 
-    assert_ne!(
-        responses_response.status_code(),
-        403,
-        "Responses should allow users with an active subscription even when the plan is not in current config"
-    );
-    assert_ne!(
+    assert_eq!(
         responses_response.status_code(),
         500,
-        "Unmatched active subscription plans should not surface as internal errors"
+        "Responses should surface plan resolution failures as internal errors"
+    );
+    let responses_body: serde_json::Value = responses_response.json();
+    assert_eq!(
+        responses_body,
+        json!({ "error": "Failed to validate model access" }),
+        "Responses should return the shared JSON error body"
     );
 }
 

--- a/crates/api/tests/model_allowlist_tests.rs
+++ b/crates/api/tests/model_allowlist_tests.rs
@@ -43,12 +43,12 @@ not-a-real-png\r\n\
 }
 
 // ============================================================================
-// Test: Users without subscription (using free plan allowed_models)
+// Test: Email-only users without subscription are blocked before model allowlist
 // ============================================================================
 
 #[tokio::test]
 #[serial(model_allowlist_tests)]
-async fn test_no_subscription_free_plan_allowed_models_allows_listed_model() {
+async fn test_no_subscription_free_plan_allowed_models_blocks_even_listed_model() {
     ensure_stripe_env_for_gating();
     let server = create_test_server().await;
 
@@ -83,7 +83,8 @@ async fn test_no_subscription_free_plan_allowed_models_allows_listed_model() {
     let user_email = "no_subscription_allowed@example.com";
     let user_token = mock_login(&server, user_email).await;
 
-    // Try to use a model that's in the free plan allowlist
+    // Try to use a model that's in the free plan allowlist. Email-only users without
+    // an active subscription are blocked before model allowlist evaluation.
     let response = server
         .post("/v1/chat/completions")
         .add_header(
@@ -96,11 +97,16 @@ async fn test_no_subscription_free_plan_allowed_models_allows_listed_model() {
         }))
         .await;
 
-    // Should NOT be 403 (will likely be 401/502 due to no upstream, but not 403)
-    assert_ne!(
+    assert_eq!(
         response.status_code(),
         403,
-        "User should be allowed to use model in free plan allowed_models"
+        "Email-only user without active subscription should be blocked before free plan allowlist"
+    );
+
+    let body: serde_json::Value = response.json();
+    assert_eq!(
+        body.get("error").and_then(|value| value.as_str()),
+        Some("Active subscription required. Please subscribe to continue.")
     );
 }
 
@@ -137,7 +143,8 @@ async fn test_no_subscription_free_plan_allowed_models_blocks_unlisted_model() {
     let user_email = "no_subscription_blocked@example.com";
     let user_token = mock_login(&server, user_email).await;
 
-    // Try to use a model NOT in the free plan allowlist
+    // Try to use a model NOT in the free plan allowlist. Email-only users without
+    // an active subscription are blocked before model allowlist evaluation.
     let response = server
         .post("/v1/chat/completions")
         .add_header(
@@ -150,21 +157,16 @@ async fn test_no_subscription_free_plan_allowed_models_blocks_unlisted_model() {
         }))
         .await;
 
-    // Should be 403 Forbidden
     assert_eq!(
         response.status_code(),
         403,
-        "User without subscription should be blocked from using model not in free plan allowed_models"
+        "Email-only user without active subscription should be blocked before free plan allowlist"
     );
 
     let body: serde_json::Value = response.json();
-    let error = body
-        .get("error")
-        .and_then(|value| value.as_str())
-        .expect("Error response should contain string error field");
-    assert!(
-        error.contains("gpt-4o") && error.contains("not available"),
-        "Error message should mention the model and that it's not available"
+    assert_eq!(
+        body.get("error").and_then(|value| value.as_str()),
+        Some("Active subscription required. Please subscribe to continue.")
     );
 }
 
@@ -760,7 +762,7 @@ async fn test_model_allowlist_resolves_non_stripe_provider_subscription() {
 
 #[tokio::test]
 #[serial(model_allowlist_tests)]
-async fn test_model_allowlist_internal_resolution_error_returns_json_500_for_both_endpoints() {
+async fn test_model_allowlist_allows_unmatched_active_plan_for_both_endpoints() {
     ensure_stripe_env_for_gating();
     let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 
@@ -793,16 +795,15 @@ async fn test_model_allowlist_internal_resolution_error_returns_json_500_for_bot
         }))
         .await;
 
-    assert_eq!(
+    assert_ne!(
+        chat_response.status_code(),
+        403,
+        "Chat completions should allow users with an active subscription even when the plan is not in current config"
+    );
+    assert_ne!(
         chat_response.status_code(),
         500,
-        "Chat completions should surface plan resolution failures as internal errors"
-    );
-    let chat_body: serde_json::Value = chat_response.json();
-    assert_eq!(
-        chat_body,
-        json!({ "error": "Failed to validate model access" }),
-        "Chat completions should return the shared JSON error body"
+        "Unmatched active subscription plans should not surface as internal errors"
     );
 
     let responses_response = server
@@ -817,16 +818,15 @@ async fn test_model_allowlist_internal_resolution_error_returns_json_500_for_bot
         }))
         .await;
 
-    assert_eq!(
+    assert_ne!(
+        responses_response.status_code(),
+        403,
+        "Responses should allow users with an active subscription even when the plan is not in current config"
+    );
+    assert_ne!(
         responses_response.status_code(),
         500,
-        "Responses should surface plan resolution failures as internal errors"
-    );
-    let responses_body: serde_json::Value = responses_response.json();
-    assert_eq!(
-        responses_body,
-        json!({ "error": "Failed to validate model access" }),
-        "Responses should return the shared JSON error body"
+        "Unmatched active subscription plans should not surface as internal errors"
     );
 }
 

--- a/crates/api/tests/models_tests.rs
+++ b/crates/api/tests/models_tests.rs
@@ -1,8 +1,8 @@
 mod common;
 
 use common::{
-    create_test_server, create_test_server_and_db, insert_test_subscription, mock_login,
-    TestServerConfig,
+    create_test_server, create_test_server_and_db, insert_test_subscription,
+    insert_test_subscription_with_price_id, mock_login, TestServerConfig,
 };
 use serde_json::json;
 use serial_test::serial;
@@ -320,7 +320,7 @@ async fn test_responses_block_non_public_model() {
     // Use an admin account to configure model settings and allowlist
     let admin_email = "visibility-non-public-admin@admin.org";
     let admin_token = mock_login(&server, admin_email).await;
-    insert_test_subscription(&server, &db, admin_email, false).await;
+    insert_test_subscription_with_price_id(&server, &db, admin_email, false, "price_free").await;
 
     let response = server
         .patch("/v1/admin/configs")
@@ -414,7 +414,7 @@ async fn test_responses_allow_public_model() {
     // Use an admin account to configure model settings and allowlist
     let admin_email = "visibility-public-admin@admin.org";
     let admin_token = mock_login(&server, admin_email).await;
-    insert_test_subscription(&server, &db, admin_email, false).await;
+    insert_test_subscription_with_price_id(&server, &db, admin_email, false, "price_free").await;
 
     let response = server
         .patch("/v1/admin/configs")
@@ -560,7 +560,7 @@ async fn test_responses_injects_system_prompt_when_instructions_missing() {
     // Now send a responses request WITHOUT instructions
     let user_email = "system-prompt-no-instructions-user@example.com";
     let user_token = mock_login(&server, user_email).await;
-    insert_test_subscription(&server, &db, user_email, false).await;
+    insert_test_subscription_with_price_id(&server, &db, user_email, false, "price_free").await;
 
     let body = json!({
         "model": "test-system-prompt-model-1",
@@ -656,7 +656,7 @@ async fn test_responses_prepends_system_prompt_when_instructions_present() {
     // Now send a responses request WITH client instructions
     let user_email = "system-prompt-with-instructions-user@example.com";
     let user_token = mock_login(&server, user_email).await;
-    insert_test_subscription(&server, &db, user_email, false).await;
+    insert_test_subscription_with_price_id(&server, &db, user_email, false, "price_free").await;
 
     let body = json!({
         "model": "test-system-prompt-model-2",

--- a/crates/api/tests/models_tests.rs
+++ b/crates/api/tests/models_tests.rs
@@ -1,6 +1,9 @@
 mod common;
 
-use common::{create_test_server, mock_login};
+use common::{
+    create_test_server, create_test_server_and_db, insert_test_subscription, mock_login,
+    TestServerConfig,
+};
 use serde_json::json;
 use serial_test::serial;
 
@@ -312,11 +315,12 @@ async fn test_delete_model_requires_admin() {
 #[tokio::test]
 #[serial(model_visibility_tests)]
 async fn test_responses_block_non_public_model() {
-    let server = create_test_server().await;
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 
     // Use an admin account to configure model settings and allowlist
     let admin_email = "visibility-non-public-admin@admin.org";
     let admin_token = mock_login(&server, admin_email).await;
+    insert_test_subscription(&server, &db, admin_email, false).await;
 
     let response = server
         .patch("/v1/admin/configs")
@@ -405,11 +409,12 @@ async fn test_responses_block_non_public_model() {
 #[tokio::test]
 #[serial(model_visibility_tests)]
 async fn test_responses_allow_public_model() {
-    let server = create_test_server().await;
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 
     // Use an admin account to configure model settings and allowlist
     let admin_email = "visibility-public-admin@admin.org";
     let admin_token = mock_login(&server, admin_email).await;
+    insert_test_subscription(&server, &db, admin_email, false).await;
 
     let response = server
         .patch("/v1/admin/configs")
@@ -494,7 +499,7 @@ async fn test_responses_allow_public_model() {
 #[tokio::test]
 #[serial(model_visibility_tests)]
 async fn test_responses_injects_system_prompt_when_instructions_missing() {
-    let server = create_test_server().await;
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 
     // Use an admin account to configure model settings and allowlist
     let admin_email = "system-prompt-no-instructions-admin@admin.org";
@@ -555,6 +560,7 @@ async fn test_responses_injects_system_prompt_when_instructions_missing() {
     // Now send a responses request WITHOUT instructions
     let user_email = "system-prompt-no-instructions-user@example.com";
     let user_token = mock_login(&server, user_email).await;
+    insert_test_subscription(&server, &db, user_email, false).await;
 
     let body = json!({
         "model": "test-system-prompt-model-1",
@@ -589,7 +595,7 @@ async fn test_responses_injects_system_prompt_when_instructions_missing() {
 #[tokio::test]
 #[serial(model_visibility_tests)]
 async fn test_responses_prepends_system_prompt_when_instructions_present() {
-    let server = create_test_server().await;
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 
     // Use an admin account to configure model settings and allowlist
     let admin_email = "system-prompt-with-instructions-admin@admin.org";
@@ -650,6 +656,7 @@ async fn test_responses_prepends_system_prompt_when_instructions_present() {
     // Now send a responses request WITH client instructions
     let user_email = "system-prompt-with-instructions-user@example.com";
     let user_token = mock_login(&server, user_email).await;
+    insert_test_subscription(&server, &db, user_email, false).await;
 
     let body = json!({
         "model": "test-system-prompt-model-2",
@@ -683,9 +690,11 @@ async fn test_responses_prepends_system_prompt_when_instructions_present() {
 /// Requests without a `model` field should be allowed (no 403 from visibility logic).
 #[tokio::test]
 async fn test_responses_allow_without_model_field() {
-    let server = create_test_server().await;
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 
-    let token = mock_login(&server, "visibility-no-model@example.com").await;
+    let email = "visibility-no-model@example.com";
+    let token = mock_login(&server, email).await;
+    insert_test_subscription(&server, &db, email, false).await;
 
     // No `model` field in body
     let body = json!({

--- a/crates/api/tests/rate_limit_tests.rs
+++ b/crates/api/tests/rate_limit_tests.rs
@@ -328,21 +328,11 @@ async fn test_cost_limit_blocks_request_when_usage_exceeds_limit() {
     })
     .await;
 
-    // Clear subscription plans via DB to avoid subscription gating interference
-    {
-        let client = db.pool().get().await.expect("DB pool");
-        let rows = client
-            .execute(
-                "UPDATE system_configs SET value = value - 'subscription_plans' WHERE key = 'config'",
-                &[],
-            )
-            .await
-            .expect("UPDATE system_configs for rate limit test");
-        assert!(rows > 0, "system_configs row for key='config' should exist");
-    }
+    configure_basic_subscription_plan(&db).await;
 
     let email = "cost-limit@example.com";
     let token = mock_login(&server, email).await;
+    insert_test_subscription(&server, &db, email, false).await;
 
     let user = db
         .user_repository()

--- a/crates/api/tests/rate_limit_tests.rs
+++ b/crates/api/tests/rate_limit_tests.rs
@@ -2,8 +2,8 @@ mod common;
 
 use chrono::Duration;
 use common::{
-    create_test_server_and_db, create_test_server_with_config, mock_login,
-    restrictive_rate_limit_config, TestServerConfig,
+    create_test_server_and_db, create_test_server_with_config, insert_test_subscription,
+    mock_login, restrictive_rate_limit_config, TestServerConfig,
 };
 use futures::future::join_all;
 use serde_json::json;
@@ -21,10 +21,20 @@ async fn create_rate_limited_test_server() -> axum_test::TestServer {
     .await
 }
 
+async fn create_rate_limited_test_server_and_db() -> (axum_test::TestServer, database::Database) {
+    create_test_server_and_db(TestServerConfig {
+        rate_limit_config: Some(restrictive_rate_limit_config()),
+        ..Default::default()
+    })
+    .await
+}
+
 #[tokio::test]
 async fn test_rate_limit_first_request_succeeds() {
-    let server = create_rate_limited_test_server().await;
-    let token = mock_login(&server, "rate-limit-test-1@example.com").await;
+    let (server, db) = create_rate_limited_test_server_and_db().await;
+    let email = "rate-limit-test-1@example.com";
+    let token = mock_login(&server, email).await;
+    insert_test_subscription(&server, &db, email, false).await;
 
     let response = server
         .post("/v1/responses")
@@ -48,8 +58,10 @@ async fn test_rate_limit_first_request_succeeds() {
 
 #[tokio::test]
 async fn test_rate_limit_blocks_rapid_requests() {
-    let server = create_rate_limited_test_server().await;
-    let token = mock_login(&server, "rate-limit-test-2@example.com").await;
+    let (server, db) = create_rate_limited_test_server_and_db().await;
+    let email = "rate-limit-test-2@example.com";
+    let token = mock_login(&server, email).await;
+    insert_test_subscription(&server, &db, email, false).await;
 
     let request_body = json!({
         "model": "test-model",
@@ -97,9 +109,13 @@ async fn test_rate_limit_blocks_rapid_requests() {
 
 #[tokio::test]
 async fn test_rate_limit_per_user_isolation() {
-    let server = create_rate_limited_test_server().await;
-    let token1 = mock_login(&server, "rate-limit-user-a@example.com").await;
-    let token2 = mock_login(&server, "rate-limit-user-b@example.com").await;
+    let (server, db) = create_rate_limited_test_server_and_db().await;
+    let email1 = "rate-limit-user-a@example.com";
+    let email2 = "rate-limit-user-b@example.com";
+    let token1 = mock_login(&server, email1).await;
+    let token2 = mock_login(&server, email2).await;
+    insert_test_subscription(&server, &db, email1, false).await;
+    insert_test_subscription(&server, &db, email2, false).await;
 
     let request_body = json!({
         "model": "test-model",
@@ -159,8 +175,11 @@ async fn test_non_rate_limited_endpoints_unaffected() {
 
 #[tokio::test]
 async fn test_concurrent_requests_rate_limited() {
-    let server = Arc::new(create_rate_limited_test_server().await);
-    let token = Arc::new(mock_login(&server, "rate-limit-concurrent@example.com").await);
+    let (server, db) = create_rate_limited_test_server_and_db().await;
+    let email = "rate-limit-concurrent@example.com";
+    let token = Arc::new(mock_login(&server, email).await);
+    insert_test_subscription(&server, &db, email, false).await;
+    let server = Arc::new(server);
 
     let request_body = json!({
         "model": "test-model",
@@ -225,6 +244,7 @@ async fn test_token_limit_blocks_request_when_usage_exceeds_limit() {
 
     let email = "token-limit@example.com";
     let token = mock_login(&server, email).await;
+    insert_test_subscription(&server, &db, email, false).await;
 
     let user = db
         .user_repository()

--- a/crates/api/tests/rate_limit_tests.rs
+++ b/crates/api/tests/rate_limit_tests.rs
@@ -3,7 +3,7 @@ mod common;
 use chrono::Duration;
 use common::{
     create_test_server_and_db, create_test_server_with_config, insert_test_subscription,
-    mock_login, restrictive_rate_limit_config, TestServerConfig,
+    mock_login, restrictive_rate_limit_config, set_subscription_plans, TestServerConfig,
 };
 use futures::future::join_all;
 use serde_json::json;
@@ -22,11 +22,22 @@ async fn create_rate_limited_test_server() -> axum_test::TestServer {
 }
 
 async fn create_rate_limited_test_server_and_db() -> (axum_test::TestServer, database::Database) {
-    create_test_server_and_db(TestServerConfig {
+    let (server, db) = create_test_server_and_db(TestServerConfig {
         rate_limit_config: Some(restrictive_rate_limit_config()),
         ..Default::default()
     })
-    .await
+    .await;
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": {
+                "providers": { "stripe": { "price_id": "price_test_basic" } },
+                "monthly_credits": { "max": 1000000 }
+            }
+        }),
+    )
+    .await;
+    (server, db)
 }
 
 #[tokio::test]
@@ -240,6 +251,16 @@ async fn test_token_limit_blocks_request_when_usage_exceeds_limit() {
         }),
         ..Default::default()
     })
+    .await;
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": {
+                "providers": { "stripe": { "price_id": "price_test_basic" } },
+                "monthly_credits": { "max": 1000000 }
+            }
+        }),
+    )
     .await;
 
     let email = "token-limit@example.com";

--- a/crates/api/tests/rate_limit_tests.rs
+++ b/crates/api/tests/rate_limit_tests.rs
@@ -3,7 +3,7 @@ mod common;
 use chrono::Duration;
 use common::{
     create_test_server_and_db, create_test_server_with_config, insert_test_subscription,
-    mock_login, restrictive_rate_limit_config, set_subscription_plans, TestServerConfig,
+    mock_login, restrictive_rate_limit_config, TestServerConfig,
 };
 use futures::future::join_all;
 use serde_json::json;
@@ -21,22 +21,35 @@ async fn create_rate_limited_test_server() -> axum_test::TestServer {
     .await
 }
 
+async fn configure_basic_subscription_plan(db: &database::Database) {
+    let plans = json!({
+        "basic": {
+            "providers": { "stripe": { "price_id": "price_test_basic" } },
+            "monthly_credits": { "max": 1000000 }
+        }
+    });
+    let client = db.pool().get().await.expect("DB pool");
+    client
+        .execute(
+            r#"
+            INSERT INTO system_configs (key, value)
+            VALUES ('config', jsonb_build_object('subscription_plans', $1::jsonb))
+            ON CONFLICT (key)
+            DO UPDATE SET value = system_configs.value || jsonb_build_object('subscription_plans', $1::jsonb)
+            "#,
+            &[&plans],
+        )
+        .await
+        .expect("set subscription_plans without hot-reloading rate limits");
+}
+
 async fn create_rate_limited_test_server_and_db() -> (axum_test::TestServer, database::Database) {
     let (server, db) = create_test_server_and_db(TestServerConfig {
         rate_limit_config: Some(restrictive_rate_limit_config()),
         ..Default::default()
     })
     .await;
-    set_subscription_plans(
-        &server,
-        json!({
-            "basic": {
-                "providers": { "stripe": { "price_id": "price_test_basic" } },
-                "monthly_credits": { "max": 1000000 }
-            }
-        }),
-    )
-    .await;
+    configure_basic_subscription_plan(&db).await;
     (server, db)
 }
 
@@ -252,16 +265,7 @@ async fn test_token_limit_blocks_request_when_usage_exceeds_limit() {
         ..Default::default()
     })
     .await;
-    set_subscription_plans(
-        &server,
-        json!({
-            "basic": {
-                "providers": { "stripe": { "price_id": "price_test_basic" } },
-                "monthly_credits": { "max": 1000000 }
-            }
-        }),
-    )
-    .await;
+    configure_basic_subscription_plan(&db).await;
 
     let email = "token-limit@example.com";
     let token = mock_login(&server, email).await;

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -41,9 +41,6 @@ fn permissive_rate_limit_config() -> RateLimitConfig {
     }
 }
 
-const EMAIL_ONLY_FREE_PLAN_ERROR_MESSAGE: &str =
-    "Email-only accounts require a paid subscription to access LLM APIs.";
-
 #[tokio::test]
 #[serial(subscription_tests)]
 async fn test_list_subscriptions_requires_auth() {
@@ -1391,7 +1388,7 @@ async fn test_proxy_returns_403_without_subscription_when_plans_configured() {
 
 #[tokio::test]
 #[serial(subscription_tests)]
-async fn test_proxy_blocks_email_only_user_on_free_priced_plan() {
+async fn test_proxy_allows_email_only_user_on_free_priced_plan() {
     ensure_stripe_env_for_gating();
     let (server, db) = create_test_server_and_db(TestServerConfig {
         rate_limit_config: Some(permissive_rate_limit_config()),
@@ -1417,9 +1414,59 @@ async fn test_proxy_blocks_email_only_user_on_free_priced_plan() {
     )
     .await;
 
-    let user_email = "test_email_only_free_plan_block@example.com";
+    let user_email = "test_email_only_free_plan_allowed@example.com";
     insert_test_subscription_with_price_id(&server, &db, user_email, false, "price_test_free")
         .await;
+    let user_token = mock_login(&server, user_email).await;
+
+    let response = server
+        .post("/v1/chat/completions")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {user_token}")).unwrap(),
+        )
+        .json(&json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hello"}]
+        }))
+        .await;
+
+    assert_ne!(
+        response.status_code(),
+        403,
+        "Email-only user with an active free-priced subscription should not be blocked from LLM APIs"
+    );
+
+    let body_res: serde_json::Value = response.json();
+    assert_ne!(
+        body_res.get("error").and_then(|v| v.as_str()),
+        Some(SUBSCRIPTION_REQUIRED_ERROR_MESSAGE),
+    );
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn test_proxy_blocks_email_only_user_without_active_subscription() {
+    ensure_stripe_env_for_gating();
+    let (server, _db) = create_test_server_and_db(TestServerConfig {
+        rate_limit_config: Some(permissive_rate_limit_config()),
+        ..Default::default()
+    })
+    .await;
+
+    set_subscription_plans(
+        &server,
+        json!({
+            "free": {
+                "providers": {"stripe": {"price_id": "price_test_free"}},
+                "price": 0,
+                "monthly_credits": {"max": 1000000}
+            }
+        }),
+    )
+    .await;
+
+    let user_email = "test_email_only_no_subscription_block@example.com";
     let user_token = mock_login(&server, user_email).await;
 
     let response = server
@@ -1437,13 +1484,13 @@ async fn test_proxy_blocks_email_only_user_on_free_priced_plan() {
     assert_eq!(
         response.status_code(),
         403,
-        "Email-only user on free-priced plan should be blocked from LLM APIs"
+        "Email-only user without an active subscription should be blocked from LLM APIs"
     );
 
     let body_res: serde_json::Value = response.json();
     assert_eq!(
         body_res.get("error").and_then(|v| v.as_str()),
-        Some(EMAIL_ONLY_FREE_PLAN_ERROR_MESSAGE)
+        Some(SUBSCRIPTION_REQUIRED_ERROR_MESSAGE)
     );
 }
 
@@ -1501,7 +1548,7 @@ async fn test_proxy_allows_email_only_user_on_paid_plan() {
     let body_res: serde_json::Value = response.json();
     assert_ne!(
         body_res.get("error").and_then(|v| v.as_str()),
-        Some(EMAIL_ONLY_FREE_PLAN_ERROR_MESSAGE),
+        Some(SUBSCRIPTION_REQUIRED_ERROR_MESSAGE),
     );
 }
 

--- a/crates/api/tests/system_configs_tests.rs
+++ b/crates/api/tests/system_configs_tests.rs
@@ -597,7 +597,10 @@ async fn test_rate_limit_config_hot_reload() {
     // Include subscription_plans so subscription passes before rate limiting is exercised
     let initial_config = json!({
         "subscription_plans": {
-            "free": { "providers": {}, "monthly_credits": { "max": 1000000 } }
+            "basic": {
+                "providers": { "stripe": { "price_id": "price_test_basic" } },
+                "monthly_credits": { "max": 1000000 }
+            }
         },
         "rate_limit": {
             "max_concurrent": 1,

--- a/crates/api/tests/system_configs_tests.rs
+++ b/crates/api/tests/system_configs_tests.rs
@@ -1,6 +1,9 @@
 mod common;
 
-use common::{create_test_server, mock_login};
+use common::{
+    create_test_server, create_test_server_and_db, insert_test_subscription, mock_login,
+    TestServerConfig,
+};
 use serde_json::json;
 use serial_test::serial;
 
@@ -585,7 +588,7 @@ async fn test_empty_window_limits_allowed() {
 #[tokio::test]
 #[serial(write_system_configs)]
 async fn test_rate_limit_config_hot_reload() {
-    let server = create_test_server().await;
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 
     let admin_email = "test_admin_hot_reload@admin.org";
     let admin_token = mock_login(&server, admin_email).await;
@@ -632,6 +635,7 @@ async fn test_rate_limit_config_hot_reload() {
     // Step 2: Make first request (should succeed)
     let test_user_email = "test_user_hot_reload@example.com";
     let user_token = mock_login(&server, test_user_email).await;
+    insert_test_subscription(&server, &db, test_user_email, false).await;
 
     let request_body = json!({
         "model": "test-model",

--- a/crates/services/src/auth/ports.rs
+++ b/crates/services/src/auth/ports.rs
@@ -108,6 +108,8 @@ pub enum RequestEmailCodeError {
     Misconfigured,
     #[error("Human verification failed")]
     HumanVerificationFailed,
+    #[error("Too many verification code requests")]
+    RateLimited,
     #[error("Internal error: {0}")]
     Internal(#[from] anyhow::Error),
 }

--- a/crates/services/src/auth/service.rs
+++ b/crates/services/src/auth/service.rs
@@ -676,7 +676,7 @@ impl EmailAuthService for EmailAuthServiceImpl {
                 client_ip = %client_ip,
                 "Email OTP request rate-limited by email threshold"
             );
-            return Ok(());
+            return Err(RequestEmailCodeError::RateLimited);
         }
 
         if self
@@ -690,7 +690,7 @@ impl EmailAuthService for EmailAuthServiceImpl {
                 client_ip = %client_ip,
                 "Email OTP request rate-limited by IP threshold"
             );
-            return Ok(());
+            return Err(RequestEmailCodeError::RateLimited);
         }
 
         let challenge_id = Uuid::new_v4();

--- a/crates/services/src/subscription/ports.rs
+++ b/crates/services/src/subscription/ports.rs
@@ -174,8 +174,6 @@ pub enum SubscriptionError {
     NotConfigured,
     /// No active subscription found for user
     NoActiveSubscription,
-    /// Email-only users on free-priced plans cannot access LLM APIs
-    EmailOnlyFreePlanNotAllowed,
     /// Credit limit exceeded (used >= limit)
     CreditLimitExceeded { used: i64, limit: u64 },
     /// Cannot switch to plan: current instance count exceeds target plan's limit
@@ -218,9 +216,6 @@ impl fmt::Display for SubscriptionError {
             Self::InvalidProvider(provider) => write!(f, "Invalid provider: {}", provider),
             Self::NotConfigured => write!(f, "Stripe is not configured"),
             Self::NoActiveSubscription => write!(f, "No active subscription found"),
-            Self::EmailOnlyFreePlanNotAllowed => {
-                write!(f, "Email-only users on free plans cannot access LLM APIs")
-            }
             Self::CreditLimitExceeded { used, limit } => {
                 write!(
                     f,

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -389,10 +389,11 @@ impl SubscriptionServiceImpl {
             .unwrap_or_default())
     }
 
-    /// Returns true only when:
-    /// 1) user has no linked OAuth accounts (email-only account), and
-    /// 2) effective plan price is explicitly free (price == 0)
-    async fn is_email_only_user_on_free_priced_plan(
+    /// Returns true only when the user has no linked OAuth accounts (email-only account)
+    /// and has no active/trialing subscription. Email-only users with any active
+    /// subscription, including a free-priced plan, may access LLM APIs subject to
+    /// the normal quota and credit checks.
+    async fn is_email_only_user_without_active_subscription(
         &self,
         user_id: UserId,
     ) -> Result<bool, SubscriptionError> {
@@ -406,29 +407,13 @@ impl SubscriptionServiceImpl {
             return Ok(false);
         }
 
-        let subscription_plans = self.get_subscription_plans().await?;
         let active_subscription = self
             .subscription_repo
             .get_active_subscription(user_id)
             .await
             .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
 
-        let is_free_priced = match active_subscription {
-            Some(sub) => {
-                resolve_plan_name_from_config(
-                    sub.provider.as_str(),
-                    &sub.price_id,
-                    &subscription_plans,
-                )
-                .as_deref()
-                .and_then(|plan_name| subscription_plans.get(plan_name))
-                .and_then(|plan| plan.price)
-                    == Some(0)
-            }
-            None => subscription_plans.get("free").and_then(|plan| plan.price) == Some(0),
-        };
-
-        Ok(is_free_priced)
+        Ok(active_subscription.is_none())
     }
 
     /// Convert Stripe subscription to our Subscription model
@@ -2004,12 +1989,15 @@ impl SubscriptionService for SubscriptionServiceImpl {
             Ok(_) => {}
         }
 
-        if self.is_email_only_user_on_free_priced_plan(user_id).await? {
+        if self
+            .is_email_only_user_without_active_subscription(user_id)
+            .await?
+        {
             tracing::info!(
-                "Blocking proxy access for email-only user_id={} on free-priced plan",
+                "Blocking proxy access for email-only user_id={}: no active subscription",
                 user_id
             );
-            return Err(SubscriptionError::EmailOnlyFreePlanNotAllowed);
+            return Err(SubscriptionError::NoActiveSubscription);
         }
 
         // 1. Get plan credits (monthly_credits) from the config. Cache 10 mins.

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -2179,15 +2179,22 @@ impl SubscriptionService for SubscriptionServiceImpl {
             Some(ref sub) => {
                 // User has an active subscription - use plan's allowlist
                 if let Some(plans) = subscription_plans {
-                    let Some(plan_name) =
-                        resolve_plan_name_from_config(sub.provider.as_str(), &sub.price_id, plans)
-                    else {
-                        tracing::warn!(
-                            "Model access allowed for user_id={}: active subscription plan is not present in current config",
-                            user_id
+                    let plan_name = resolve_plan_name_from_config(
+                        sub.provider.as_str(),
+                        &sub.price_id,
+                        plans,
+                    )
+                    .ok_or_else(|| {
+                        tracing::error!(
+                            "Failed to resolve plan name for model access: user_id={}, provider={}, price_id={} does not match any configured plan",
+                            user_id,
+                            sub.provider,
+                            sub.price_id
                         );
-                        return Ok(());
-                    };
+                        SubscriptionError::InternalError(
+                            "Failed to resolve subscription plan configuration".to_string(),
+                        )
+                    })?;
                     plans
                         .get(&plan_name)
                         .and_then(|config| config.allowed_models.as_ref())

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -2179,21 +2179,15 @@ impl SubscriptionService for SubscriptionServiceImpl {
             Some(ref sub) => {
                 // User has an active subscription - use plan's allowlist
                 if let Some(plans) = subscription_plans {
-                    let plan_name = resolve_plan_name_from_config(
-                        sub.provider.as_str(),
-                        &sub.price_id,
-                        plans,
-                    )
-                    .ok_or_else(|| {
-                        tracing::error!(
-                            "Failed to resolve plan name for user_id={}: price_id='{}' does not match any configured plan",
-                            user_id,
-                            sub.price_id
+                    let Some(plan_name) =
+                        resolve_plan_name_from_config(sub.provider.as_str(), &sub.price_id, plans)
+                    else {
+                        tracing::warn!(
+                            "Model access allowed for user_id={}: active subscription plan is not present in current config",
+                            user_id
                         );
-                        SubscriptionError::InternalError(
-                            "Failed to resolve subscription plan configuration".to_string(),
-                        )
-                    })?;
+                        return Ok(());
+                    };
                     plans
                         .get(&plan_name)
                         .and_then(|config| config.allowed_models.as_ref())


### PR DESCRIPTION
## Summary
- map email OTP rate-limit failures to HTTP 429 instead of returning 204
- preserve explicit error handling for request-code rate limit cases
- allow email-only users to access LLM APIs when they have any active/trialing subscription, including free-priced plans
- only block email-only users when they have no active subscription
- add/update coverage for email/IP/global rate-limit responses and email-only subscription gating

## Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`

Related to #272
