### PR TITLE
fix: account deletion subscription precondition

### DIFF
--- a/crates/api/src/bin/task_worker.rs
+++ b/crates/api/src/bin/task_worker.rs
@@ -423,7 +423,7 @@ impl TaskExecutor for DefaultTaskExecutor {
                 Ok(())
             }
             Err(
-                err @ (AccountDeletionError::ActiveSubscriptions { .. }
+                err @ (AccountDeletionError::BlockingSubscriptions { .. }
                 | AccountDeletionError::InstancesNotDeleted { .. }),
             ) => {
                 let progress = build_account_deletion_progress(

--- a/crates/api/src/routes/users.rs
+++ b/crates/api/src/routes/users.rs
@@ -46,7 +46,7 @@ pub async fn get_current_user(
 
 /// Delete current user account
 ///
-/// Requests asynchronous account deletion after verifying the user has no active subscriptions
+/// Requests asynchronous account deletion after verifying the user has no non-terminal subscriptions
 /// and no remaining non-deleted instances.
 #[utoipa::path(
     delete,
@@ -56,7 +56,7 @@ pub async fn get_current_user(
         (status = 202, description = "User account deletion requested", body = UserAccountDeletionResponse),
         (status = 401, description = "Unauthorized", body = crate::error::ApiErrorResponse),
         (status = 404, description = "User not found", body = crate::error::ApiErrorResponse),
-        (status = 409, description = "Account cannot be deleted until subscriptions are inactive and instances are deleted", body = crate::error::ApiErrorResponse),
+        (status = 409, description = "Account cannot be deleted until subscriptions are terminal and instances are deleted", body = crate::error::ApiErrorResponse),
         (status = 500, description = "Internal server error", body = crate::error::ApiErrorResponse)
     ),
     security(
@@ -124,10 +124,10 @@ fn account_deletion_error_to_api_error(e: AccountDeletionError) -> ApiError {
             tracing::warn!("Account deletion failed: user not found");
             ApiError::not_found("User not found")
         }
-        AccountDeletionError::ActiveSubscriptions { count } => {
-            tracing::warn!("Account deletion blocked: {count} active subscription(s) exist");
+        AccountDeletionError::BlockingSubscriptions { count } => {
+            tracing::warn!("Account deletion blocked: {count} non-terminal subscription(s) exist");
             ApiError::conflict(format!(
-                "Cannot delete account while {count} active subscription(s) exist"
+                "Cannot delete account while {count} non-terminal subscription(s) exist"
             ))
         }
         AccountDeletionError::InstancesNotDeleted { count, statuses } => {

--- a/crates/api/tests/user_account_deletion_tests.rs
+++ b/crates/api/tests/user_account_deletion_tests.rs
@@ -13,42 +13,107 @@ fn auth_header(token: &str) -> (HeaderName, HeaderValue) {
 }
 
 #[tokio::test]
-async fn delete_account_blocks_active_subscription() {
+async fn delete_account_blocks_non_terminal_subscription_statuses() {
     let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
-    let email = format!(
-        "delete_account_active_subscription_{}@test.org",
-        Uuid::new_v4()
-    );
-    let token = mock_login(&server, &email).await;
-    let user = db
-        .user_repository()
-        .get_user_by_email(&email)
-        .await
-        .expect("get user")
-        .expect("user exists");
-
     let client = db.pool().get().await.expect("db client");
-    client
-        .execute(
-            "INSERT INTO subscriptions (
-                subscription_id, user_id, provider, customer_id, price_id, status,
-                current_period_end, cancel_at_period_end
-            ) VALUES ($1, $2, 'stripe', 'cus_delete_active', 'price_test', 'active', NOW() + INTERVAL '1 day', false)",
-            &[&format!("sub_delete_active_{}", Uuid::new_v4()), &user.id],
-        )
-        .await
-        .expect("insert active subscription");
 
-    let (name, value) = auth_header(&token);
-    let response = server.delete("/v1/users/me").add_header(name, value).await;
+    for status in [
+        "active",
+        "trialing",
+        "past_due",
+        "unpaid",
+        "incomplete",
+        "paused",
+    ] {
+        let email = format!(
+            "delete_account_{}_subscription_{}@test.org",
+            status,
+            Uuid::new_v4()
+        );
+        let token = mock_login(&server, &email).await;
+        let user = db
+            .user_repository()
+            .get_user_by_email(&email)
+            .await
+            .expect("get user")
+            .expect("user exists");
+        let subscription_id = format!("sub_delete_{}_{}", status, Uuid::new_v4());
+        let customer_id = format!("cus_delete_{}_{}", status, Uuid::new_v4());
 
-    assert_eq!(response.status_code(), 409);
-    assert!(db
-        .user_repository()
-        .get_user(user.id)
-        .await
-        .expect("get user after blocked delete")
-        .is_some());
+        client
+            .execute(
+                "INSERT INTO subscriptions (
+                    subscription_id, user_id, provider, customer_id, price_id, status,
+                    current_period_end, cancel_at_period_end
+                ) VALUES ($1, $2, 'stripe', $3, 'price_test', $4, NOW() + INTERVAL '1 day', false)",
+                &[&subscription_id, &user.id, &customer_id, &status],
+            )
+            .await
+            .expect("insert non-terminal subscription");
+
+        let (name, value) = auth_header(&token);
+        let response = server.delete("/v1/users/me").add_header(name, value).await;
+
+        assert_eq!(
+            response.status_code(),
+            409,
+            "{status} subscription should block account deletion"
+        );
+        let body: serde_json::Value = response.json();
+        assert!(body
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .contains("non-terminal subscription"));
+        assert!(db
+            .user_repository()
+            .get_user(user.id)
+            .await
+            .expect("get user after blocked delete")
+            .is_some());
+    }
+}
+
+#[tokio::test]
+async fn delete_account_allows_terminal_subscription_statuses() {
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
+    let client = db.pool().get().await.expect("db client");
+
+    for status in ["canceled", "incomplete_expired"] {
+        let email = format!(
+            "delete_account_{}_subscription_{}@test.org",
+            status,
+            Uuid::new_v4()
+        );
+        let token = mock_login(&server, &email).await;
+        let user = db
+            .user_repository()
+            .get_user_by_email(&email)
+            .await
+            .expect("get user")
+            .expect("user exists");
+        let subscription_id = format!("sub_delete_{}_{}", status, Uuid::new_v4());
+        let customer_id = format!("cus_delete_{}_{}", status, Uuid::new_v4());
+
+        client
+            .execute(
+                "INSERT INTO subscriptions (
+                    subscription_id, user_id, provider, customer_id, price_id, status,
+                    current_period_end, cancel_at_period_end
+                ) VALUES ($1, $2, 'stripe', $3, 'price_test', $4, NOW() - INTERVAL '1 day', false)",
+                &[&subscription_id, &user.id, &customer_id, &status],
+            )
+            .await
+            .expect("insert terminal subscription");
+
+        let (name, value) = auth_header(&token);
+        let response = server.delete("/v1/users/me").add_header(name, value).await;
+        assert_eq!(
+            response.status_code(),
+            202,
+            "{status} subscription should allow account deletion"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/database/src/repositories/user_repository.rs
+++ b/crates/database/src/repositories/user_repository.rs
@@ -38,19 +38,21 @@ impl PostgresUserRepository {
             return Err(AccountDeletionError::UserNotFound);
         }
 
-        let active_subscription_count: i64 = client
+        // Only known terminal Stripe subscription states are safe to ignore.
+        let blocking_subscription_count: i64 = client
             .query_one(
                 "SELECT COUNT(*)
                  FROM subscriptions
-                 WHERE user_id = $1 AND status IN ('active', 'trialing')",
+                 WHERE user_id = $1
+                   AND status NOT IN ('canceled', 'incomplete_expired')",
                 &[&user_id],
             )
             .await
             .map_err(anyhow::Error::from)?
             .get(0);
-        if active_subscription_count > 0 {
-            return Err(AccountDeletionError::ActiveSubscriptions {
-                count: active_subscription_count,
+        if blocking_subscription_count > 0 {
+            return Err(AccountDeletionError::BlockingSubscriptions {
+                count: blocking_subscription_count,
             });
         }
 

--- a/crates/services/src/user/ports.rs
+++ b/crates/services/src/user/ports.rs
@@ -131,8 +131,8 @@ pub struct AccountDeletionRequestResult {
 pub enum AccountDeletionError {
     #[error("User not found")]
     UserNotFound,
-    #[error("Cannot delete account while active subscriptions exist")]
-    ActiveSubscriptions { count: i64 },
+    #[error("Cannot delete account while non-terminal subscriptions exist")]
+    BlockingSubscriptions { count: i64 },
     #[error("Cannot delete account while instances are not deleted")]
     InstancesNotDeleted { count: i64, statuses: Vec<String> },
     #[error("Cannot delete account because conversation cleanup is incomplete")]


### PR DESCRIPTION
## Summary
- block account deletion when any non-terminal subscription exists
- treat only canceled and incomplete_expired subscriptions as terminal for deletion preconditions
- update API/worker policy error naming and account deletion coverage

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings

Tests are left to CI per request.