### PR TITLE
fix: oauth frontend callback validation

### DIFF
--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -51,6 +51,22 @@ async fn main() -> anyhow::Result<()> {
     }
 
     tracing::info!("Starting API server...");
+    let frontend_callback_allowed_origins = api::routes::oauth::frontend_callback_allowed_origins();
+    match frontend_callback_allowed_origins.as_ref() {
+        Some(origins)
+            if origins.is_empty()
+                && (!config.oauth.google_client_id.is_empty()
+                    || !config.oauth.github_client_id.is_empty()) =>
+        {
+            anyhow::bail!("FRONTEND_CALLBACK_ALLOWED_ORIGINS is set but contains no valid origins");
+        }
+        None => {
+            tracing::warn!(
+                "FRONTEND_CALLBACK_ALLOWED_ORIGINS is not set; OAuth frontend callback origins are unrestricted"
+            );
+        }
+        _ => {}
+    }
 
     tracing::info!(
         "Database: {}:{}/{}",
@@ -356,6 +372,7 @@ async fn main() -> anyhow::Result<()> {
         agent_repository: agent_repo,
         agent_proxy_service,
         redirect_uri: config.oauth.redirect_uri,
+        frontend_callback_allowed_origins: frontend_callback_allowed_origins.map(Arc::new),
         admin_domains: Arc::new(config.admin.admin_domains),
         user_repository: user_repo.clone(),
         vpc_credentials_service,

--- a/crates/api/src/routes/oauth.rs
+++ b/crates/api/src/routes/oauth.rs
@@ -18,9 +18,41 @@ use services::metrics::consts::{
     METRIC_USER_LOGIN, METRIC_USER_SIGNUP, TAG_AUTH_METHOD, TAG_IS_NEW_USER,
 };
 use services::SessionId;
+use std::collections::HashSet;
 use std::convert::Infallible;
 use std::net::{IpAddr, SocketAddr};
+use url::{Host, Url};
 use utoipa::ToSchema;
+
+const FRONTEND_CALLBACK_ALLOWED_ORIGINS_ENV: &str = "FRONTEND_CALLBACK_ALLOWED_ORIGINS";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FrontendCallbackValidationError {
+    Malformed,
+    UnsupportedScheme,
+    MissingHost,
+    CredentialsNotAllowed,
+    QueryOrFragmentNotAllowed,
+    Insecure,
+    UntrustedOrigin,
+}
+
+impl std::fmt::Display for FrontendCallbackValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::Malformed => "malformed URL",
+            Self::UnsupportedScheme => "unsupported URL scheme",
+            Self::MissingHost => "missing URL host",
+            Self::CredentialsNotAllowed => "credentials are not allowed in callback URLs",
+            Self::QueryOrFragmentNotAllowed => {
+                "query strings and fragments are not allowed in callback URLs"
+            }
+            Self::Insecure => "callback URL must use HTTPS",
+            Self::UntrustedOrigin => "callback URL origin is not allowlisted",
+        };
+        f.write_str(message)
+    }
+}
 
 pub struct OptionalConnectInfo<T>(Option<T>);
 
@@ -59,6 +91,152 @@ fn try_add_gateway_cookie(headers: &mut HeaderMap, cookie: Option<String>, conte
             context
         );
     }
