### PR TITLE
fix: block proxy path traversal

### DIFF
--- a/crates/api/src/routes/api.rs
+++ b/crates/api/src/routes/api.rs
@@ -238,19 +238,12 @@ pub struct ErrorResponse {
 fn validate_proxy_path_segment(value: &str, field_name: &str) -> Result<(), Response> {
     validate_proxy_path_segment_variant(value, field_name)?;
 
-    let mut decoded = value.to_string();
-    for _ in 0..3 {
-        let next = urlencoding::decode(&decoded)
-            .map_err(|_| invalid_proxy_path_segment_response(field_name))?
-            .into_owned();
-
-        if next == decoded {
-            break;
-        }
-
-        validate_proxy_path_segment_variant(&next, field_name)?;
-        decoded = next;
+    let decoded =
+        urlencoding::decode(value).map_err(|_| invalid_proxy_path_segment_response(field_name))?;
+    if decoded.contains('%') {
+        return Err(invalid_proxy_path_segment_response(field_name));
     }
+    validate_proxy_path_segment_variant(&decoded, field_name)?;
 
     Ok(())
 }

--- a/crates/api/src/routes/api.rs
+++ b/crates/api/src/routes/api.rs
@@ -235,6 +235,52 @@ pub struct ErrorResponse {
     pub error: String,
 }
 
+fn validate_proxy_path_segment(value: &str, field_name: &str) -> Result<(), Response> {
+    validate_proxy_path_segment_variant(value, field_name)?;
+
+    let mut decoded = value.to_string();
+    for _ in 0..3 {
+        let next = urlencoding::decode(&decoded)
+            .map_err(|_| invalid_proxy_path_segment_response(field_name))?
+            .into_owned();
+
+        if next == decoded {
+            break;
+        }
+
+        validate_proxy_path_segment_variant(&next, field_name)?;
+        decoded = next;
+    }
+
+    Ok(())
+}
+
+fn validate_proxy_path_segment_variant(value: &str, field_name: &str) -> Result<(), Response> {
+    if value.is_empty()
+        || value == "."
+        || value == ".."
+        || value.contains('/')
+        || value.contains('\\')
+        || value.contains('?')
+        || value.contains('#')
+        || value.chars().any(char::is_control)
+    {
+        return Err(invalid_proxy_path_segment_response(field_name));
+    }
+
+    Ok(())
+}
+
+fn invalid_proxy_path_segment_response(field_name: &str) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse {
+            error: format!("Invalid {field_name}: unsafe path segment"),
+        }),
+    )
+        .into_response()
+}
+
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct ShareRecipientPayload {
     pub kind: ShareRecipientKind,
@@ -2073,6 +2119,8 @@ async fn get_file(
     Extension(user): Extension<AuthenticatedUser>,
     Path(file_id): Path<String>,
 ) -> Result<Json<crate::models::FileGetResponse>, Response> {
+    validate_proxy_path_segment(&file_id, "file_id")?;
+
     tracing::info!(
         "get_file called for user_id={}, file_id={}",
         user.user_id,
@@ -2124,6 +2172,8 @@ async fn delete_file(
     Extension(user): Extension<AuthenticatedUser>,
     Path(file_id): Path<String>,
 ) -> Result<Response, Response> {
+    validate_proxy_path_segment(&file_id, "file_id")?;
+
     tracing::info!(
         "delete_file called for user_id={}, file_id={}",
         user.user_id,
@@ -3011,6 +3061,8 @@ async fn proxy_signature(
     Path(chat_id): Path<String>,
     headers: HeaderMap,
 ) -> Result<Response, Response> {
+    validate_proxy_path_segment(&chat_id, "chat_id")?;
+
     tracing::info!(
         "proxy_signature: GET /v1/signature/{} for user_id={}, session_id={}",
         chat_id,
@@ -4716,6 +4768,8 @@ async fn validate_user_conversation(
     conversation_id: &str,
     required_permission: SharePermission,
 ) -> Result<(), Response> {
+    validate_proxy_path_segment(conversation_id, "conversation_id")?;
+
     state
         .conversation_share_service
         .ensure_access(conversation_id, user.user_id, required_permission)
@@ -4730,6 +4784,8 @@ async fn validate_user_or_public_conversation(
     conversation_id: &str,
     required_permission: SharePermission,
 ) -> Result<(), Response> {
+    validate_proxy_path_segment(conversation_id, "conversation_id")?;
+
     // First check regular access
     let user_access = state
         .conversation_share_service
@@ -4758,6 +4814,8 @@ async fn validate_conversation_access_optional_auth(
     conversation_id: &str,
     required_permission: SharePermission,
 ) -> Result<(), Response> {
+    validate_proxy_path_segment(conversation_id, "conversation_id")?;
+
     if let Some(user) = user {
         // User is authenticated - check their access or public share
         validate_user_or_public_conversation(state, user, conversation_id, required_permission)
@@ -4778,6 +4836,8 @@ async fn validate_owner_conversation(
     user: &AuthenticatedUser,
     conversation_id: &str,
 ) -> Result<(), Response> {
+    validate_proxy_path_segment(conversation_id, "conversation_id")?;
+
     state
         .conversation_service
         .access_conversation(conversation_id, user.user_id)
@@ -4819,6 +4879,8 @@ async fn fetch_conversation_from_proxy(
     conversation_id: &str,
     headers: HeaderMap,
 ) -> Result<serde_json::Value, Response> {
+    validate_proxy_path_segment(conversation_id, "conversation_id")?;
+
     fn bad_gateway(message: impl Into<String>) -> Response {
         (
             StatusCode::BAD_GATEWAY,
@@ -4878,6 +4940,8 @@ async fn validate_user_file(
     user: &AuthenticatedUser,
     file_id: &str,
 ) -> Result<(), Response> {
+    validate_proxy_path_segment(file_id, "file_id")?;
+
     state
         .file_service
         .access_file(file_id, user.user_id)
@@ -5313,7 +5377,7 @@ async fn collect_stream_to_bytes(
 
 #[cfg(test)]
 mod tests {
-    use super::decompress_if_encoded;
+    use super::{decompress_if_encoded, validate_proxy_path_segment};
     use bytes::Bytes;
     use flate2::{write::DeflateEncoder, write::GzEncoder, write::ZlibEncoder, Compression};
     use http::{HeaderMap, HeaderValue};
@@ -5357,6 +5421,38 @@ mod tests {
 
     fn zstd_encode(input: &[u8]) -> Vec<u8> {
         zstd::stream::encode_all(input, 1).unwrap()
+    }
+
+    #[test]
+    fn validates_safe_proxy_path_segments() {
+        for value in ["conv_abc123", "file-abc_123", "Qwen3.5-122B-A10B"] {
+            assert!(
+                validate_proxy_path_segment(value, "id").is_ok(),
+                "segment should be accepted: {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_proxy_path_segment_breakouts() {
+        for value in [
+            "",
+            ".",
+            "..",
+            "../files",
+            "..%2Ffiles",
+            "%2e%2e%2ffiles",
+            "%252e%252e%252ffiles",
+            "abc%2Fdef",
+            "abc%5Cdef",
+            "abc%3Fadmin=true",
+            "abc#fragment",
+        ] {
+            assert!(
+                validate_proxy_path_segment(value, "id").is_err(),
+                "segment should be rejected: {value}"
+            );
+        }
     }
 
     #[test]

--- a/crates/api/src/routes/api.rs
+++ b/crates/api/src/routes/api.rs
@@ -235,20 +235,22 @@ pub struct ErrorResponse {
     pub error: String,
 }
 
-fn validate_proxy_path_segment(value: &str, field_name: &str) -> Result<(), Response> {
-    validate_proxy_path_segment_variant(value, field_name)?;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct InvalidProxyPathSegment;
 
-    let decoded =
-        urlencoding::decode(value).map_err(|_| invalid_proxy_path_segment_response(field_name))?;
+fn validate_proxy_path_segment(value: &str) -> Result<(), InvalidProxyPathSegment> {
+    validate_proxy_path_segment_variant(value)?;
+
+    let decoded = urlencoding::decode(value).map_err(|_| InvalidProxyPathSegment)?;
     if decoded.contains('%') {
-        return Err(invalid_proxy_path_segment_response(field_name));
+        return Err(InvalidProxyPathSegment);
     }
-    validate_proxy_path_segment_variant(&decoded, field_name)?;
+    validate_proxy_path_segment_variant(&decoded)?;
 
     Ok(())
 }
 
-fn validate_proxy_path_segment_variant(value: &str, field_name: &str) -> Result<(), Response> {
+fn validate_proxy_path_segment_variant(value: &str) -> Result<(), InvalidProxyPathSegment> {
     if value.is_empty()
         || value == "."
         || value == ".."
@@ -258,7 +260,7 @@ fn validate_proxy_path_segment_variant(value: &str, field_name: &str) -> Result<
         || value.contains('#')
         || value.chars().any(char::is_control)
     {
-        return Err(invalid_proxy_path_segment_response(field_name));
+        return Err(InvalidProxyPathSegment);
     }
 
     Ok(())
@@ -2112,7 +2114,8 @@ async fn get_file(
     Extension(user): Extension<AuthenticatedUser>,
     Path(file_id): Path<String>,
 ) -> Result<Json<crate::models::FileGetResponse>, Response> {
-    validate_proxy_path_segment(&file_id, "file_id")?;
+    validate_proxy_path_segment(&file_id)
+        .map_err(|_| invalid_proxy_path_segment_response("file_id"))?;
 
     tracing::info!(
         "get_file called for user_id={}, file_id={}",
@@ -2165,7 +2168,8 @@ async fn delete_file(
     Extension(user): Extension<AuthenticatedUser>,
     Path(file_id): Path<String>,
 ) -> Result<Response, Response> {
-    validate_proxy_path_segment(&file_id, "file_id")?;
+    validate_proxy_path_segment(&file_id)
+        .map_err(|_| invalid_proxy_path_segment_response("file_id"))?;
 
     tracing::info!(
         "delete_file called for user_id={}, file_id={}",
@@ -3054,7 +3058,8 @@ async fn proxy_signature(
     Path(chat_id): Path<String>,
     headers: HeaderMap,
 ) -> Result<Response, Response> {
-    validate_proxy_path_segment(&chat_id, "chat_id")?;
+    validate_proxy_path_segment(&chat_id)
+        .map_err(|_| invalid_proxy_path_segment_response("chat_id"))?;
 
     tracing::info!(
         "proxy_signature: GET /v1/signature/{} for user_id={}, session_id={}",
@@ -4761,7 +4766,8 @@ async fn validate_user_conversation(
     conversation_id: &str,
     required_permission: SharePermission,
 ) -> Result<(), Response> {
-    validate_proxy_path_segment(conversation_id, "conversation_id")?;
+    validate_proxy_path_segment(conversation_id)
+        .map_err(|_| invalid_proxy_path_segment_response("conversation_id"))?;
 
     state
         .conversation_share_service
@@ -4777,7 +4783,8 @@ async fn validate_user_or_public_conversation(
     conversation_id: &str,
     required_permission: SharePermission,
 ) -> Result<(), Response> {
-    validate_proxy_path_segment(conversation_id, "conversation_id")?;
+    validate_proxy_path_segment(conversation_id)
+        .map_err(|_| invalid_proxy_path_segment_response("conversation_id"))?;
 
     // First check regular access
     let user_access = state
@@ -4807,7 +4814,8 @@ async fn validate_conversation_access_optional_auth(
     conversation_id: &str,
     required_permission: SharePermission,
 ) -> Result<(), Response> {
-    validate_proxy_path_segment(conversation_id, "conversation_id")?;
+    validate_proxy_path_segment(conversation_id)
+        .map_err(|_| invalid_proxy_path_segment_response("conversation_id"))?;
 
     if let Some(user) = user {
         // User is authenticated - check their access or public share
@@ -4829,7 +4837,8 @@ async fn validate_owner_conversation(
     user: &AuthenticatedUser,
     conversation_id: &str,
 ) -> Result<(), Response> {
-    validate_proxy_path_segment(conversation_id, "conversation_id")?;
+    validate_proxy_path_segment(conversation_id)
+        .map_err(|_| invalid_proxy_path_segment_response("conversation_id"))?;
 
     state
         .conversation_service
@@ -4872,7 +4881,8 @@ async fn fetch_conversation_from_proxy(
     conversation_id: &str,
     headers: HeaderMap,
 ) -> Result<serde_json::Value, Response> {
-    validate_proxy_path_segment(conversation_id, "conversation_id")?;
+    validate_proxy_path_segment(conversation_id)
+        .map_err(|_| invalid_proxy_path_segment_response("conversation_id"))?;
 
     fn bad_gateway(message: impl Into<String>) -> Response {
         (
@@ -4933,7 +4943,8 @@ async fn validate_user_file(
     user: &AuthenticatedUser,
     file_id: &str,
 ) -> Result<(), Response> {
-    validate_proxy_path_segment(file_id, "file_id")?;
+    validate_proxy_path_segment(file_id)
+        .map_err(|_| invalid_proxy_path_segment_response("file_id"))?;
 
     state
         .file_service
@@ -5420,7 +5431,7 @@ mod tests {
     fn validates_safe_proxy_path_segments() {
         for value in ["conv_abc123", "file-abc_123", "Qwen3.5-122B-A10B"] {
             assert!(
-                validate_proxy_path_segment(value, "id").is_ok(),
+                validate_proxy_path_segment(value).is_ok(),
                 "segment should be accepted: {value}"
             );
         }
@@ -5442,7 +5453,7 @@ mod tests {
             "abc#fragment",
         ] {
             assert!(
-                validate_proxy_path_segment(value, "id").is_err(),
+                validate_proxy_path_segment(value).is_err(),
                 "segment should be rejected: {value}"
             );
         }

--- a/crates/services/src/response/service.rs
+++ b/crates/services/src/response/service.rs
@@ -49,19 +49,14 @@ fn validate_proxy_path(path: &str) -> Result<&str, ProxyError> {
 
     validate_proxy_path_variant(path_part)?;
 
-    let mut decoded = path_part.to_string();
-    for _ in 0..3 {
-        let next = urlencoding::decode(&decoded)
-            .map_err(|_| ProxyError::InvalidRequest("Proxy path is not valid URL encoding".into()))?
-            .into_owned();
-
-        if next == decoded {
-            break;
-        }
-
-        validate_proxy_path_variant(&next)?;
-        decoded = next;
+    let decoded = urlencoding::decode(path_part)
+        .map_err(|_| ProxyError::InvalidRequest("Proxy path is not valid URL encoding".into()))?;
+    if decoded.contains('%') {
+        return Err(ProxyError::InvalidRequest(
+            "Proxy path contains nested encoding".into(),
+        ));
     }
+    validate_proxy_path_variant(&decoded)?;
 
     Ok(clean_path)
 }

--- a/crates/services/src/response/service.rs
+++ b/crates/services/src/response/service.rs
@@ -28,6 +28,68 @@ impl OpenAIProxy {
     }
 }
 
+fn validate_proxy_path(path: &str) -> Result<&str, ProxyError> {
+    let clean_path = path.trim_start_matches('/');
+    if clean_path.is_empty() {
+        return Err(ProxyError::InvalidRequest(
+            "Proxy path cannot be empty".to_string(),
+        ));
+    }
+
+    if clean_path.contains('#') || clean_path.chars().any(char::is_control) {
+        return Err(ProxyError::InvalidRequest(
+            "Proxy path contains an unsafe delimiter".to_string(),
+        ));
+    }
+
+    let path_part = clean_path
+        .split_once('?')
+        .map(|(path_part, _)| path_part)
+        .unwrap_or(clean_path);
+
+    validate_proxy_path_variant(path_part)?;
+
+    let mut decoded = path_part.to_string();
+    for _ in 0..3 {
+        let next = urlencoding::decode(&decoded)
+            .map_err(|_| ProxyError::InvalidRequest("Proxy path is not valid URL encoding".into()))?
+            .into_owned();
+
+        if next == decoded {
+            break;
+        }
+
+        validate_proxy_path_variant(&next)?;
+        decoded = next;
+    }
+
+    Ok(clean_path)
+}
+
+fn validate_proxy_path_variant(path: &str) -> Result<(), ProxyError> {
+    if path.contains('\\') {
+        return Err(ProxyError::InvalidRequest(
+            "Proxy path cannot contain backslashes".to_string(),
+        ));
+    }
+
+    if path.contains('?') || path.contains('#') || path.chars().any(char::is_control) {
+        return Err(ProxyError::InvalidRequest(
+            "Proxy path contains an unsafe delimiter".to_string(),
+        ));
+    }
+
+    for segment in path.split('/') {
+        if segment.is_empty() || segment == "." || segment == ".." {
+            return Err(ProxyError::InvalidRequest(
+                "Proxy path contains an unsafe path segment".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 #[async_trait]
 impl OpenAIProxyService for OpenAIProxy {
     async fn forward_request(
@@ -37,15 +99,15 @@ impl OpenAIProxyService for OpenAIProxy {
         mut headers: HeaderMap,
         body: Option<Bytes>,
     ) -> Result<ProxyResponse, ProxyError> {
+        let clean_path = validate_proxy_path(path)?;
+
         // Get API key
         let api_key = self.vpc_service.get_api_key().await.map_err(|e| {
             tracing::error!("Failed to get API key: {}", e);
             ProxyError::ApiError("Failed to get API key".to_string())
         })?;
 
-        // Ensure path doesn't start with a slash
-        let clean_path = path.trim_start_matches('/');
-        let url = format!("{}/{}", self.base_url, clean_path);
+        let url = format!("{}/{}", self.base_url.trim_end_matches('/'), clean_path);
 
         tracing::info!("OpenAI Proxy: Forwarding request {} to {}", method, url);
 
@@ -129,5 +191,70 @@ mod tests {
         let service =
             OpenAIProxy::new(vpc_service).with_base_url("https://custom.api.com/v1".to_string());
         assert_eq!(service.base_url, "https://custom.api.com/v1");
+    }
+
+    #[test]
+    fn validate_proxy_path_allows_normal_paths_and_encoded_model_names() {
+        assert_eq!(
+            validate_proxy_path("chat/completions").unwrap(),
+            "chat/completions"
+        );
+        assert_eq!(
+            validate_proxy_path("/model/Qwen%2FQwen3.5-122B-A10B").unwrap(),
+            "model/Qwen%2FQwen3.5-122B-A10B"
+        );
+        assert_eq!(
+            validate_proxy_path("attestation/report?nonce=abc123").unwrap(),
+            "attestation/report?nonce=abc123"
+        );
+    }
+
+    #[test]
+    fn validate_proxy_path_rejects_raw_traversal() {
+        assert!(matches!(
+            validate_proxy_path("signature/../files"),
+            Err(ProxyError::InvalidRequest(_))
+        ));
+        assert!(matches!(
+            validate_proxy_path("signature/./files"),
+            Err(ProxyError::InvalidRequest(_))
+        ));
+    }
+
+    #[test]
+    fn validate_proxy_path_rejects_encoded_traversal() {
+        for path in [
+            "signature/..%2Ffiles",
+            "signature/%2e%2e%2ffiles",
+            "signature/%252e%252e%252ffiles",
+            "signature/%2e%2e%5cfiles",
+            "signature/%2e%2e%3Ftarget=files",
+        ] {
+            assert!(
+                matches!(
+                    validate_proxy_path(path),
+                    Err(ProxyError::InvalidRequest(_))
+                ),
+                "path should be rejected: {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_proxy_path_rejects_ambiguous_paths() {
+        for path in [
+            "",
+            "files//content",
+            "signature/..\\files",
+            "files/abc#frag",
+        ] {
+            assert!(
+                matches!(
+                    validate_proxy_path(path),
+                    Err(ProxyError::InvalidRequest(_))
+                ),
+                "path should be rejected: {path}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add centralized proxy path validation to reject raw, encoded, and double-encoded traversal segments before forwarding upstream
- add generic dynamic path segment validation for signature, conversation, and file IDs without tying checks to business-specific ID prefixes
- preserve legitimate proxy paths that use encoded model names or query strings such as attestation reports

## Tests
- cargo test -p services response::service::tests -- --nocapture
- cargo test -p api routes::api::tests:: --lib -- --nocapture
- cargo check -p api --lib

Note: full `cargo check -p api` is currently blocked by existing `task_worker` bin error: `TaskConfig::worker_sqs_queue_url()` is missing.