+}
+
+pub fn frontend_callback_allowed_origins() -> Option<Vec<String>> {
+    frontend_callback_allowed_origins_from(
+        std::env::var(FRONTEND_CALLBACK_ALLOWED_ORIGINS_ENV)
+            .ok()
+            .as_deref(),
+    )
+}
+
+fn frontend_callback_allowed_origins_from(configured_origins: Option<&str>) -> Option<Vec<String>> {
+    let raw_origins = configured_origins?;
+    let mut origins = Vec::new();
+    let mut seen = HashSet::new();
+
+    for origin in raw_origins
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        match validate_frontend_origin(origin) {
+            Ok(url) => insert_origin(&mut origins, &mut seen, &url),
+            Err(err) => tracing::warn!(
+                "Ignoring invalid {FRONTEND_CALLBACK_ALLOWED_ORIGINS_ENV} entry '{origin}': {err}"
+            ),
+        }
+    }
+
+    Some(origins)
+}
+
+fn validate_frontend_callback_url(
+    raw_url: &str,
+    allowed_origins: Option<&[String]>,
+) -> Result<String, FrontendCallbackValidationError> {
+    if let Some(origins) = allowed_origins {
+        if origins.is_empty() {
+            return Err(FrontendCallbackValidationError::UntrustedOrigin);
+        }
+    }
+
+    validate_frontend_url(raw_url, allowed_origins.unwrap_or(&[]))
+        .map(|url| trim_trailing_slash(url.as_str()))
+}
+
+fn build_oauth_frontend_redirect(
+    frontend_base_url: &str,
+    token: &str,
+    session_id: &str,
+    expires_at: &str,
+    is_new_user: bool,
+) -> Result<String, url::ParseError> {
+    let mut url = Url::parse(frontend_base_url)?;
+    let base_path = url.path().trim_end_matches('/');
+    let callback_path = if base_path.is_empty() {
+        "/auth/callback".to_string()
+    } else {
+        format!("{base_path}/auth/callback")
+    };
+
+    url.set_path(&callback_path);
+    url.query_pairs_mut()
+        .clear()
+        .append_pair("token", token)
+        .append_pair("session_id", session_id)
+        .append_pair("expires_at", expires_at);
+
+    if is_new_user {
+        url.query_pairs_mut().append_pair("is_new_user", "true");
+    }
+
+    Ok(url.to_string())
+}
+
+fn validate_frontend_origin(raw_url: &str) -> Result<Url, FrontendCallbackValidationError> {
+    let url = validate_frontend_url(raw_url, &[])?;
+    if !url.path().is_empty() && url.path() != "/" {
+        return Err(FrontendCallbackValidationError::Malformed);
+    }
+    Ok(url)
+}
+
+fn validate_frontend_url(
+    raw_url: &str,
+    allowed_origins: &[String],
+) -> Result<Url, FrontendCallbackValidationError> {
+    let url = Url::parse(raw_url.trim()).map_err(|_| FrontendCallbackValidationError::Malformed)?;
+
+    match url.scheme() {
+        "http" | "https" => {}
+        _ => return Err(FrontendCallbackValidationError::UnsupportedScheme),
+    }
+
+    if url.host().is_none() {
+        return Err(FrontendCallbackValidationError::MissingHost);
+    }
+
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(FrontendCallbackValidationError::CredentialsNotAllowed);
+    }
+
+    if url.query().is_some() || url.fragment().is_some() {
+        return Err(FrontendCallbackValidationError::QueryOrFragmentNotAllowed);
+    }
+
+    if url.scheme() != "https" && !is_loopback_http_url(&url) {
+        return Err(FrontendCallbackValidationError::Insecure);
+    }
+
+    if !allowed_origins.is_empty()
+        && !allowed_origins
+            .iter()
+            .any(|origin| origin == &url_origin(&url))
+    {
+        return Err(FrontendCallbackValidationError::UntrustedOrigin);
+    }
+
+    Ok(url)
+}
+
+fn is_loopback_http_url(url: &Url) -> bool {
+    if url.scheme() != "http" {
+        return false;
+    }
+
+    match url.host() {
+        Some(Host::Domain(domain)) => domain.eq_ignore_ascii_case("localhost"),
+        Some(Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(Host::Ipv6(ip)) => IpAddr::V6(ip).is_loopback(),
+        None => false,
+    }
+}
+
+fn insert_origin(origins: &mut Vec<String>, seen: &mut HashSet<String>, url: &Url) {
+    let origin = url_origin(url);
+    if seen.insert(origin.clone()) {
+        origins.push(origin);
+    }
+}
+
+fn url_origin(url: &Url) -> String {
+    url.origin().ascii_serialization()
+}
+
+fn trim_trailing_slash(value: &str) -> String {
+    value.trim_end_matches('/').to_string()
 }
 
 /// Request body for email OTP code request
@@ -275,7 +453,24 @@ pub struct OAuthCallbackQuery {
 #[derive(Debug, Deserialize)]
 pub struct OAuthInitQuery {
     pub redirect_uri: Option<String>,
-    pub frontend_callback: Option<String>,
+    pub frontend_callback: String,
+}
+
+fn validate_oauth_frontend_callback(
+    frontend_callback: &str,
+    app_state: &AppState,
+) -> Result<String, ApiError> {
+    validate_frontend_callback_url(
+        frontend_callback,
+        app_state
+            .frontend_callback_allowed_origins
+            .as_deref()
+            .map(|origins| origins.as_slice()),
+    )
+    .map_err(|err| {
+        tracing::warn!("Rejected OAuth frontend_callback: {}", err);
+        ApiError::bad_request("Invalid frontend_callback")
+    })
 }
 
 /// Request body for logout
@@ -547,7 +742,7 @@ pub async fn verify_email_code(
     tag = "Auth",
     params(
         ("redirect_uri" = Option<String>, Query, description = "Optional OAuth redirect URI (usually your API callback)"),
-        ("frontend_callback" = Option<String>, Query, description = "Frontend URL to redirect to after authentication")
+        ("frontend_callback" = String, Query, description = "Required frontend URL to redirect to after authentication")
     ),
     responses(
         (status = 302, description = "Redirect to Google OAuth"),
@@ -559,15 +754,16 @@ pub async fn google_login(
     Query(params): Query<OAuthInitQuery>,
 ) -> Result<Redirect, ApiError> {
     tracing::info!(
-        "Google OAuth login initiated - redirect_uri: {:?}, frontend_callback: {:?}",
+        "Google OAuth login initiated - redirect_uri: {:?}, frontend_callback_provided=true",
         params.redirect_uri,
-        params.frontend_callback
     );
 
     let redirect_uri = params
         .redirect_uri
         .clone()
         .unwrap_or_else(|| format!("{}/v1/auth/callback", app_state.redirect_uri));
+    let frontend_callback =
+        validate_oauth_frontend_callback(&params.frontend_callback, &app_state)?;
 
     tracing::debug!("Using OAuth redirect_uri: {}", redirect_uri);
 
@@ -576,7 +772,7 @@ pub async fn google_login(
         .get_authorization_url(
             services::auth::ports::OAuthProvider::Google,
             redirect_uri.clone(),
-            params.frontend_callback.clone(),
+            Some(frontend_callback),
         )
         .await
         .map_err(|e| {
@@ -703,31 +899,44 @@ pub async fn oauth_callback(
     let mut headers = HeaderMap::new();
     try_add_gateway_cookie(&mut headers, gateway_cookie, "oauth_callback");
 
-    // Use frontend_callback from OAuth state, or fall back to FRONTEND_URL env var
-    let frontend_url = frontend_callback.clone().unwrap_or_else(|| {
-        let fallback =
-            std::env::var("FRONTEND_URL").unwrap_or_else(|_| "http://localhost:3000".to_string());
-        tracing::debug!(
-            "No frontend_callback in OAuth state, using fallback: {}",
-            fallback
-        );
-        fallback
-    });
+    // Use the validated frontend_callback from OAuth state as the only redirect destination.
+    let frontend_url = match frontend_callback.as_deref() {
+        Some(callback) => {
+            match validate_frontend_callback_url(
+                callback,
+                app_state
+                    .frontend_callback_allowed_origins
+                    .as_deref()
+                    .map(|origins| origins.as_slice()),
+            ) {
+                Ok(validated) => validated,
+                Err(err) => {
+                    tracing::warn!("Stored OAuth frontend_callback is invalid: {}", err);
+                    return Err(ApiError::bad_request("Invalid frontend_callback"));
+                }
+            }
+        }
+        None => {
+            tracing::warn!("OAuth state is missing frontend_callback");
+            return Err(ApiError::bad_request("frontend_callback is required"));
+        }
+    };
 
-    tracing::info!("Redirecting to frontend: {}", frontend_url);
+    tracing::info!("Redirecting to validated OAuth frontend callback");
 
-    let mut callback_url = format!(
-        "{}/auth/callback?token={}&session_id={}&expires_at={}",
-        frontend_url,
-        urlencoding::encode(&token),
-        urlencoding::encode(&session.session_id.to_string()),
-        urlencoding::encode(&session.expires_at.to_rfc3339())
-    );
-    if is_new_user {
-        callback_url.push_str("&is_new_user=true");
-    }
+    let callback_url = build_oauth_frontend_redirect(
+        &frontend_url,
+        &token,
+        &session.session_id.to_string(),
+        &session.expires_at.to_rfc3339(),
+        is_new_user,
+    )
+    .map_err(|err| {
+        tracing::error!("Failed to build OAuth frontend callback URL: {}", err);
+        ApiError::internal_server_error("Invalid callback URL")
+    })?;
 
-    tracing::debug!("Final callback URL: {}", callback_url);
+    tracing::debug!("OAuth frontend callback URL built successfully");
     headers.insert(
         LOCATION,
         callback_url.parse().map_err(|_| {
@@ -746,7 +955,7 @@ pub async fn oauth_callback(
     tag = "Auth",
     params(
         ("redirect_uri" = Option<String>, Query, description = "Optional OAuth redirect URI (usually your API callback)"),
-        ("frontend_callback" = Option<String>, Query, description = "Frontend URL to redirect to after authentication")
+        ("frontend_callback" = String, Query, description = "Required frontend URL to redirect to after authentication")
     ),
     responses(
         (status = 302, description = "Redirect to Github OAuth"),
@@ -758,15 +967,16 @@ pub async fn github_login(
     Query(params): Query<OAuthInitQuery>,
 ) -> Result<Redirect, ApiError> {
     tracing::info!(
-        "Github OAuth login initiated - redirect_uri: {:?}, frontend_callback: {:?}",
+        "Github OAuth login initiated - redirect_uri: {:?}, frontend_callback_provided=true",
         params.redirect_uri,
-        params.frontend_callback
     );
 
     let redirect_uri = params
         .redirect_uri
         .clone()
         .unwrap_or_else(|| format!("{}/v1/auth/callback", app_state.redirect_uri));
+    let frontend_callback =
+        validate_oauth_frontend_callback(&params.frontend_callback, &app_state)?;
 
     tracing::debug!("Using OAuth redirect_uri: {}", redirect_uri);
 
@@ -775,7 +985,7 @@ pub async fn github_login(
         .get_authorization_url(
             services::auth::ports::OAuthProvider::Github,
             redirect_uri.clone(),
-            params.frontend_callback.clone(),
+            Some(frontend_callback),
         )
         .await
         .map_err(|e| {
@@ -1168,9 +1378,122 @@ pub fn create_oauth_router() -> Router<AppState> {
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_client_ip, select_proxy_chain_ip};
+    use super::{
+        build_oauth_frontend_redirect, extract_client_ip, frontend_callback_allowed_origins_from,
+        select_proxy_chain_ip, validate_frontend_callback_url, FrontendCallbackValidationError,
+    };
     use axum::http::{HeaderMap, HeaderValue};
     use std::net::{IpAddr, SocketAddr};
+
+    fn allowlist() -> Vec<String> {
+        vec![
+            "https://app.near.ai".to_string(),
+            "http://localhost:3000".to_string(),
+        ]
+    }
+
+    #[test]
+    fn validates_https_callback_on_allowlisted_origin() {
+        let callback =
+            validate_frontend_callback_url("https://app.near.ai/app/", Some(&allowlist())).unwrap();
+        assert_eq!(callback, "https://app.near.ai/app");
+    }
+
+    #[test]
+    fn rejects_untrusted_callback_origin() {
+        let err = validate_frontend_callback_url("https://evil.example/auth", Some(&allowlist()))
+            .unwrap_err();
+        assert_eq!(err, FrontendCallbackValidationError::UntrustedOrigin);
+    }
+
+    #[test]
+    fn allows_any_origin_when_allowlist_is_unset() {
+        let callback = validate_frontend_callback_url("https://staging.example.dev", None).unwrap();
+        assert_eq!(callback, "https://staging.example.dev");
+    }
+
+    #[test]
+    fn rejects_callbacks_when_allowlist_is_explicitly_empty() {
+        let err = validate_frontend_callback_url("https://app.near.ai", Some(&[])).unwrap_err();
+        assert_eq!(err, FrontendCallbackValidationError::UntrustedOrigin);
+    }
+
+    #[test]
+    fn rejects_insecure_remote_callback_even_when_allowlisted() {
+        let allowed = vec!["http://app.near.ai".to_string()];
+        let err = validate_frontend_callback_url("http://app.near.ai", Some(&allowed)).unwrap_err();
+        assert_eq!(err, FrontendCallbackValidationError::Insecure);
+    }
+
+    #[test]
+    fn allows_localhost_http_for_local_development() {
+        let callback =
+            validate_frontend_callback_url("http://localhost:3000", Some(&allowlist())).unwrap();
+        assert_eq!(callback, "http://localhost:3000");
+    }
+
+    #[test]
+    fn rejects_ambiguous_callback_urls() {
+        assert_eq!(
+            validate_frontend_callback_url("javascript:alert(1)", Some(&allowlist())).unwrap_err(),
+            FrontendCallbackValidationError::UnsupportedScheme
+        );
+        assert_eq!(
+            validate_frontend_callback_url("https://user@app.near.ai", Some(&allowlist()))
+                .unwrap_err(),
+            FrontendCallbackValidationError::CredentialsNotAllowed
+        );
+        assert_eq!(
+            validate_frontend_callback_url(
+                "https://app.near.ai?next=https://evil.example",
+                Some(&allowlist())
+            )
+            .unwrap_err(),
+            FrontendCallbackValidationError::QueryOrFragmentNotAllowed
+        );
+        assert_eq!(
+            validate_frontend_callback_url("https://app.near.ai#token", Some(&allowlist()))
+                .unwrap_err(),
+            FrontendCallbackValidationError::QueryOrFragmentNotAllowed
+        );
+    }
+
+    #[test]
+    fn builds_oauth_redirect_under_validated_frontend_base() {
+        let redirect = build_oauth_frontend_redirect(
+            "https://app.near.ai/app",
+            "tok en",
+            "session-1",
+            "2026-05-27T00:00:00Z",
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(
+            redirect,
+            "https://app.near.ai/app/auth/callback?token=tok+en&session_id=session-1&expires_at=2026-05-27T00%3A00%3A00Z&is_new_user=true"
+        );
+    }
+
+    #[test]
+    fn derives_allowed_origins_from_env_list() {
+        let origins = frontend_callback_allowed_origins_from(Some(
+            "https://admin.near.ai,ftp://bad.example,http://localhost:3000",
+        ));
+
+        assert_eq!(
+            origins,
+            Some(vec![
+                "https://admin.near.ai".to_string(),
+                "http://localhost:3000".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn unset_env_origin_list_disables_origin_restrictions() {
+        assert_eq!(frontend_callback_allowed_origins_from(None), None);
+    }
 
     #[test]
     fn select_proxy_chain_ip_uses_ip_before_trusted_suffix() {

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -61,6 +61,9 @@ pub struct AppState {
     pub agent_repository: Arc<dyn services::agent::ports::AgentRepository>,
     pub agent_proxy_service: Arc<dyn services::agent::AgentProxyService>,
     pub redirect_uri: String,
+    /// Exact frontend origins allowed for user-provided OAuth frontend callbacks.
+    /// None means origin restrictions are disabled.
+    pub frontend_callback_allowed_origins: Option<Arc<Vec<String>>>,
     pub admin_domains: Arc<Vec<String>>,
     pub vpc_credentials_service: Arc<dyn services::vpc::VpcCredentialsService>,
     /// Whether Stripe test clock feature is enabled

--- a/crates/api/tests/common.rs
+++ b/crates/api/tests/common.rs
@@ -335,6 +335,9 @@ pub async fn create_test_server_and_db(
         agent_repository: agent_repo,
         agent_proxy_service,
         redirect_uri: config.oauth.redirect_uri,
+        frontend_callback_allowed_origins: Some(Arc::new(
+            vec!["http://localhost:3000".to_string()],
+        )),
         admin_domains: Arc::new(admin_domains),
         stripe_test_clock_enabled: config.stripe.test_clock_enabled,
         cloud_api_base_url: test_config.cloud_api_base_url.clone(),

--- a/env.example
+++ b/env.example
@@ -54,8 +54,14 @@ REDIRECT_URI=http://localhost:8081
 # Example: near.ai,admin.org
 AUTH_ADMIN_DOMAINS=
 
-# Frontend URL (where to redirect users after authentication)
+# Frontend URL used by local development/frontends
 FRONTEND_URL=http://localhost:3000
+# Optional comma-separated exact bare origins allowed for user-provided OAuth frontend_callback.
+# If unset, callback origins are unrestricted; this is useful for staging frontend tests.
+# Entries must not include a path, query string, or fragment.
+# Remote callback origins must use HTTPS.
+# Example: https://app.yourdomain.com,https://admin.yourdomain.com
+FRONTEND_CALLBACK_ALLOWED_ORIGINS=http://localhost:3000
 
 # OpenAI/Cloud API Configuration
 # REQUIRED: API key for the NEAR AI Cloud. Get your API key at https://cloud-api.near.ai


### PR DESCRIPTION
## Summary

Fixes an open redirect risk in the OAuth flow by validating `frontend_callback` before it is stored in OAuth state and before it is used as a redirect destination.

The redirect validation is kept local to `oauth.rs` and now:
- requires `frontend_callback` for OAuth login initiation
- requires the callback origin to match `FRONTEND_CALLBACK_ALLOWED_ORIGINS`
- rejects malformed URLs, non-HTTP(S) schemes, credentials, query strings, fragments, empty allowlists, and untrusted origins
- requires HTTPS for remote origins while still allowing loopback HTTP for local development
- builds the final `/auth/callback` redirect with `url::Url` instead of string concatenation

## Impact

Clients initiating Google/GitHub OAuth must provide a trusted `frontend_callback`. Missing or invalid callbacks now fail closed instead of falling back to a server-side frontend URL.

## Validation

- `cargo test -p api --lib routes::oauth::tests`
- `cargo check -p api --bins`
