### PR TITLE
feat: add admin migration endpoints for legacy-to-CrabShack migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,12 +1369,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
-name = "bech32"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
-
-[[package]]
 name = "bip39"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5571,7 +5565,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bech32",
  "bytes",
  "chrono",
  "config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,6 +1369,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
+name = "bech32"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
 name = "bip39"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,6 +1894,7 @@ dependencies = [
  "fiat-crypto",
  "rustc_version 0.4.1",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5564,6 +5571,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bech32",
  "bytes",
  "chrono",
  "config",
@@ -5597,6 +5605,7 @@ dependencies = [
  "utoipa",
  "uuid",
  "wiremock",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -7308,6 +7317,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/api/src/models.rs
+++ b/crates/api/src/models.rs
@@ -989,6 +989,12 @@ pub struct InstanceResponse {
     /// Service type selected when creating the instance (e.g. "openclaw", "ironclaw")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_type: Option<String>,
+    /// Agent manager URL that owns this instance
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_api_base_url: Option<String>,
+    /// Last usage timestamp (from agent_balance table), RFC3339 format
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_usage_at: Option<String>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -1005,6 +1011,8 @@ impl From<services::agent::ports::AgentInstance> for InstanceResponse {
             status,
             ssh_command: None,
             service_type: inst.service_type,
+            agent_api_base_url: None,
+            last_usage_at: None,
             created_at: inst.created_at.to_rfc3339(),
             updated_at: inst.updated_at.to_rfc3339(),
         }
@@ -1029,16 +1037,26 @@ fn sanitize_dashboard_url(url: Option<String>) -> Option<String> {
 pub fn instance_response_for_admin(
     inst: services::agent::ports::AgentInstance,
 ) -> InstanceResponse {
+    instance_response_for_admin_with_usage(inst, None)
+}
+
+/// Build InstanceResponse for admin list endpoint with optional last_usage_at from agent_balance.
+pub fn instance_response_for_admin_with_usage(
+    inst: services::agent::ports::AgentInstance,
+    last_usage_at: Option<chrono::DateTime<chrono::Utc>>,
+) -> InstanceResponse {
     let status = status_from_db(&inst.status);
     InstanceResponse {
         id: inst.id.to_string(),
         instance_id: inst.instance_id,
+        agent_api_base_url: inst.agent_api_base_url,
         name: inst.name,
         public_ssh_key: inst.public_ssh_key,
         dashboard_url: sanitize_dashboard_url(inst.dashboard_url),
         status,
         ssh_command: None,
         service_type: inst.service_type,
+        last_usage_at: last_usage_at.map(|t| t.to_rfc3339()),
         created_at: inst.created_at.to_rfc3339(),
         updated_at: inst.updated_at.to_rfc3339(),
     }
@@ -1063,6 +1081,8 @@ pub fn instance_response_with_enrichment(
         status,
         ssh_command,
         service_type: inst.service_type,
+        agent_api_base_url: None,
+        last_usage_at: None,
         created_at: inst.created_at.to_rfc3339(),
         updated_at: inst.updated_at.to_rfc3339(),
     }

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3277,6 +3277,7 @@ pub struct MigrationStatusResponse {
     pub total: i64,
     pub migrated: i64,
     pub pending: i64,
+    pub no_url: i64,
     pub unknown: i64,
     pub failed: i64,
 }
@@ -3288,11 +3289,10 @@ pub async fn admin_migration_status(
 ) -> Result<Json<MigrationStatusResponse>, ApiError> {
     tracing::info!("Admin: Getting migration status");
 
-    // Legacy compose-api URLs contain "claws" or "sare.dev"; CrabShack URLs contain "agents.near.ai"
     let legacy_patterns = vec!["%claws%".to_string(), "%sare.dev%".to_string()];
     let crabshack_pattern = "%agents.near.ai%".to_string();
 
-    let (total, migrated, pending, unknown) = app_state
+    let (total, migrated, pending, no_url, unknown) = app_state
         .agent_repository
         .get_migration_status_counts(legacy_patterns, crabshack_pattern)
         .await
@@ -3305,8 +3305,9 @@ pub async fn admin_migration_status(
         total,
         migrated,
         pending,
+        no_url,
         unknown,
-        failed: 0, // derived from instance status in future iterations
+        failed: 0,
     }))
 }
 
@@ -3409,8 +3410,8 @@ pub async fn admin_migrate_instance(
         .as_deref()
         .ok_or_else(|| ApiError::bad_request("Instance has no instance_token"))?;
 
-    // Validate decrypted token is not still in encrypted format
-    if is_encrypted_format(instance_token) {
+    // If the token can still be decrypted, it wasn't decrypted by the repository layer
+    if database::encryption::decrypt(instance_token).is_ok() {
         return Err(ApiError::internal_server_error(
             "Instance token appears to still be encrypted after decryption",
         ));
@@ -3466,14 +3467,47 @@ pub async fn admin_migrate_instance(
         ApiError::internal_server_error("Failed to parse legacy instance metadata")
     })?;
 
+    // Preflight: extract required fields before any side effects (start/backup/stop).
+    // CrabShack's import validator rejects null values for these.
+    let ssh_pubkey = compose_data
+        .get("ssh_pubkey")
+        .and_then(|v| v.as_str())
+        .or(instance.public_ssh_key.as_deref())
+        .ok_or_else(|| ApiError::bad_request("Instance has no ssh_pubkey — cannot migrate"))?;
+    let nearai_api_key = compose_data
+        .get("nearai_api_key")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| ApiError::bad_request("Instance has no nearai_api_key — cannot migrate"))?;
+    let nearai_api_url = compose_data
+        .get("nearai_api_url")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| ApiError::bad_request("Instance has no nearai_api_url — cannot migrate"))?;
+    // Fallbacks match create_instance_from_agent_api defaults (service.rs unwrap_or values)
+    let image = compose_data
+        .get("image")
+        .and_then(|v| v.as_str())
+        .unwrap_or("docker.io/nearaidev/ironclaw-dind:latest");
+    let mem_limit = compose_data
+        .get("mem_limit")
+        .and_then(|v| v.as_str())
+        .unwrap_or("4g");
+    let cpus = compose_data
+        .get("cpus")
+        .and_then(|v| v.as_str())
+        .unwrap_or("1");
+    let storage_size = compose_data
+        .get("storage_size")
+        .and_then(|v| v.as_str())
+        .unwrap_or("10G");
+
     let compose_status = compose_data
         .get("status")
         .and_then(|v| v.as_str())
         .unwrap_or("unknown");
 
     // If instance is stopped, start it first (backup requires running instance)
-    let was_stopped = compose_status == "stopped" || compose_status == "exited";
-    if was_stopped {
+    let was_running = compose_status != "stopped" && compose_status != "exited";
+    if !was_running {
         tracing::info!(
             "Instance is stopped, starting before backup: instance_id={}",
             id
@@ -3525,12 +3559,13 @@ pub async fn admin_migrate_instance(
         .await
         .map_err(|e| {
             tracing::error!("Failed to create backup: instance_id={}, error={}", id, e);
-            maybe_restart_on_failure(
+            restore_on_failure(
                 &app_state,
                 compose_api_url,
                 &encoded_name,
                 &manager.token,
-                was_stopped,
+                was_running,
+                "stop",
             );
             ApiError::internal_server_error("Failed to initiate backup on legacy compose-api")
         })?;
@@ -3542,12 +3577,13 @@ pub async fn admin_migrate_instance(
             id,
             status
         );
-        maybe_restart_on_failure(
+        restore_on_failure(
             &app_state,
             compose_api_url,
             &encoded_name,
             &manager.token,
-            was_stopped,
+            was_running,
+            "stop",
         );
         return Err(ApiError::internal_server_error(
             "Failed to create backup on legacy compose-api",
@@ -3563,12 +3599,13 @@ pub async fn admin_migrate_instance(
                 id,
                 e
             );
-            maybe_restart_on_failure(
+            restore_on_failure(
                 &app_state,
                 compose_api_url,
                 &encoded_name,
                 &manager.token,
-                was_stopped,
+                was_running,
+                "stop",
             );
             return Err(ApiError::internal_server_error(
                 "Failed to get backup URL from legacy compose-api",
@@ -3586,49 +3623,43 @@ pub async fn admin_migrate_instance(
         .send()
         .await;
 
-    if let Err(e) = &stop_resp {
-        tracing::warn!(
-            "Failed to stop instance on compose-api (continuing): instance_id={}, error={}",
-            id,
-            e
-        );
-    } else if let Ok(resp) = &stop_resp {
-        if !resp.status().is_success() {
-            tracing::warn!(
-                "Compose-api stop returned non-success (continuing): instance_id={}, status={}",
+    let stop_failed = match &stop_resp {
+        Err(e) => {
+            tracing::error!(
+                "Failed to stop instance on compose-api: instance_id={}, error={}",
+                id,
+                e
+            );
+            true
+        }
+        Ok(resp) if !resp.status().is_success() => {
+            tracing::error!(
+                "Compose-api stop returned non-success: instance_id={}, status={}",
                 id,
                 resp.status()
             );
+            true
         }
+        _ => false,
+    };
+    if stop_failed {
+        restore_on_failure(
+            &app_state,
+            compose_api_url,
+            &encoded_name,
+            &manager.token,
+            was_running,
+            "stop",
+        );
+        return Err(ApiError::internal_server_error(
+            "Failed to stop legacy instance before import",
+        ));
     }
 
     // Import into CrabShack
     let service_type = instance.service_type.as_deref().unwrap_or("openclaw");
     let crabshack_service_type =
         services::agent::service::service_type_for_crabshack(service_type, None);
-
-    let ssh_pubkey = compose_data
-        .get("ssh_pubkey")
-        .and_then(|v| v.as_str())
-        .or(instance.public_ssh_key.as_deref());
-    let nearai_api_key = compose_data.get("nearai_api_key").and_then(|v| v.as_str());
-    let nearai_api_url = compose_data.get("nearai_api_url").and_then(|v| v.as_str());
-    let image = compose_data
-        .get("image")
-        .and_then(|v| v.as_str())
-        .unwrap_or("docker.io/nearaidev/ironclaw-dind:latest");
-    let mem_limit = compose_data
-        .get("mem_limit")
-        .and_then(|v| v.as_str())
-        .unwrap_or("4g");
-    let cpus = compose_data
-        .get("cpus")
-        .and_then(|v| v.as_str())
-        .unwrap_or("1");
-    let storage_size = compose_data
-        .get("storage_size")
-        .and_then(|v| v.as_str())
-        .unwrap_or("10G");
 
     // Store overwritten values in extra_env for rollback reference
     let extra_env = serde_json::json!({
@@ -3642,12 +3673,13 @@ pub async fn admin_migrate_instance(
         .find_crabshack_manager()
         .ok_or_else(|| {
             tracing::error!("No CrabShack manager configured for import");
-            maybe_restart_on_failure(
+            restore_on_failure(
                 &app_state,
                 compose_api_url,
                 &encoded_name,
                 &manager.token,
-                was_stopped,
+                was_running,
+                "start",
             );
             ApiError::internal_server_error("No CrabShack manager configured")
         })?;
@@ -3683,12 +3715,13 @@ pub async fn admin_migrate_instance(
                 id,
                 e
             );
-            maybe_restart_on_failure(
+            restore_on_failure(
                 &app_state,
                 compose_api_url,
                 &encoded_name,
                 &manager.token,
-                was_stopped,
+                was_running,
+                "start",
             );
             ApiError::internal_server_error("Failed to import into CrabShack")
         })?;
@@ -3700,18 +3733,19 @@ pub async fn admin_migrate_instance(
             id,
             status
         );
-        maybe_restart_on_failure(
+        restore_on_failure(
             &app_state,
             compose_api_url,
             &encoded_name,
             &manager.token,
-            was_stopped,
+            was_running,
+            "start",
         );
         return Err(ApiError::internal_server_error("CrabShack import failed"));
     }
 
-    // Parse CrabShack import SSE response for the new instance details
-    let import_data = match parse_sse_for_import_result(import_resp).await {
+    // Parse CrabShack import SSE to confirm completion (we don't use the data — URLs are constructed)
+    let _import_data = match parse_sse_for_import_result(import_resp).await {
         Ok(data) => data,
         Err(e) => {
             tracing::error!(
@@ -3719,12 +3753,13 @@ pub async fn admin_migrate_instance(
                 id,
                 e
             );
-            maybe_restart_on_failure(
+            restore_on_failure(
                 &app_state,
                 compose_api_url,
                 &encoded_name,
                 &manager.token,
-                was_stopped,
+                was_running,
+                "start",
             );
             return Err(ApiError::internal_server_error(
                 "Failed to parse CrabShack import response",
@@ -3732,18 +3767,21 @@ pub async fn admin_migrate_instance(
         }
     };
 
-    // Extract new URLs from CrabShack response
-    let new_instance_url = import_data
-        .get("url")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
-    let new_dashboard_url = import_data
-        .get("dashboard_url")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+    // Construct instance_url from CrabShack manager domain + instance name + token.
+    // CrabShack doesn't emit URLs — same pattern as the normal create flow (service.rs:1584-1597).
+    let new_instance_url = url::Url::parse(&crabshack_manager.url)
+        .ok()
+        .and_then(|u| u.host_str().map(|h| h.to_string()))
+        .map(|domain| {
+            format!(
+                "https://{}.{}/?token={}",
+                instance_name, domain, instance_token
+            )
+        });
+    let new_dashboard_url = new_instance_url.clone();
 
     // Update chat-api DB to point to CrabShack
-    let _updated = app_state
+    let db_update = app_state
         .agent_repository
         .admin_update_instance(
             id,
@@ -3752,15 +3790,24 @@ pub async fn admin_migrate_instance(
             None, // keep instance_token unchanged
             new_dashboard_url,
         )
-        .await
-        .map_err(|e| {
-            tracing::error!(
-                "Failed to update instance after migration: instance_id={}, error={}",
-                id,
-                e
-            );
-            ApiError::internal_server_error("Migration succeeded but failed to update DB")
-        })?;
+        .await;
+    if let Err(e) = db_update {
+        tracing::error!(
+            "Failed to update instance after migration: instance_id={}, crabshack_url={}, error={}. Restarting legacy instance.",
+            id, crabshack_manager.url, e
+        );
+        restore_on_failure(
+            &app_state,
+            compose_api_url,
+            &encoded_name,
+            &manager.token,
+            was_running,
+            "start",
+        );
+        return Err(ApiError::internal_server_error(
+            "Migration succeeded but failed to update DB — legacy instance restarted",
+        ));
+    }
 
     tracing::info!(
         "Migration completed: instance_id={}, instance_name={}",
@@ -3773,21 +3820,6 @@ pub async fn admin_migrate_instance(
         instance_name,
         message: "Instance migrated to CrabShack".to_string(),
     }))
-}
-
-/// Check if a string looks like AES-256-GCM encrypted format (nonce:ciphertext)
-fn is_encrypted_format(s: &str) -> bool {
-    let parts: Vec<&str> = s.split(':').collect();
-    if parts.len() != 2 {
-        return false;
-    }
-    // Nonce is 12 bytes = 24 hex chars
-    let nonce = parts[0];
-    let ciphertext = parts[1];
-    nonce.len() == 24
-        && !ciphertext.is_empty()
-        && nonce.chars().all(|c| c.is_ascii_hexdigit())
-        && ciphertext.chars().all(|c| c.is_ascii_hexdigit())
 }
 
 /// Maximum buffer size for SSE parsing (1 MB).
@@ -3911,43 +3943,53 @@ async fn parse_sse_for_import_result(
     anyhow::bail!("CrabShack import stream ended without completion event")
 }
 
-/// Best-effort restart of an instance on compose-api if we stopped it for backup.
-/// Errors are logged but not propagated — this is cleanup after a failure.
-fn maybe_restart_on_failure(
+/// Best-effort lifecycle call on compose-api to restore original instance state after failure.
+/// Fire-and-forget (tokio::spawn) — errors are logged, not propagated.
+fn restore_on_failure(
     app_state: &AppState,
     compose_api_url: &str,
     encoded_name: &str,
     token: &str,
-    was_stopped: bool,
+    was_running: bool,
+    action: &str,
 ) {
-    // was_stopped=true means the instance was already stopped before migration,
-    // so we only need to restart it if it was RUNNING (i.e. we stopped it ourselves).
-    if was_stopped {
+    let should_restore = match action {
+        "stop" => !was_running,
+        "start" => was_running,
+        _ => false,
+    };
+    if !should_restore {
         return;
     }
-    let start_url = format!("{}/instances/{}/start", compose_api_url, encoded_name);
+    let url = format!("{}/instances/{}/{}", compose_api_url, encoded_name, action);
     let client = app_state.http_client.clone();
     let token = token.to_string();
+    let action = action.to_string();
     tokio::spawn(async move {
         match client
-            .post(&start_url)
+            .post(&url)
             .bearer_auth(&token)
             .timeout(std::time::Duration::from_secs(60))
             .send()
             .await
         {
             Ok(resp) if resp.status().is_success() => {
-                tracing::info!("Restarted legacy instance after migration failure");
+                tracing::info!(
+                    "Restored legacy instance after migration failure: action={}",
+                    action
+                );
             }
             Ok(resp) => {
                 tracing::warn!(
-                    "Failed to restart legacy instance after migration failure: status={}",
+                    "Failed to restore legacy instance: action={}, status={}",
+                    action,
                     resp.status()
                 );
             }
             Err(e) => {
                 tracing::warn!(
-                    "Failed to restart legacy instance after migration failure: error={}",
+                    "Failed to restore legacy instance: action={}, error={}",
+                    action,
                     e
                 );
             }

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3279,8 +3279,8 @@ pub async fn admin_migration_status(
     tracing::info!("Admin: Getting migration status");
 
     // Legacy compose-api URLs contain "claws" or "sare.dev"; CrabShack URLs contain "agents.near.ai"
-    let legacy_patterns = &["%claws%", "%sare.dev%"];
-    let crabshack_pattern = "%agents.near.ai%";
+    let legacy_patterns = vec!["%claws%".to_string(), "%sare.dev%".to_string()];
+    let crabshack_pattern = "%agents.near.ai%".to_string();
 
     let (total, migrated, pending, unknown) = app_state
         .agent_repository

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3279,12 +3279,12 @@ pub async fn admin_migration_status(
     tracing::info!("Admin: Getting migration status");
 
     // Legacy compose-api URLs contain "claws" or "sare.dev"; CrabShack URLs contain "agents.near.ai"
-    let legacy_pattern = "%claws%";
+    let legacy_patterns = &["%claws%", "%sare.dev%"];
     let crabshack_pattern = "%agents.near.ai%";
 
     let (total, migrated, pending, unknown) = app_state
         .agent_repository
-        .get_migration_status_counts(legacy_pattern, crabshack_pattern)
+        .get_migration_status_counts(legacy_patterns, crabshack_pattern)
         .await
         .map_err(|e| {
             tracing::error!("Failed to get migration status: error={}", e);
@@ -3671,15 +3671,28 @@ fn is_encrypted_format(s: &str) -> bool {
         && ciphertext.chars().all(|c| c.is_ascii_hexdigit())
 }
 
+/// Maximum buffer size for SSE parsing (1 MB).
+const SSE_BUFFER_LIMIT: usize = 1024 * 1024;
+/// Timeout for receiving each SSE chunk (30 seconds).
+const SSE_CHUNK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Parse an SSE response stream to extract the backup presigned URL from the "complete" event.
 async fn parse_sse_for_backup_url(response: reqwest::Response) -> anyhow::Result<String> {
     use futures::stream::StreamExt;
     let mut stream = response.bytes_stream();
     let mut buffer = String::new();
 
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk?;
+    loop {
+        let chunk = match tokio::time::timeout(SSE_CHUNK_TIMEOUT, stream.next()).await {
+            Ok(Some(chunk)) => chunk?,
+            Ok(None) => break,
+            Err(_) => anyhow::bail!("Timed out waiting for SSE chunk from backup stream ({}s)", SSE_CHUNK_TIMEOUT.as_secs()),
+        };
         buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+        if buffer.len() > SSE_BUFFER_LIMIT {
+            anyhow::bail!("SSE buffer exceeded {} bytes limit in backup stream", SSE_BUFFER_LIMIT);
+        }
 
         while let Some(newline_pos) = buffer.find('\n') {
             let line = buffer[..newline_pos].to_string();
@@ -3717,9 +3730,17 @@ async fn parse_sse_for_import_result(
     let mut buffer = String::new();
     let mut last_event = None;
 
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk?;
+    loop {
+        let chunk = match tokio::time::timeout(SSE_CHUNK_TIMEOUT, stream.next()).await {
+            Ok(Some(chunk)) => chunk?,
+            Ok(None) => break,
+            Err(_) => anyhow::bail!("Timed out waiting for SSE chunk from import stream ({}s)", SSE_CHUNK_TIMEOUT.as_secs()),
+        };
         buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+        if buffer.len() > SSE_BUFFER_LIMIT {
+            anyhow::bail!("SSE buffer exceeded {} bytes limit in import stream", SSE_BUFFER_LIMIT);
+        }
 
         while let Some(newline_pos) = buffer.find('\n') {
             let line = buffer[..newline_pos].to_string();
@@ -3743,7 +3764,7 @@ async fn parse_sse_for_import_result(
     last_event.ok_or_else(|| anyhow::anyhow!("No events received from CrabShack import"))
 }
 
-/// Best-effort restart of an instance on compose-api if it was stopped for backup.
+/// Best-effort restart of an instance on compose-api if we stopped it for backup.
 /// Errors are logged but not propagated — this is cleanup after a failure.
 fn maybe_restart_on_failure(
     app_state: &AppState,
@@ -3752,7 +3773,9 @@ fn maybe_restart_on_failure(
     token: &str,
     was_stopped: bool,
 ) {
-    if !was_stopped {
+    // was_stopped=true means the instance was already stopped before migration,
+    // so we only need to restart it if it was RUNNING (i.e. we stopped it ourselves).
+    if was_stopped {
         return;
     }
     let start_url = format!("{}/instances/{}/start", compose_api_url, encoded_name);

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3371,9 +3371,7 @@ pub async fn admin_migrate_instance(
     let is_crabshack = app_state
         .agent_service
         .find_crabshack_manager()
-        .is_some_and(|m| {
-            agent_api_base_url.trim_end_matches('/') == m.url.trim_end_matches('/')
-        });
+        .is_some_and(|m| agent_api_base_url.trim_end_matches('/') == m.url.trim_end_matches('/'));
     if is_crabshack {
         return Ok(Json(MigrateInstanceResponse {
             status: "skipped".to_string(),

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3,7 +3,7 @@ use crate::{
     consts::LIST_USERS_LIMIT_MAX, error::ApiError, middleware::AuthenticatedUser, models::*,
     state::AppState,
 };
-use axum::routing::post;
+use axum::routing::{patch, post};
 use axum::{
     extract::{Extension, Path, Query, State},
     http::StatusCode,
@@ -1696,10 +1696,10 @@ pub async fn admin_list_all_instances(
 
     params.validate()?;
 
-    // Use DB (agent_instances) for correct user_id per instance
-    let (instances, total) = app_state
-        .agent_service
-        .list_all_instances(params.limit, params.offset)
+    // Use DB (agent_instances) with LEFT JOIN agent_balance for last_usage_at
+    let (instances, usage_map, total) = app_state
+        .agent_repository
+        .list_all_instances_with_usage(params.limit, params.offset)
         .await
         .map_err(|e| {
             tracing::error!("Failed to list all instances: error={}", e);
@@ -1708,7 +1708,10 @@ pub async fn admin_list_all_instances(
 
     let items: Vec<InstanceResponse> = instances
         .into_iter()
-        .map(crate::models::instance_response_for_admin)
+        .map(|inst| {
+            let last_usage = usage_map.get(&inst.id).copied();
+            crate::models::instance_response_for_admin_with_usage(inst, last_usage)
+        })
         .collect();
     Ok(Json(PaginatedResponse {
         items,
@@ -3203,6 +3206,556 @@ pub async fn admin_retry_account_deletion(
     }))
 }
 
+// ========== Migration Admin Endpoints ==========
+
+/// Request body for PATCH /v1/admin/agents/instances/{id}
+#[derive(Deserialize)]
+pub struct PatchInstanceRequest {
+    pub agent_api_base_url: Option<String>,
+    pub instance_url: Option<String>,
+    /// Instance token — will be encrypted before storage
+    pub instance_token: Option<String>,
+    pub dashboard_url: Option<String>,
+}
+
+/// Admin endpoint: Patch an agent instance (migration fields)
+pub async fn admin_patch_instance(
+    State(app_state): State<AppState>,
+    Extension(_user): Extension<AuthenticatedUser>,
+    Path(instance_id): Path<String>,
+    Json(request): Json<PatchInstanceRequest>,
+) -> Result<Json<InstanceResponse>, ApiError> {
+    let id = Uuid::parse_str(&instance_id).map_err(|_| {
+        ApiError::bad_request("Invalid instance ID format")
+    })?;
+
+    tracing::info!("Admin: Patching instance id={}", id);
+
+    // Encrypt instance_token if provided
+    let encrypted_token = match request.instance_token {
+        Some(ref token) => {
+            let encrypted = database::encryption::encrypt(token).map_err(|e| {
+                tracing::error!("Failed to encrypt instance token: error={}", e);
+                ApiError::internal_server_error("Failed to encrypt instance token")
+            })?;
+            Some(encrypted)
+        }
+        None => None,
+    };
+
+    let instance = app_state
+        .agent_repository
+        .admin_update_instance(
+            id,
+            request.agent_api_base_url,
+            request.instance_url,
+            encrypted_token,
+            request.dashboard_url,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to patch instance: instance_id={}, error={}", id, e);
+            ApiError::internal_server_error("Failed to update instance")
+        })?;
+
+    Ok(Json(crate::models::instance_response_for_admin(instance)))
+}
+
+/// Migration status response
+#[derive(Serialize)]
+pub struct MigrationStatusResponse {
+    pub total: i64,
+    pub migrated: i64,
+    pub pending: i64,
+    pub unknown: i64,
+    pub failed: i64,
+}
+
+/// Admin endpoint: Get migration status counts
+pub async fn admin_migration_status(
+    State(app_state): State<AppState>,
+    Extension(_user): Extension<AuthenticatedUser>,
+) -> Result<Json<MigrationStatusResponse>, ApiError> {
+    tracing::info!("Admin: Getting migration status");
+
+    // Legacy compose-api URLs contain "claws" or "sare.dev"; CrabShack URLs contain "agents.near.ai"
+    let legacy_pattern = "%claws%";
+    let crabshack_pattern = "%agents.near.ai%";
+
+    let (total, migrated, pending, unknown) = app_state
+        .agent_repository
+        .get_migration_status_counts(legacy_pattern, crabshack_pattern)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get migration status: error={}", e);
+            ApiError::internal_server_error("Failed to get migration status")
+        })?;
+
+    Ok(Json(MigrationStatusResponse {
+        total,
+        migrated,
+        pending,
+        unknown,
+        failed: 0, // derived from instance status in future iterations
+    }))
+}
+
+/// Response for migrate endpoint
+#[derive(Serialize)]
+pub struct MigrateInstanceResponse {
+    pub status: String,
+    pub instance_name: String,
+    pub message: String,
+}
+
+/// Admin endpoint: Migrate a single instance from legacy compose-api to CrabShack
+pub async fn admin_migrate_instance(
+    State(app_state): State<AppState>,
+    Extension(_user): Extension<AuthenticatedUser>,
+    Path(instance_id): Path<String>,
+) -> Result<Json<MigrateInstanceResponse>, ApiError> {
+    let id = Uuid::parse_str(&instance_id).map_err(|_| {
+        ApiError::bad_request("Invalid instance ID format")
+    })?;
+
+    tracing::info!("Admin: Starting migration for instance_id={}", id);
+
+    let instance = app_state
+        .agent_repository
+        .get_instance(id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get instance: instance_id={}, error={}", id, e);
+            ApiError::internal_server_error("Failed to get instance")
+        })?
+        .ok_or_else(|| ApiError::not_found("Instance not found"))?;
+
+    let instance_name = instance.name.clone();
+
+    // Verify this is a legacy instance (agent_api_base_url contains compose-api pattern)
+    let agent_api_base_url = instance.agent_api_base_url.as_deref().ok_or_else(|| {
+        ApiError::bad_request("Instance has no agent_api_base_url, cannot determine if legacy")
+    })?;
+
+    if !agent_api_base_url.contains("claws") && !agent_api_base_url.contains("sare.dev") {
+        return Ok(Json(MigrateInstanceResponse {
+            status: "skipped".to_string(),
+            instance_name,
+            message: "Instance is not on a legacy compose-api".to_string(),
+        }));
+    }
+
+    // Look up backup_passphrase for the user
+    let creds = app_state
+        .agent_repository
+        .get_user_passkey_credentials(instance.user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get passkey credentials: user_id={}, error={}", instance.user_id, e);
+            ApiError::internal_server_error("Failed to get user credentials")
+        })?;
+
+    let backup_passphrase = match creds {
+        Some((_auth_secret, passphrase)) => passphrase,
+        None => {
+            // Generate and store a new passphrase
+            // Generate random 32-byte hex strings using two UUIDv4 (16 bytes each)
+            let passphrase = format!(
+                "{}{}",
+                Uuid::new_v4().as_simple(),
+                Uuid::new_v4().as_simple()
+            );
+            let auth_secret = format!(
+                "{}{}",
+                Uuid::new_v4().as_simple(),
+                Uuid::new_v4().as_simple()
+            );
+            app_state
+                .agent_repository
+                .upsert_user_passkey_credentials(instance.user_id, &auth_secret, &passphrase)
+                .await
+                .map_err(|e| {
+                    tracing::error!("Failed to store passkey credentials: user_id={}, error={}", instance.user_id, e);
+                    ApiError::internal_server_error("Failed to store credentials")
+                })?;
+            passphrase
+        }
+    };
+
+    // Derive age recipient for the backup
+    let (age_recipient, _age_identity) =
+        services::agent::age_derivation::derive_age_keypair(&backup_passphrase, &instance.name);
+
+    // Decrypt and validate instance_token
+    let instance_token = instance.instance_token.as_deref().ok_or_else(|| {
+        ApiError::bad_request("Instance has no instance_token")
+    })?;
+
+    // Validate decrypted token is not still in encrypted format
+    if is_encrypted_format(instance_token) {
+        return Err(ApiError::internal_server_error(
+            "Instance token appears to still be encrypted after decryption",
+        ));
+    }
+
+    // Step 5: GET instance metadata from compose-api
+    let compose_api_url = agent_api_base_url.trim_end_matches('/');
+    let encoded_name = urlencoding::encode(&instance.name);
+
+    // Find the manager token for the legacy compose-api
+    let manager = app_state
+        .agent_service
+        .find_manager_for_url(agent_api_base_url)
+        .ok_or_else(|| {
+            ApiError::bad_request("No manager configured for this instance's agent_api_base_url")
+        })?;
+
+    let compose_instance_url = format!("{}/instances/{}", compose_api_url, encoded_name);
+    let compose_resp = app_state
+        .http_client
+        .get(&compose_instance_url)
+        .bearer_auth(&manager.token)
+        .timeout(std::time::Duration::from_secs(30))
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get instance from compose-api: instance_id={}, error={}", id, e);
+            ApiError::internal_server_error("Failed to contact legacy compose-api")
+        })?;
+
+    if !compose_resp.status().is_success() {
+        let status = compose_resp.status();
+        tracing::error!("Compose-api GET /instances failed: instance_id={}, status={}", id, status);
+        return Err(ApiError::internal_server_error(
+            "Failed to get instance metadata from legacy compose-api",
+        ));
+    }
+
+    let compose_data: serde_json::Value = compose_resp.json().await.map_err(|e| {
+        tracing::error!("Failed to parse compose-api response: instance_id={}, error={}", id, e);
+        ApiError::internal_server_error("Failed to parse legacy instance metadata")
+    })?;
+
+    let compose_status = compose_data
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+
+    // If instance is stopped, start it first (backup requires running instance)
+    let was_stopped = compose_status == "stopped" || compose_status == "exited";
+    if was_stopped {
+        tracing::info!("Instance is stopped, starting before backup: instance_id={}", id);
+        let start_url = format!("{}/instances/{}/start", compose_api_url, encoded_name);
+        let start_resp = app_state
+            .http_client
+            .post(&start_url)
+            .bearer_auth(&manager.token)
+            .timeout(std::time::Duration::from_secs(60))
+            .send()
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to start instance on compose-api: instance_id={}, error={}", id, e);
+                ApiError::internal_server_error("Failed to start legacy instance")
+            })?;
+
+        if !start_resp.status().is_success() {
+            tracing::error!("Compose-api start failed: instance_id={}, status={}", id, start_resp.status());
+            return Err(ApiError::internal_server_error(
+                "Failed to start legacy instance for backup",
+            ));
+        }
+    }
+
+    // Create backup on compose-api via SSE
+    let backup_url = format!("{}/instances/{}/backup", compose_api_url, encoded_name);
+    let backup_body = serde_json::json!({
+        "age_recipient": age_recipient,
+        "expiry_secs": 7200,
+        "full_export": true
+    });
+
+    let backup_resp = app_state
+        .http_client
+        .post(&backup_url)
+        .bearer_auth(&manager.token)
+        .json(&backup_body)
+        .timeout(std::time::Duration::from_secs(600))
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to create backup: instance_id={}, error={}", id, e);
+            maybe_restart_on_failure(&app_state, compose_api_url, &encoded_name, &manager.token, was_stopped);
+            ApiError::internal_server_error("Failed to initiate backup on legacy compose-api")
+        })?;
+
+    if !backup_resp.status().is_success() {
+        let status = backup_resp.status();
+        tracing::error!("Compose-api backup failed: instance_id={}, status={}", id, status);
+        maybe_restart_on_failure(&app_state, compose_api_url, &encoded_name, &manager.token, was_stopped);
+        return Err(ApiError::internal_server_error(
+            "Failed to create backup on legacy compose-api",
+        ));
+    }
+
+    // Parse SSE stream to get backup presigned URL
+    let backup_presigned_url = match parse_sse_for_backup_url(backup_resp).await {
+        Ok(url) => url,
+        Err(e) => {
+            tracing::error!("Failed to parse backup SSE stream: instance_id={}, error={}", id, e);
+            maybe_restart_on_failure(&app_state, compose_api_url, &encoded_name, &manager.token, was_stopped);
+            return Err(ApiError::internal_server_error(
+                "Failed to get backup URL from legacy compose-api",
+            ));
+        }
+    };
+
+    // Stop instance on compose-api
+    let stop_url = format!("{}/instances/{}/stop", compose_api_url, encoded_name);
+    let stop_resp = app_state
+        .http_client
+        .post(&stop_url)
+        .bearer_auth(&manager.token)
+        .timeout(std::time::Duration::from_secs(60))
+        .send()
+        .await;
+
+    if let Err(e) = &stop_resp {
+        tracing::warn!("Failed to stop instance on compose-api (continuing): instance_id={}, error={}", id, e);
+    } else if let Ok(resp) = &stop_resp {
+        if !resp.status().is_success() {
+            tracing::warn!("Compose-api stop returned non-success (continuing): instance_id={}, status={}", id, resp.status());
+        }
+    }
+
+    // Import into CrabShack
+    let service_type = instance.service_type.as_deref().unwrap_or("openclaw");
+    let crabshack_service_type =
+        services::agent::service::service_type_for_crabshack(service_type, None);
+
+    let ssh_pubkey = compose_data
+        .get("ssh_pubkey")
+        .and_then(|v| v.as_str())
+        .or(instance.public_ssh_key.as_deref());
+    let nearai_api_key = compose_data
+        .get("nearai_api_key")
+        .and_then(|v| v.as_str());
+    let nearai_api_url = compose_data
+        .get("nearai_api_url")
+        .and_then(|v| v.as_str());
+
+    // Find a CrabShack (non-legacy) manager for import
+    let crabshack_manager = app_state
+        .agent_service
+        .find_crabshack_manager()
+        .ok_or_else(|| {
+            tracing::error!("No CrabShack manager configured for import");
+            // Restart on compose-api if we stopped it
+            maybe_restart_on_failure(&app_state, compose_api_url, &encoded_name, &manager.token, was_stopped);
+            ApiError::internal_server_error("No CrabShack manager configured")
+        })?;
+
+    let import_url = format!("{}/instances/import", crabshack_manager.url);
+    let import_body = serde_json::json!({
+        "name": instance.name,
+        "backup_url": backup_presigned_url,
+        "backup_passphrase": backup_passphrase,
+        "legacy_token": instance_token,
+        "service_type": crabshack_service_type,
+        "ssh_pubkey": ssh_pubkey,
+        "nearai_api_key": nearai_api_key,
+        "nearai_api_url": nearai_api_url,
+        "user_id": instance.user_id.to_string(),
+    });
+
+    let import_resp = app_state
+        .http_client
+        .post(&import_url)
+        .bearer_auth(&crabshack_manager.token)
+        .json(&import_body)
+        .timeout(std::time::Duration::from_secs(600))
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to import into CrabShack: instance_id={}, error={}", id, e);
+            maybe_restart_on_failure(&app_state, compose_api_url, &encoded_name, &manager.token, was_stopped);
+            ApiError::internal_server_error("Failed to import into CrabShack")
+        })?;
+
+    if !import_resp.status().is_success() {
+        let status = import_resp.status();
+        tracing::error!("CrabShack import failed: instance_id={}, status={}", id, status);
+        maybe_restart_on_failure(&app_state, compose_api_url, &encoded_name, &manager.token, was_stopped);
+        return Err(ApiError::internal_server_error(
+            "CrabShack import failed",
+        ));
+    }
+
+    // Parse CrabShack import SSE response for the new instance details
+    let import_data = match parse_sse_for_import_result(import_resp).await {
+        Ok(data) => data,
+        Err(e) => {
+            tracing::error!("Failed to parse CrabShack import SSE: instance_id={}, error={}", id, e);
+            maybe_restart_on_failure(&app_state, compose_api_url, &encoded_name, &manager.token, was_stopped);
+            return Err(ApiError::internal_server_error(
+                "Failed to parse CrabShack import response",
+            ));
+        }
+    };
+
+    // Extract new URLs from CrabShack response
+    let new_instance_url = import_data.get("url").and_then(|v| v.as_str()).map(|s| s.to_string());
+    let new_dashboard_url = import_data.get("dashboard_url").and_then(|v| v.as_str()).map(|s| s.to_string());
+
+    // Update chat-api DB to point to CrabShack
+    let _updated = app_state
+        .agent_repository
+        .admin_update_instance(
+            id,
+            Some(crabshack_manager.url.clone()),
+            new_instance_url,
+            None, // keep instance_token unchanged
+            new_dashboard_url,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to update instance after migration: instance_id={}, error={}", id, e);
+            ApiError::internal_server_error("Migration succeeded but failed to update DB")
+        })?;
+
+    tracing::info!("Migration completed: instance_id={}, instance_name={}", id, instance_name);
+
+    Ok(Json(MigrateInstanceResponse {
+        status: "success".to_string(),
+        instance_name,
+        message: "Instance migrated to CrabShack".to_string(),
+    }))
+}
+
+/// Check if a string looks like AES-256-GCM encrypted format (nonce:ciphertext)
+fn is_encrypted_format(s: &str) -> bool {
+    let parts: Vec<&str> = s.split(':').collect();
+    if parts.len() != 2 {
+        return false;
+    }
+    // Nonce is 12 bytes = 24 hex chars
+    let nonce = parts[0];
+    let ciphertext = parts[1];
+    nonce.len() == 24
+        && !ciphertext.is_empty()
+        && nonce.chars().all(|c| c.is_ascii_hexdigit())
+        && ciphertext.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Parse an SSE response stream to extract the backup presigned URL from the "complete" event.
+async fn parse_sse_for_backup_url(response: reqwest::Response) -> anyhow::Result<String> {
+    use futures::stream::StreamExt;
+    let mut stream = response.bytes_stream();
+    let mut buffer = String::new();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+        while let Some(newline_pos) = buffer.find('\n') {
+            let line = buffer[..newline_pos].to_string();
+            buffer.drain(..=newline_pos);
+
+            if let Some(data) = line.strip_prefix("data: ") {
+                if let Ok(event) = serde_json::from_str::<serde_json::Value>(data) {
+                    let stage = event.get("stage").and_then(|v| v.as_str()).unwrap_or("");
+                    if stage == "complete" || stage == "done" {
+                        if let Some(url) = event.get("presigned_url").and_then(|v| v.as_str()) {
+                            return Ok(url.to_string());
+                        }
+                        if let Some(url) = event.get("backup_url").and_then(|v| v.as_str()) {
+                            return Ok(url.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    anyhow::bail!("No backup URL found in SSE stream")
+}
+
+/// Parse an SSE response stream to extract the final import result from CrabShack.
+async fn parse_sse_for_import_result(
+    response: reqwest::Response,
+) -> anyhow::Result<serde_json::Value> {
+    use futures::stream::StreamExt;
+    let mut stream = response.bytes_stream();
+    let mut buffer = String::new();
+    let mut last_event = None;
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+        while let Some(newline_pos) = buffer.find('\n') {
+            let line = buffer[..newline_pos].to_string();
+            buffer.drain(..=newline_pos);
+
+            if let Some(data) = line.strip_prefix("data: ") {
+                if let Ok(event) = serde_json::from_str::<serde_json::Value>(data) {
+                    let stage = event.get("stage").and_then(|v| v.as_str()).unwrap_or("");
+                    if stage == "complete" || stage == "done" {
+                        if let Some(inst) = event.get("instance") {
+                            return Ok(inst.clone());
+                        }
+                        return Ok(event);
+                    }
+                    last_event = Some(event);
+                }
+            }
+        }
+    }
+
+    last_event.ok_or_else(|| anyhow::anyhow!("No events received from CrabShack import"))
+}
+
+/// Best-effort restart of an instance on compose-api if it was stopped for backup.
+/// Errors are logged but not propagated — this is cleanup after a failure.
+fn maybe_restart_on_failure(
+    app_state: &AppState,
+    compose_api_url: &str,
+    encoded_name: &str,
+    token: &str,
+    was_stopped: bool,
+) {
+    if !was_stopped {
+        return;
+    }
+    let start_url = format!("{}/instances/{}/start", compose_api_url, encoded_name);
+    let client = app_state.http_client.clone();
+    let token = token.to_string();
+    tokio::spawn(async move {
+        match client
+            .post(&start_url)
+            .bearer_auth(&token)
+            .timeout(std::time::Duration::from_secs(60))
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => {
+                tracing::info!("Restarted legacy instance after migration failure");
+            }
+            Ok(resp) => {
+                tracing::warn!(
+                    "Failed to restart legacy instance after migration failure: status={}",
+                    resp.status()
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to restart legacy instance after migration failure: error={}",
+                    e
+                );
+            }
+        }
+    });
+}
+
 /// Create admin router with all admin routes (requires admin authentication)
 pub fn create_admin_router() -> Router<AppState> {
     Router::new()
@@ -3244,10 +3797,15 @@ pub fn create_admin_router() -> Router<AppState> {
                     get(admin_list_all_instances).post(admin_create_instance),
                 )
                 .route("/instances/sync-status", post(admin_sync_agent_status))
+                .route(
+                    "/instances/migration-status",
+                    get(admin_migration_status),
+                )
+                .route("/instances/{id}", patch(admin_patch_instance).delete(admin_delete_instance))
                 .route("/instances/{id}/start", post(admin_start_instance))
                 .route("/instances/{id}/stop", post(admin_stop_instance))
                 .route("/instances/{id}/restart", post(admin_restart_instance))
-                .route("/instances/{id}", delete(admin_delete_instance))
+                .route("/instances/{id}/migrate", post(admin_migrate_instance))
                 .route("/instances/{id}/backup", post(admin_create_backup))
                 .route("/instances/{id}/backups", get(admin_list_backups))
                 .route("/instances/{id}/backups/{backup_id}", get(admin_get_backup))

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3225,9 +3225,8 @@ pub async fn admin_patch_instance(
     Path(instance_id): Path<String>,
     Json(request): Json<PatchInstanceRequest>,
 ) -> Result<Json<InstanceResponse>, ApiError> {
-    let id = Uuid::parse_str(&instance_id).map_err(|_| {
-        ApiError::bad_request("Invalid instance ID format")
-    })?;
+    let id = Uuid::parse_str(&instance_id)
+        .map_err(|_| ApiError::bad_request("Invalid instance ID format"))?;
 
     tracing::info!("Admin: Patching instance id={}", id);
 
@@ -3314,9 +3313,8 @@ pub async fn admin_migrate_instance(
     Extension(_user): Extension<AuthenticatedUser>,
     Path(instance_id): Path<String>,
 ) -> Result<Json<MigrateInstanceResponse>, ApiError> {
-    let id = Uuid::parse_str(&instance_id).map_err(|_| {
-        ApiError::bad_request("Invalid instance ID format")
-    })?;
+    let id = Uuid::parse_str(&instance_id)
+        .map_err(|_| ApiError::bad_request("Invalid instance ID format"))?;
 
     tracing::info!("Admin: Starting migration for instance_id={}", id);
 
@@ -3351,7 +3349,11 @@ pub async fn admin_migrate_instance(
         .get_user_passkey_credentials(instance.user_id)
         .await
         .map_err(|e| {
-            tracing::error!("Failed to get passkey credentials: user_id={}, error={}", instance.user_id, e);
+            tracing::error!(
+                "Failed to get passkey credentials: user_id={}, error={}",
+                instance.user_id,
+                e
+            );
             ApiError::internal_server_error("Failed to get user credentials")
         })?;
 
@@ -3375,7 +3377,11 @@ pub async fn admin_migrate_instance(
                 .upsert_user_passkey_credentials(instance.user_id, &auth_secret, &passphrase)
                 .await
                 .map_err(|e| {
-                    tracing::error!("Failed to store passkey credentials: user_id={}, error={}", instance.user_id, e);
+                    tracing::error!(
+                        "Failed to store passkey credentials: user_id={}, error={}",
+                        instance.user_id,
+                        e
+                    );
                     ApiError::internal_server_error("Failed to store credentials")
                 })?;
             passphrase
@@ -3387,9 +3393,10 @@ pub async fn admin_migrate_instance(
         services::agent::age_derivation::derive_age_keypair(&backup_passphrase, &instance.name);
 
     // Decrypt and validate instance_token
-    let instance_token = instance.instance_token.as_deref().ok_or_else(|| {
-        ApiError::bad_request("Instance has no instance_token")
-    })?;
+    let instance_token = instance
+        .instance_token
+        .as_deref()
+        .ok_or_else(|| ApiError::bad_request("Instance has no instance_token"))?;
 
     // Validate decrypted token is not still in encrypted format
     if is_encrypted_format(instance_token) {
@@ -3419,20 +3426,32 @@ pub async fn admin_migrate_instance(
         .send()
         .await
         .map_err(|e| {
-            tracing::error!("Failed to get instance from compose-api: instance_id={}, error={}", id, e);
+            tracing::error!(
+                "Failed to get instance from compose-api: instance_id={}, error={}",
+                id,
+                e
+            );
             ApiError::internal_server_error("Failed to contact legacy compose-api")
         })?;
 
     if !compose_resp.status().is_success() {
         let status = compose_resp.status();
-        tracing::error!("Compose-api GET /instances failed: instance_id={}, status={}", id, status);
+        tracing::error!(
+            "Compose-api GET /instances failed: instance_id={}, status={}",
+            id,
+            status
+        );
         return Err(ApiError::internal_server_error(
             "Failed to get instance metadata from legacy compose-api",
         ));
     }
 
     let compose_data: serde_json::Value = compose_resp.json().await.map_err(|e| {
-        tracing::error!("Failed to parse compose-api response: instance_id={}, error={}", id, e);
+        tracing::error!(
+            "Failed to parse compose-api response: instance_id={}, error={}",
+            id,
+            e
+        );
         ApiError::internal_server_error("Failed to parse legacy instance metadata")
     })?;
 
@@ -3444,7 +3463,10 @@ pub async fn admin_migrate_instance(
     // If instance is stopped, start it first (backup requires running instance)
     let was_stopped = compose_status == "stopped" || compose_status == "exited";
     if was_stopped {
-        tracing::info!("Instance is stopped, starting before backup: instance_id={}", id);
+        tracing::info!(
+            "Instance is stopped, starting before backup: instance_id={}",
+            id
+        );
         let start_url = format!("{}/instances/{}/start", compose_api_url, encoded_name);
         let start_resp = app_state
             .http_client
@@ -3454,12 +3476,20 @@ pub async fn admin_migrate_instance(
             .send()
             .await
             .map_err(|e| {
-                tracing::error!("Failed to start instance on compose-api: instance_id={}, error={}", id, e);
+                tracing::error!(
+                    "Failed to start instance on compose-api: instance_id={}, error={}",
+                    id,
+                    e
+                );
                 ApiError::internal_server_error("Failed to start legacy instance")
             })?;
 
         if !start_resp.status().is_success() {
-            tracing::error!("Compose-api start failed: instance_id={}, status={}", id, start_resp.status());
+            tracing::error!(
+                "Compose-api start failed: instance_id={}, status={}",
+                id,
+                start_resp.status()
+            );
             return Err(ApiError::internal_server_error(
                 "Failed to start legacy instance for backup",
             ));
@@ -3484,14 +3514,30 @@ pub async fn admin_migrate_instance(
         .await
         .map_err(|e| {
             tracing::error!("Failed to create backup: instance_id={}, error={}", id, e);
-            maybe_restart_on_failure(&app_state, compose_api_url, &encoded_name, &manager.token, was_stopped);
+            maybe_restart_on_failure(
+                &app_state,
+                compose_api_url,
+                &encoded_name,
+                &manager.token,
+                was_stopped,
+            );
             ApiError::internal_server_error("Failed to initiate backup on legacy compose-api")
         })?;
 
     if !backup_resp.status().is_success() {
         let status = backup_resp.status();
-        tracing::error!("Compose-api backup failed: instance_id={}, status={}", id, status);
-        maybe_restart_on_failure(&app_state, compose_api_url, &encoded_name, &manager.token, was_stopped);
+        tracing::error!(
+            "Compose-api backup failed: instance_id={}, status={}",
+            id,
+            status
+        );
+        maybe_restart_on_failure(
+            &app_state,
+            compose_api_url,
+            &encoded_name,
+            &manager.token,
+            was_stopped,
+        );
         return Err(ApiError::internal_server_error(
             "Failed to create backup on legacy compose-api",
         ));
@@ -3501,8 +3547,18 @@ pub async fn admin_migrate_instance(
     let backup_presigned_url = match parse_sse_for_backup_url(backup_resp).await {
         Ok(url) => url,
         Err(e) => {
-            tracing::error!("Failed to parse backup SSE stream: instance_id={}, error={}", id, e);
-            maybe_restart_on_failure(&app_state, compose_api_url, &encoded_name, &manager.token, was_stopped);
+            tracing::error!(
+                "Failed to parse backup SSE stream: instance_id={}, error={}",
+                id,
+                e
+            );
+            maybe_restart_on_failure(
+                &app_state,
+                compose_api_url,
+                &encoded_name,
+                &manager.token,
+                was_stopped,
+            );
             return Err(ApiError::internal_server_error(
                 "Failed to get backup URL from legacy compose-api",
             ));
@@ -3520,10 +3576,18 @@ pub async fn admin_migrate_instance(
         .await;
 
     if let Err(e) = &stop_resp {
-        tracing::warn!("Failed to stop instance on compose-api (continuing): instance_id={}, error={}", id, e);
+        tracing::warn!(
+            "Failed to stop instance on compose-api (continuing): instance_id={}, error={}",
+            id,
+            e
+        );
     } else if let Ok(resp) = &stop_resp {
         if !resp.status().is_success() {
-            tracing::warn!("Compose-api stop returned non-success (continuing): instance_id={}, status={}", id, resp.status());
+            tracing::warn!(
+                "Compose-api stop returned non-success (continuing): instance_id={}, status={}",
+                id,
+                resp.status()
+            );
         }
     }
 
@@ -3536,12 +3600,8 @@ pub async fn admin_migrate_instance(
         .get("ssh_pubkey")
         .and_then(|v| v.as_str())
         .or(instance.public_ssh_key.as_deref());
-    let nearai_api_key = compose_data
-        .get("nearai_api_key")
-        .and_then(|v| v.as_str());
-    let nearai_api_url = compose_data
-        .get("nearai_api_url")
-        .and_then(|v| v.as_str());
+    let nearai_api_key = compose_data.get("nearai_api_key").and_then(|v| v.as_str());
+    let nearai_api_url = compose_data.get("nearai_api_url").and_then(|v| v.as_str());
     let image = compose_data
         .get("image")
         .and_then(|v| v.as_str())
@@ -3571,7 +3631,13 @@ pub async fn admin_migrate_instance(
         .find_crabshack_manager()
         .ok_or_else(|| {
             tracing::error!("No CrabShack manager configured for import");
-            maybe_restart_on_failure(&app_state, compose_api_url, &encoded_name, &manager.token, was_stopped);
+            maybe_restart_on_failure(
+                &app_state,
+                compose_api_url,
+                &encoded_name,
+                &manager.token,
+                was_stopped,
+            );
             ApiError::internal_server_error("No CrabShack manager configured")
         })?;
 
@@ -3601,26 +3667,54 @@ pub async fn admin_migrate_instance(
         .send()
         .await
         .map_err(|e| {
-            tracing::error!("Failed to import into CrabShack: instance_id={}, error={}", id, e);
-            maybe_restart_on_failure(&app_state, compose_api_url, &encoded_name, &manager.token, was_stopped);
+            tracing::error!(
+                "Failed to import into CrabShack: instance_id={}, error={}",
+                id,
+                e
+            );
+            maybe_restart_on_failure(
+                &app_state,
+                compose_api_url,
+                &encoded_name,
+                &manager.token,
+                was_stopped,
+            );
             ApiError::internal_server_error("Failed to import into CrabShack")
         })?;
 
     if !import_resp.status().is_success() {
         let status = import_resp.status();
-        tracing::error!("CrabShack import failed: instance_id={}, status={}", id, status);
-        maybe_restart_on_failure(&app_state, compose_api_url, &encoded_name, &manager.token, was_stopped);
-        return Err(ApiError::internal_server_error(
-            "CrabShack import failed",
-        ));
+        tracing::error!(
+            "CrabShack import failed: instance_id={}, status={}",
+            id,
+            status
+        );
+        maybe_restart_on_failure(
+            &app_state,
+            compose_api_url,
+            &encoded_name,
+            &manager.token,
+            was_stopped,
+        );
+        return Err(ApiError::internal_server_error("CrabShack import failed"));
     }
 
     // Parse CrabShack import SSE response for the new instance details
     let import_data = match parse_sse_for_import_result(import_resp).await {
         Ok(data) => data,
         Err(e) => {
-            tracing::error!("Failed to parse CrabShack import SSE: instance_id={}, error={}", id, e);
-            maybe_restart_on_failure(&app_state, compose_api_url, &encoded_name, &manager.token, was_stopped);
+            tracing::error!(
+                "Failed to parse CrabShack import SSE: instance_id={}, error={}",
+                id,
+                e
+            );
+            maybe_restart_on_failure(
+                &app_state,
+                compose_api_url,
+                &encoded_name,
+                &manager.token,
+                was_stopped,
+            );
             return Err(ApiError::internal_server_error(
                 "Failed to parse CrabShack import response",
             ));
@@ -3628,8 +3722,14 @@ pub async fn admin_migrate_instance(
     };
 
     // Extract new URLs from CrabShack response
-    let new_instance_url = import_data.get("url").and_then(|v| v.as_str()).map(|s| s.to_string());
-    let new_dashboard_url = import_data.get("dashboard_url").and_then(|v| v.as_str()).map(|s| s.to_string());
+    let new_instance_url = import_data
+        .get("url")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let new_dashboard_url = import_data
+        .get("dashboard_url")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
 
     // Update chat-api DB to point to CrabShack
     let _updated = app_state
@@ -3643,11 +3743,19 @@ pub async fn admin_migrate_instance(
         )
         .await
         .map_err(|e| {
-            tracing::error!("Failed to update instance after migration: instance_id={}, error={}", id, e);
+            tracing::error!(
+                "Failed to update instance after migration: instance_id={}, error={}",
+                id,
+                e
+            );
             ApiError::internal_server_error("Migration succeeded but failed to update DB")
         })?;
 
-    tracing::info!("Migration completed: instance_id={}, instance_name={}", id, instance_name);
+    tracing::info!(
+        "Migration completed: instance_id={}, instance_name={}",
+        id,
+        instance_name
+    );
 
     Ok(Json(MigrateInstanceResponse {
         status: "success".to_string(),
@@ -3686,12 +3794,18 @@ async fn parse_sse_for_backup_url(response: reqwest::Response) -> anyhow::Result
         let chunk = match tokio::time::timeout(SSE_CHUNK_TIMEOUT, stream.next()).await {
             Ok(Some(chunk)) => chunk?,
             Ok(None) => break,
-            Err(_) => anyhow::bail!("Timed out waiting for SSE chunk from backup stream ({}s)", SSE_CHUNK_TIMEOUT.as_secs()),
+            Err(_) => anyhow::bail!(
+                "Timed out waiting for SSE chunk from backup stream ({}s)",
+                SSE_CHUNK_TIMEOUT.as_secs()
+            ),
         };
         buffer.push_str(&String::from_utf8_lossy(&chunk));
 
         if buffer.len() > SSE_BUFFER_LIMIT {
-            anyhow::bail!("SSE buffer exceeded {} bytes limit in backup stream", SSE_BUFFER_LIMIT);
+            anyhow::bail!(
+                "SSE buffer exceeded {} bytes limit in backup stream",
+                SSE_BUFFER_LIMIT
+            );
         }
 
         while let Some(newline_pos) = buffer.find('\n') {
@@ -3734,12 +3848,18 @@ async fn parse_sse_for_import_result(
         let chunk = match tokio::time::timeout(SSE_CHUNK_TIMEOUT, stream.next()).await {
             Ok(Some(chunk)) => chunk?,
             Ok(None) => break,
-            Err(_) => anyhow::bail!("Timed out waiting for SSE chunk from import stream ({}s)", SSE_CHUNK_TIMEOUT.as_secs()),
+            Err(_) => anyhow::bail!(
+                "Timed out waiting for SSE chunk from import stream ({}s)",
+                SSE_CHUNK_TIMEOUT.as_secs()
+            ),
         };
         buffer.push_str(&String::from_utf8_lossy(&chunk));
 
         if buffer.len() > SSE_BUFFER_LIMIT {
-            anyhow::bail!("SSE buffer exceeded {} bytes limit in import stream", SSE_BUFFER_LIMIT);
+            anyhow::bail!(
+                "SSE buffer exceeded {} bytes limit in import stream",
+                SSE_BUFFER_LIMIT
+            );
         }
 
         while let Some(newline_pos) = buffer.find('\n') {
@@ -3849,11 +3969,11 @@ pub fn create_admin_router() -> Router<AppState> {
                     get(admin_list_all_instances).post(admin_create_instance),
                 )
                 .route("/instances/sync-status", post(admin_sync_agent_status))
+                .route("/instances/migration-status", get(admin_migration_status))
                 .route(
-                    "/instances/migration-status",
-                    get(admin_migration_status),
+                    "/instances/{id}",
+                    patch(admin_patch_instance).delete(admin_delete_instance),
                 )
-                .route("/instances/{id}", patch(admin_patch_instance).delete(admin_delete_instance))
                 .route("/instances/{id}/start", post(admin_start_instance))
                 .route("/instances/{id}/stop", post(admin_stop_instance))
                 .route("/instances/{id}/restart", post(admin_restart_instance))

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3542,6 +3542,28 @@ pub async fn admin_migrate_instance(
     let nearai_api_url = compose_data
         .get("nearai_api_url")
         .and_then(|v| v.as_str());
+    let image = compose_data
+        .get("image")
+        .and_then(|v| v.as_str())
+        .unwrap_or("docker.io/nearaidev/ironclaw-dind:latest");
+    let mem_limit = compose_data
+        .get("mem_limit")
+        .and_then(|v| v.as_str())
+        .unwrap_or("4g");
+    let cpus = compose_data
+        .get("cpus")
+        .and_then(|v| v.as_str())
+        .unwrap_or("1");
+    let storage_size = compose_data
+        .get("storage_size")
+        .and_then(|v| v.as_str())
+        .unwrap_or("10G");
+
+    // Store overwritten values in extra_env for rollback reference
+    let extra_env = serde_json::json!({
+        "LEGACY_API_BASE_URL": agent_api_base_url,
+        "LEGACY_INSTANCE_URL": instance.instance_url.as_deref().unwrap_or(""),
+    });
 
     // Find a CrabShack (non-legacy) manager for import
     let crabshack_manager = app_state
@@ -3549,7 +3571,6 @@ pub async fn admin_migrate_instance(
         .find_crabshack_manager()
         .ok_or_else(|| {
             tracing::error!("No CrabShack manager configured for import");
-            // Restart on compose-api if we stopped it
             maybe_restart_on_failure(&app_state, compose_api_url, &encoded_name, &manager.token, was_stopped);
             ApiError::internal_server_error("No CrabShack manager configured")
         })?;
@@ -3557,14 +3578,18 @@ pub async fn admin_migrate_instance(
     let import_url = format!("{}/instances/import", crabshack_manager.url);
     let import_body = serde_json::json!({
         "name": instance.name,
+        "token": instance_token,
         "backup_url": backup_presigned_url,
         "backup_passphrase": backup_passphrase,
-        "legacy_token": instance_token,
         "service_type": crabshack_service_type,
+        "image": image,
         "ssh_pubkey": ssh_pubkey,
         "nearai_api_key": nearai_api_key,
         "nearai_api_url": nearai_api_url,
-        "user_id": instance.user_id.to_string(),
+        "mem_limit": mem_limit,
+        "cpus": cpus,
+        "storage_size": storage_size,
+        "extra_env": extra_env,
     });
 
     let import_resp = app_state
@@ -3664,10 +3689,14 @@ async fn parse_sse_for_backup_url(response: reqwest::Response) -> anyhow::Result
                 if let Ok(event) = serde_json::from_str::<serde_json::Value>(data) {
                     let stage = event.get("stage").and_then(|v| v.as_str()).unwrap_or("");
                     if stage == "complete" || stage == "done" {
-                        if let Some(url) = event.get("presigned_url").and_then(|v| v.as_str()) {
-                            return Ok(url.to_string());
+                        // compose-api returns download_url inside "backup" object
+                        if let Some(backup) = event.get("backup") {
+                            if let Some(url) = backup.get("download_url").and_then(|v| v.as_str()) {
+                                return Ok(url.to_string());
+                            }
                         }
-                        if let Some(url) = event.get("backup_url").and_then(|v| v.as_str()) {
+                        // fallback: top-level field
+                        if let Some(url) = event.get("download_url").and_then(|v| v.as_str()) {
                             return Ok(url.to_string());
                         }
                     }

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3209,7 +3209,7 @@ pub async fn admin_retry_account_deletion(
 // ========== Migration Admin Endpoints ==========
 
 /// Request body for PATCH /v1/admin/agents/instances/{id}
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
 pub struct PatchInstanceRequest {
     pub agent_api_base_url: Option<String>,
     pub instance_url: Option<String>,
@@ -3242,6 +3242,17 @@ pub async fn admin_patch_instance(
         None => None,
     };
 
+    // Verify instance exists first
+    let _existing = app_state
+        .agent_repository
+        .get_instance(id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get instance: instance_id={}, error={}", id, e);
+            ApiError::internal_server_error("Failed to get instance")
+        })?
+        .ok_or_else(|| ApiError::not_found("Instance not found"))?;
+
     let instance = app_state
         .agent_repository
         .admin_update_instance(
@@ -3261,7 +3272,7 @@ pub async fn admin_patch_instance(
 }
 
 /// Migration status response
-#[derive(Serialize)]
+#[derive(Serialize, utoipa::ToSchema)]
 pub struct MigrationStatusResponse {
     pub total: i64,
     pub migrated: i64,
@@ -3300,7 +3311,7 @@ pub async fn admin_migration_status(
 }
 
 /// Response for migrate endpoint
-#[derive(Serialize)]
+#[derive(Serialize, utoipa::ToSchema)]
 pub struct MigrateInstanceResponse {
     pub status: String,
     pub instance_name: String,
@@ -3809,20 +3820,25 @@ async fn parse_sse_for_backup_url(response: reqwest::Response) -> anyhow::Result
         }
 
         while let Some(newline_pos) = buffer.find('\n') {
-            let line = buffer[..newline_pos].to_string();
+            let line = buffer[..newline_pos].trim_end_matches('\r').to_string();
             buffer.drain(..=newline_pos);
 
             if let Some(data) = line.strip_prefix("data: ") {
                 if let Ok(event) = serde_json::from_str::<serde_json::Value>(data) {
                     let stage = event.get("stage").and_then(|v| v.as_str()).unwrap_or("");
+                    if stage == "error" {
+                        let msg = event
+                            .get("message")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("unknown error");
+                        anyhow::bail!("Backup failed: {}", msg);
+                    }
                     if stage == "complete" || stage == "done" {
-                        // compose-api returns download_url inside "backup" object
                         if let Some(backup) = event.get("backup") {
                             if let Some(url) = backup.get("download_url").and_then(|v| v.as_str()) {
                                 return Ok(url.to_string());
                             }
                         }
-                        // fallback: top-level field
                         if let Some(url) = event.get("download_url").and_then(|v| v.as_str()) {
                             return Ok(url.to_string());
                         }
@@ -3836,13 +3852,13 @@ async fn parse_sse_for_backup_url(response: reqwest::Response) -> anyhow::Result
 }
 
 /// Parse an SSE response stream to extract the final import result from CrabShack.
+/// Returns only on "complete"/"done" event — fails if stream ends without one.
 async fn parse_sse_for_import_result(
     response: reqwest::Response,
 ) -> anyhow::Result<serde_json::Value> {
     use futures::stream::StreamExt;
     let mut stream = response.bytes_stream();
     let mut buffer = String::new();
-    let mut last_event = None;
 
     loop {
         let chunk = match tokio::time::timeout(SSE_CHUNK_TIMEOUT, stream.next()).await {
@@ -3863,25 +3879,36 @@ async fn parse_sse_for_import_result(
         }
 
         while let Some(newline_pos) = buffer.find('\n') {
-            let line = buffer[..newline_pos].to_string();
+            let line = buffer[..newline_pos].trim_end_matches('\r').to_string();
             buffer.drain(..=newline_pos);
 
             if let Some(data) = line.strip_prefix("data: ") {
                 if let Ok(event) = serde_json::from_str::<serde_json::Value>(data) {
                     let stage = event.get("stage").and_then(|v| v.as_str()).unwrap_or("");
-                    if stage == "complete" || stage == "done" {
+                    let event_type = event.get("event").and_then(|v| v.as_str()).unwrap_or("");
+                    if stage == "error" || event_type == "error" {
+                        let msg = event
+                            .get("message")
+                            .or_else(|| event.get("data").and_then(|d| d.get("message")))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("unknown error");
+                        anyhow::bail!("CrabShack import failed: {}", msg);
+                    }
+                    if stage == "complete" || stage == "done" || event_type == "import_complete" {
                         if let Some(inst) = event.get("instance") {
                             return Ok(inst.clone());
                         }
+                        if let Some(data) = event.get("data") {
+                            return Ok(data.clone());
+                        }
                         return Ok(event);
                     }
-                    last_event = Some(event);
                 }
             }
         }
     }
 
-    last_event.ok_or_else(|| anyhow::anyhow!("No events received from CrabShack import"))
+    anyhow::bail!("CrabShack import stream ended without completion event")
 }
 
 /// Best-effort restart of an instance on compose-api if we stopped it for backup.

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3237,6 +3237,9 @@ pub async fn admin_patch_instance(
 
     // Encrypt instance_token if provided
     let encrypted_token = match request.instance_token {
+        Some(ref token) if token.is_empty() => {
+            return Err(ApiError::bad_request("instance_token must not be empty"));
+        }
         Some(ref token) => {
             let encrypted = database::encryption::encrypt(token).map_err(|e| {
                 tracing::error!("Failed to encrypt instance token: error={}", e);
@@ -3294,8 +3297,21 @@ pub async fn admin_migration_status(
 ) -> Result<Json<MigrationStatusResponse>, ApiError> {
     tracing::info!("Admin: Getting migration status");
 
-    let legacy_patterns = vec!["%claws%".to_string(), "%sare.dev%".to_string()];
-    let crabshack_pattern = "%agents.near.ai%".to_string();
+    // Derive patterns from configured managers — no hardcoded URL strings.
+    let crabshack_url = app_state
+        .agent_service
+        .find_crabshack_manager()
+        .map(|m| m.url);
+    let all_urls = app_state.agent_service.manager_urls();
+    let legacy_patterns: Vec<String> = all_urls
+        .iter()
+        .filter(|u| Some(u.as_str()) != crabshack_url.as_deref())
+        .map(|u| format!("%{}%", u.trim_end_matches('/')))
+        .collect();
+    let crabshack_pattern = crabshack_url
+        .as_deref()
+        .map(|u| format!("%{}%", u.trim_end_matches('/')))
+        .unwrap_or_default();
 
     let (total, migrated, pending, no_url, unknown) = app_state
         .agent_repository
@@ -3352,11 +3368,17 @@ pub async fn admin_migrate_instance(
         ApiError::bad_request("Instance has no agent_api_base_url, cannot determine if legacy")
     })?;
 
-    if !agent_api_base_url.contains("claws") && !agent_api_base_url.contains("sare.dev") {
+    let is_crabshack = app_state
+        .agent_service
+        .find_crabshack_manager()
+        .is_some_and(|m| {
+            agent_api_base_url.trim_end_matches('/') == m.url.trim_end_matches('/')
+        });
+    if is_crabshack {
         return Ok(Json(MigrateInstanceResponse {
             status: "skipped".to_string(),
             instance_name,
-            message: "Instance is not on a legacy compose-api".to_string(),
+            message: "Instance is already on CrabShack".to_string(),
         }));
     }
 

--- a/crates/database/src/repositories/agent_repository.rs
+++ b/crates/database/src/repositories/agent_repository.rs
@@ -1079,4 +1079,158 @@ impl AgentRepository for PostgresAgentRepository {
 
         Ok(())
     }
+
+    async fn list_all_instances_with_usage(
+        &self,
+        limit: i64,
+        offset: i64,
+    ) -> anyhow::Result<(Vec<AgentInstance>, std::collections::HashMap<Uuid, DateTime<Utc>>, i64)> {
+        let client = self.pool.get().await?;
+
+        let count_row = client
+            .query_one("SELECT COUNT(*) FROM agent_instances", &[])
+            .await?;
+        let total: i64 = count_row.get(0);
+
+        let rows = client
+            .query(
+                "SELECT ai.id, ai.user_id, ai.instance_id, ai.name, ai.type, ai.public_ssh_key,
+                        ai.instance_url, ai.instance_token, ai.dashboard_url, ai.agent_api_base_url,
+                        ai.status, ai.created_at, ai.updated_at, ab.last_usage_at
+                 FROM agent_instances ai
+                 LEFT JOIN agent_balance ab ON ab.instance_id = ai.id
+                 ORDER BY ai.created_at DESC
+                 LIMIT $1 OFFSET $2",
+                &[&limit, &offset],
+            )
+            .await?;
+
+        let mut usage_map = std::collections::HashMap::new();
+        let instances = rows
+            .into_iter()
+            .map(|r| {
+                let id: Uuid = r.get(0);
+                let last_usage: Option<DateTime<Utc>> = r.get(13);
+                if let Some(ts) = last_usage {
+                    usage_map.insert(id, ts);
+                }
+                AgentInstance {
+                    id,
+                    user_id: r.get(1),
+                    instance_id: r.get(2),
+                    name: r.get(3),
+                    public_ssh_key: r.get(5),
+                    instance_url: r.get(6),
+                    instance_token: decrypt_token(r.get(7)),
+                    dashboard_url: r.get(8),
+                    agent_api_base_url: r.get(9),
+                    service_type: r.get(4),
+                    status: r.get(10),
+                    created_at: r.get(11),
+                    updated_at: r.get(12),
+                }
+            })
+            .collect();
+
+        Ok((instances, usage_map, total))
+    }
+
+    async fn admin_update_instance(
+        &self,
+        instance_id: Uuid,
+        agent_api_base_url: Option<String>,
+        instance_url: Option<String>,
+        encrypted_instance_token: Option<String>,
+        dashboard_url: Option<String>,
+    ) -> anyhow::Result<AgentInstance> {
+        let client = self.pool.get().await?;
+
+        // Build dynamic SET clause for provided fields
+        let mut set_clauses = Vec::new();
+        let mut param_values: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> = Vec::new();
+        let mut param_idx = 1u32;
+
+        if let Some(ref val) = agent_api_base_url {
+            set_clauses.push(format!("agent_api_base_url = ${}", param_idx));
+            param_values.push(Box::new(val.clone()));
+            param_idx += 1;
+        }
+        if let Some(ref val) = instance_url {
+            set_clauses.push(format!("instance_url = ${}", param_idx));
+            param_values.push(Box::new(val.clone()));
+            param_idx += 1;
+        }
+        if let Some(ref val) = encrypted_instance_token {
+            set_clauses.push(format!("instance_token = ${}", param_idx));
+            param_values.push(Box::new(val.clone()));
+            param_idx += 1;
+        }
+        if let Some(ref val) = dashboard_url {
+            set_clauses.push(format!("dashboard_url = ${}", param_idx));
+            param_values.push(Box::new(val.clone()));
+            param_idx += 1;
+        }
+
+        if set_clauses.is_empty() {
+            // No changes, just return current instance
+            return self.get_instance(instance_id).await?.ok_or_else(|| {
+                anyhow::anyhow!("Instance not found: instance_id={}", instance_id)
+            });
+        }
+
+        set_clauses.push("updated_at = NOW()".to_string());
+
+        let query = format!(
+            "UPDATE agent_instances SET {} WHERE id = ${} \
+             RETURNING id, user_id, instance_id, name, type, public_ssh_key, instance_url, \
+             instance_token, dashboard_url, agent_api_base_url, status, created_at, updated_at",
+            set_clauses.join(", "),
+            param_idx
+        );
+        param_values.push(Box::new(instance_id));
+
+        let params: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> =
+            param_values.iter().map(|p| p.as_ref() as &(dyn tokio_postgres::types::ToSql + Sync)).collect();
+
+        let row = client.query_one(&query, &params).await?;
+
+        Ok(AgentInstance {
+            id: row.get(0),
+            user_id: row.get(1),
+            instance_id: row.get(2),
+            name: row.get(3),
+            public_ssh_key: row.get(5),
+            instance_url: row.get(6),
+            instance_token: decrypt_token(row.get(7)),
+            dashboard_url: row.get(8),
+            agent_api_base_url: row.get(9),
+            service_type: row.get(4),
+            status: row.get(10),
+            created_at: row.get(11),
+            updated_at: row.get(12),
+        })
+    }
+
+    async fn get_migration_status_counts(
+        &self,
+        legacy_pattern: &str,
+        crabshack_pattern: &str,
+    ) -> anyhow::Result<(i64, i64, i64, i64)> {
+        let client = self.pool.get().await?;
+
+        let row = client
+            .query_one(
+                "SELECT
+                    COUNT(*) AS total,
+                    COUNT(*) FILTER (WHERE agent_api_base_url LIKE $2) AS migrated,
+                    COUNT(*) FILTER (WHERE agent_api_base_url LIKE $1) AS pending,
+                    COUNT(*) FILTER (WHERE agent_api_base_url IS NULL) AS unknown
+                 FROM agent_instances
+                 WHERE status != 'deleted'",
+                &[&legacy_pattern, &crabshack_pattern],
+            )
+            .await?;
+
+        Ok((row.get(0), row.get(1), row.get(2), row.get(3)))
+    }
 }

--- a/crates/database/src/repositories/agent_repository.rs
+++ b/crates/database/src/repositories/agent_repository.rs
@@ -1213,23 +1213,46 @@ impl AgentRepository for PostgresAgentRepository {
 
     async fn get_migration_status_counts(
         &self,
-        legacy_pattern: &str,
+        legacy_patterns: &[&str],
         crabshack_pattern: &str,
     ) -> anyhow::Result<(i64, i64, i64, i64)> {
         let client = self.pool.get().await?;
 
-        let row = client
-            .query_one(
-                "SELECT
-                    COUNT(*) AS total,
-                    COUNT(*) FILTER (WHERE agent_api_base_url LIKE $2) AS migrated,
-                    COUNT(*) FILTER (WHERE agent_api_base_url LIKE $1) AS pending,
-                    COUNT(*) FILTER (WHERE agent_api_base_url IS NULL) AS unknown
-                 FROM agent_instances
-                 WHERE status != 'deleted'",
-                &[&legacy_pattern, &crabshack_pattern],
-            )
-            .await?;
+        // Build OR clauses for multiple legacy patterns
+        let mut pending_clauses = Vec::new();
+        let mut params: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> = Vec::new();
+        let mut param_idx = 1u32;
+
+        for pattern in legacy_patterns {
+            pending_clauses.push(format!("agent_api_base_url LIKE ${}", param_idx));
+            params.push(Box::new(pattern.to_string()));
+            param_idx += 1;
+        }
+
+        let crabshack_param_idx = param_idx;
+        params.push(Box::new(crabshack_pattern.to_string()));
+
+        let pending_expr = if pending_clauses.is_empty() {
+            "FALSE".to_string()
+        } else {
+            pending_clauses.join(" OR ")
+        };
+
+        let query = format!(
+            "SELECT
+                COUNT(*) AS total,
+                COUNT(*) FILTER (WHERE agent_api_base_url LIKE ${}) AS migrated,
+                COUNT(*) FILTER (WHERE {}) AS pending,
+                COUNT(*) FILTER (WHERE agent_api_base_url IS NULL) AS unknown
+             FROM agent_instances
+             WHERE status != 'deleted'",
+            crabshack_param_idx, pending_expr
+        );
+
+        let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> =
+            params.iter().map(|p| p.as_ref() as &(dyn tokio_postgres::types::ToSql + Sync)).collect();
+
+        let row = client.query_one(&query, &param_refs).await?;
 
         Ok((row.get(0), row.get(1), row.get(2), row.get(3)))
     }

--- a/crates/database/src/repositories/agent_repository.rs
+++ b/crates/database/src/repositories/agent_repository.rs
@@ -1222,47 +1222,48 @@ impl AgentRepository for PostgresAgentRepository {
         &self,
         legacy_patterns: Vec<String>,
         crabshack_pattern: String,
-    ) -> anyhow::Result<(i64, i64, i64, i64)> {
+    ) -> anyhow::Result<(i64, i64, i64, i64, i64)> {
         let client = self.pool.get().await?;
 
-        // Build OR clauses for multiple legacy patterns
-        let mut pending_clauses = Vec::new();
         let mut params: Vec<Box<dyn tokio_postgres::types::ToSql + Sync + Send>> = Vec::new();
-        let mut param_idx = 1u32;
+        let mut idx = 1u32;
 
-        for pattern in legacy_patterns {
-            pending_clauses.push(format!("agent_api_base_url LIKE ${}", param_idx));
-            params.push(Box::new(pattern.to_string()));
-            param_idx += 1;
-        }
-
-        let crabshack_param_idx = param_idx;
-        params.push(Box::new(crabshack_pattern.to_string()));
-
-        let pending_expr = if pending_clauses.is_empty() {
+        let pending_expr = if legacy_patterns.is_empty() {
             "FALSE".to_string()
         } else {
-            pending_clauses.join(" OR ")
+            let clauses: Vec<String> = legacy_patterns
+                .into_iter()
+                .map(|p| {
+                    let clause = format!("agent_api_base_url LIKE ${}", idx);
+                    params.push(Box::new(p));
+                    idx += 1;
+                    clause
+                })
+                .collect();
+            clauses.join(" OR ")
         };
 
+        params.push(Box::new(crabshack_pattern));
+        let crabshack_idx = idx;
+
         let query = format!(
-            "SELECT
-                COUNT(*) AS total,
-                COUNT(*) FILTER (WHERE agent_api_base_url LIKE ${}) AS migrated,
-                COUNT(*) FILTER (WHERE {}) AS pending,
-                COUNT(*) FILTER (WHERE agent_api_base_url IS NULL) AS unknown
-             FROM agent_instances
-             WHERE status != 'deleted'",
-            crabshack_param_idx, pending_expr
+            "SELECT COUNT(*) AS total, \
+                    COUNT(*) FILTER (WHERE agent_api_base_url LIKE ${crabshack_idx}) AS migrated, \
+                    COUNT(*) FILTER (WHERE {pending_expr}) AS pending, \
+                    COUNT(*) FILTER (WHERE agent_api_base_url IS NULL) AS no_url \
+             FROM agent_instances WHERE status != 'deleted'"
         );
 
-        let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = params
-            .iter()
-            .map(|p| p.as_ref() as &(dyn tokio_postgres::types::ToSql + Sync))
-            .collect();
+        let refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> =
+            params.iter().map(|p| p.as_ref() as _).collect();
+        let row = client.query_one(&query, &refs).await?;
 
-        let row = client.query_one(&query, &param_refs).await?;
+        let total: i64 = row.get(0);
+        let migrated: i64 = row.get(1);
+        let pending: i64 = row.get(2);
+        let no_url: i64 = row.get(3);
+        let unknown = total - migrated - pending - no_url;
 
-        Ok((row.get(0), row.get(1), row.get(2), row.get(3)))
+        Ok((total, migrated, pending, no_url, unknown))
     }
 }

--- a/crates/database/src/repositories/agent_repository.rs
+++ b/crates/database/src/repositories/agent_repository.rs
@@ -1084,7 +1084,11 @@ impl AgentRepository for PostgresAgentRepository {
         &self,
         limit: i64,
         offset: i64,
-    ) -> anyhow::Result<(Vec<AgentInstance>, std::collections::HashMap<Uuid, DateTime<Utc>>, i64)> {
+    ) -> anyhow::Result<(
+        Vec<AgentInstance>,
+        std::collections::HashMap<Uuid, DateTime<Utc>>,
+        i64,
+    )> {
         let client = self.pool.get().await?;
 
         let count_row = client
@@ -1173,9 +1177,10 @@ impl AgentRepository for PostgresAgentRepository {
 
         if set_clauses.is_empty() {
             // No changes, just return current instance
-            return self.get_instance(instance_id).await?.ok_or_else(|| {
-                anyhow::anyhow!("Instance not found: instance_id={}", instance_id)
-            });
+            return self
+                .get_instance(instance_id)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("Instance not found: instance_id={}", instance_id));
         }
 
         set_clauses.push("updated_at = NOW()".to_string());
@@ -1189,8 +1194,10 @@ impl AgentRepository for PostgresAgentRepository {
         );
         param_values.push(Box::new(instance_id));
 
-        let params: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> =
-            param_values.iter().map(|p| p.as_ref() as &(dyn tokio_postgres::types::ToSql + Sync)).collect();
+        let params: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = param_values
+            .iter()
+            .map(|p| p.as_ref() as &(dyn tokio_postgres::types::ToSql + Sync))
+            .collect();
 
         let row = client.query_one(&query, &params).await?;
 
@@ -1249,8 +1256,10 @@ impl AgentRepository for PostgresAgentRepository {
             crabshack_param_idx, pending_expr
         );
 
-        let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> =
-            params.iter().map(|p| p.as_ref() as &(dyn tokio_postgres::types::ToSql + Sync)).collect();
+        let param_refs: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = params
+            .iter()
+            .map(|p| p.as_ref() as &(dyn tokio_postgres::types::ToSql + Sync))
+            .collect();
 
         let row = client.query_one(&query, &param_refs).await?;
 

--- a/crates/database/src/repositories/agent_repository.rs
+++ b/crates/database/src/repositories/agent_repository.rs
@@ -1213,8 +1213,8 @@ impl AgentRepository for PostgresAgentRepository {
 
     async fn get_migration_status_counts(
         &self,
-        legacy_patterns: &[&str],
-        crabshack_pattern: &str,
+        legacy_patterns: Vec<String>,
+        crabshack_pattern: String,
     ) -> anyhow::Result<(i64, i64, i64, i64)> {
         let client = self.pool.get().await?;
 

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -41,8 +41,6 @@ hmac = "0.12"
 sha2 = "0.10"
 # X25519 key derivation for age encryption (backup keypair derivation)
 x25519-dalek = { version = "2", features = ["static_secrets"] }
-# Bech32 encoding for age key formatting
-bech32 = "0.11"
 dstack-sdk = "0.1"
 # OpenTelemetry for metrics
 opentelemetry = { version = "0.31", features = ["metrics"] }

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -39,6 +39,10 @@ rmcp = { version = "0.6", features = [
 hex = "0.4"
 hmac = "0.12"
 sha2 = "0.10"
+# X25519 key derivation for age encryption (backup keypair derivation)
+x25519-dalek = { version = "2", features = ["static_secrets"] }
+# Bech32 encoding for age key formatting
+bech32 = "0.11"
 dstack-sdk = "0.1"
 # OpenTelemetry for metrics
 opentelemetry = { version = "0.31", features = ["metrics"] }

--- a/crates/services/src/agent/age_derivation.rs
+++ b/crates/services/src/agent/age_derivation.rs
@@ -1,6 +1,6 @@
 //! Deterministic age X25519 keypair derivation from a passphrase.
 //!
-//! Produces IDENTICAL output to CrabShack's TypeScript implementation at
+//! Intended to produce identical output to CrabShack's TypeScript implementation at
 //! `orchestrator-api/src/backup/age-identity.ts`.
 //!
 //! Algorithm:
@@ -172,13 +172,15 @@ mod tests {
         assert_ne!(r1, r2);
     }
 
-    // TODO: Add golden test vectors from CrabShack TypeScript implementation.
+    // Golden test vectors from CrabShack TypeScript implementation.
     // Run the TypeScript `deriveAgeKeypair("test-passphrase", "golden-test-instance")`
-    // and add the expected (recipient, identity) here.
+    // and fill in the expected (recipient, identity) here.
     #[test]
-    fn test_golden_vectors_placeholder() {
-        let (_recipient, _identity) = derive_age_keypair("test-passphrase", "golden-test-instance");
-        // TODO: Uncomment after generating golden values from TypeScript:
+    #[ignore = "golden vectors not yet generated from TypeScript implementation"]
+    fn test_golden_vectors() {
+        let (recipient, identity) = derive_age_keypair("test-passphrase", "golden-test-instance");
+        // TODO: Fill in after generating golden values from TypeScript:
+        let _ = (recipient, identity);
         // assert_eq!(recipient, "age1...");
         // assert_eq!(identity, "AGE-SECRET-KEY-1...");
     }

--- a/crates/services/src/agent/age_derivation.rs
+++ b/crates/services/src/agent/age_derivation.rs
@@ -172,17 +172,32 @@ mod tests {
         assert_ne!(r1, r2);
     }
 
-    // Golden test vectors from CrabShack TypeScript implementation.
-    // Run the TypeScript `deriveAgeKeypair("test-passphrase", "golden-test-instance")`
-    // and fill in the expected (recipient, identity) here.
     #[test]
-    #[ignore = "golden vectors not yet generated from TypeScript implementation"]
-    fn test_golden_vectors() {
-        let (recipient, identity) = derive_age_keypair("test-passphrase", "golden-test-instance");
-        // TODO: Fill in after generating golden values from TypeScript:
-        let _ = (recipient, identity);
-        // assert_eq!(recipient, "age1...");
-        // assert_eq!(identity, "AGE-SECRET-KEY-1...");
+    fn test_golden_vector_1() {
+        let (r, i) = derive_age_keypair("test-passphrase", "golden-test-instance");
+        assert_eq!(r, "age1x96uqc6ucwvsfeqj0p83dme4ve76xj6jh9v5q2tcez8efqg7g9zs9kdp0y");
+        assert_eq!(i, "AGE-SECRET-KEY-1S6ZSMWVK9M6MRMRQW5V5G099ZDK4PHKE9HD3QKM527E5ET4D0Y3S8GVUCK");
+    }
+
+    #[test]
+    fn test_golden_vector_2() {
+        let (r, i) = derive_age_keypair("abc123def456", "mighty-jay");
+        assert_eq!(r, "age1shyzgr34w6cw4kkp9pny725cduu7u3xfntx79u8nzgzseh0pyguqnr882m");
+        assert_eq!(i, "AGE-SECRET-KEY-1HDD0KF7VU5HWEF4VS96Q5EQQFDXH8E8A7VN75YWGC8WZ73AZTVZQJ7V8SU");
+    }
+
+    #[test]
+    fn test_golden_vector_3_empty_passphrase() {
+        let (r, i) = derive_age_keypair("", "empty-passphrase");
+        assert_eq!(r, "age1xhfpav4rtg4286njkse6akpwyq6l80xgw7tw5cxz5m3k46l99plqp6mzke");
+        assert_eq!(i, "AGE-SECRET-KEY-13ZNRYFR3X7RQUZNNCP6FCCAJ73X82F2WUUSM3MS8NG5A8LJ90L8S46PSE5");
+    }
+
+    #[test]
+    fn test_golden_vector_4_special_chars() {
+        let (r, i) = derive_age_keypair("a]very/long+passphrase!with@special#chars$", "special-chars-test");
+        assert_eq!(r, "age12ayk7rn78uujvqp4a7cae42g6hvzjx8dgkrgcc6zulq32ffmq3ts0npdgp");
+        assert_eq!(i, "AGE-SECRET-KEY-169JM43WKP2FSJ3XX6VZA6DYHPP0TTYJUPH9UNAJ72XS4TDCX5ATQY4GGMT");
     }
 
     #[test]

--- a/crates/services/src/agent/age_derivation.rs
+++ b/crates/services/src/agent/age_derivation.rs
@@ -1,0 +1,196 @@
+//! Deterministic age X25519 keypair derivation from a passphrase.
+//!
+//! Produces IDENTICAL output to CrabShack's TypeScript implementation at
+//! `orchestrator-api/src/backup/age-identity.ts`.
+//!
+//! Algorithm:
+//! 1. HKDF-SHA256(salt="crabshack", ikm=passphrase, info="age-keypair-v2:{instanceName}") -> 32-byte seed
+//! 2. X25519 scalar multiplication: public_key = seed * basepoint
+//! 3. recipient = bech32_encode("age", public_key_bytes)
+//! 4. identity = bech32_encode("age-secret-key-", seed).to_uppercase()
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Bech32 character set (BIP173)
+const BECH32_CHARSET: &[u8] = b"qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+const BECH32_GEN: [u32; 5] = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
+
+fn bech32_polymod(values: &[u8]) -> u32 {
+    let mut chk: u32 = 1;
+    for &v in values {
+        let top = chk >> 25;
+        chk = ((chk & 0x1ffffff) << 5) ^ (v as u32);
+        for (i, gen) in BECH32_GEN.iter().enumerate() {
+            if (top >> i) & 1 != 0 {
+                chk ^= gen;
+            }
+        }
+    }
+    chk
+}
+
+fn bech32_hrp_expand(hrp: &str) -> Vec<u8> {
+    let mut r = Vec::with_capacity(hrp.len() * 2 + 1);
+    for c in hrp.bytes() {
+        r.push(c >> 5);
+    }
+    r.push(0);
+    for c in hrp.bytes() {
+        r.push(c & 31);
+    }
+    r
+}
+
+fn convert_bits_8_to_5(data: &[u8]) -> Vec<u8> {
+    let mut acc: u32 = 0;
+    let mut bits: u32 = 0;
+    let mut out = Vec::new();
+    for &b in data {
+        acc = (acc << 8) | (b as u32);
+        bits += 8;
+        while bits >= 5 {
+            bits -= 5;
+            out.push(((acc >> bits) & 31) as u8);
+        }
+    }
+    if bits > 0 {
+        out.push(((acc << (5 - bits)) & 31) as u8);
+    }
+    out
+}
+
+fn bech32_encode(hrp: &str, data: &[u8]) -> String {
+    let dp = convert_bits_8_to_5(data);
+    let lhrp = hrp.to_lowercase();
+    let hrp_expanded = bech32_hrp_expand(&lhrp);
+
+    let mut values = hrp_expanded;
+    values.extend_from_slice(&dp);
+    values.extend_from_slice(&[0, 0, 0, 0, 0, 0]);
+
+    let pm = bech32_polymod(&values) ^ 1;
+
+    let mut result = lhrp;
+    result.push('1');
+    for &v in &dp {
+        result.push(BECH32_CHARSET[v as usize] as char);
+    }
+    for i in 0..6 {
+        let idx = ((pm >> (5 * (5 - i))) & 31) as usize;
+        result.push(BECH32_CHARSET[idx] as char);
+    }
+    result
+}
+
+/// HKDF-SHA256 Extract + Expand (single-block, 32-byte output).
+///
+/// Matches the TypeScript: `createHmac("sha256", salt).update(ikm).digest()` for PRK,
+/// then `createHmac("sha256", prk).update(info || 0x01).digest()[0..32]` for OKM.
+fn hkdf_sha256(ikm: &str, salt: &str, info: &str) -> [u8; 32] {
+    // Extract: PRK = HMAC-SHA256(key=salt, data=ikm)
+    let mut mac =
+        HmacSha256::new_from_slice(salt.as_bytes()).expect("HMAC accepts any key length");
+    mac.update(ikm.as_bytes());
+    let prk = mac.finalize().into_bytes();
+
+    // Expand: OKM = HMAC-SHA256(key=PRK, data=(info || 0x01))[0..32]
+    let mut mac =
+        HmacSha256::new_from_slice(&prk).expect("HMAC accepts any key length");
+    mac.update(info.as_bytes());
+    mac.update(&[0x01]);
+    let okm = mac.finalize().into_bytes();
+
+    let mut seed = [0u8; 32];
+    seed.copy_from_slice(&okm[..32]);
+    seed
+}
+
+/// Derive a deterministic age X25519 keypair from a passphrase and instance name.
+///
+/// Returns `(recipient, identity)` where:
+/// - `recipient` is the bech32-encoded public key (e.g., "age1...")
+/// - `identity` is the bech32-encoded seed (e.g., "AGE-SECRET-KEY-1...")
+pub fn derive_age_keypair(passphrase: &str, instance_name: &str) -> (String, String) {
+    let info = format!("age-keypair-v2:{}", instance_name);
+    let seed = hkdf_sha256(passphrase, "crabshack", &info);
+
+    // X25519: derive public key from seed (used as static secret / scalar)
+    let secret = x25519_dalek::StaticSecret::from(seed);
+    let public = x25519_dalek::PublicKey::from(&secret);
+    let public_bytes = public.as_bytes();
+
+    let recipient = bech32_encode("age", public_bytes);
+    let identity = bech32_encode("age-secret-key-", &seed).to_uppercase();
+
+    (recipient, identity)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hkdf_deterministic() {
+        let seed1 = hkdf_sha256("pass", "crabshack", "age-keypair-v2:test");
+        let seed2 = hkdf_sha256("pass", "crabshack", "age-keypair-v2:test");
+        assert_eq!(seed1, seed2);
+    }
+
+    #[test]
+    fn test_hkdf_different_inputs() {
+        let seed1 = hkdf_sha256("pass1", "crabshack", "age-keypair-v2:test");
+        let seed2 = hkdf_sha256("pass2", "crabshack", "age-keypair-v2:test");
+        assert_ne!(seed1, seed2);
+    }
+
+    #[test]
+    fn test_derive_age_keypair_format() {
+        let (recipient, identity) = derive_age_keypair("test-passphrase", "my-instance");
+        assert!(recipient.starts_with("age1"), "recipient should start with 'age1': {}", recipient);
+        assert!(
+            identity.starts_with("AGE-SECRET-KEY-1"),
+            "identity should start with 'AGE-SECRET-KEY-1': {}",
+            identity
+        );
+    }
+
+    #[test]
+    fn test_derive_age_keypair_deterministic() {
+        let (r1, i1) = derive_age_keypair("pass", "inst");
+        let (r2, i2) = derive_age_keypair("pass", "inst");
+        assert_eq!(r1, r2);
+        assert_eq!(i1, i2);
+    }
+
+    #[test]
+    fn test_derive_age_keypair_different_instances() {
+        let (r1, _) = derive_age_keypair("pass", "inst-a");
+        let (r2, _) = derive_age_keypair("pass", "inst-b");
+        assert_ne!(r1, r2);
+    }
+
+    // TODO: Add golden test vectors from CrabShack TypeScript implementation.
+    // Run the TypeScript `deriveAgeKeypair("test-passphrase", "golden-test-instance")`
+    // and add the expected (recipient, identity) here.
+    #[test]
+    fn test_golden_vectors_placeholder() {
+        let (_recipient, _identity) = derive_age_keypair("test-passphrase", "golden-test-instance");
+        // TODO: Uncomment after generating golden values from TypeScript:
+        // assert_eq!(recipient, "age1...");
+        // assert_eq!(identity, "AGE-SECRET-KEY-1...");
+    }
+
+    #[test]
+    fn test_bech32_encode_roundtrip_format() {
+        // Verify bech32 encoding produces valid-looking output
+        let data = [0u8; 32];
+        let encoded = bech32_encode("age", &data);
+        assert!(encoded.starts_with("age1"));
+        // age1 + 52 data chars + 6 checksum chars = 62 total for 32-byte input
+        // 32 bytes = 256 bits -> ceil(256/5) = 52 5-bit groups
+        assert_eq!(encoded.len(), 4 + 52 + 6); // "age1" prefix + data + checksum
+    }
+}

--- a/crates/services/src/agent/age_derivation.rs
+++ b/crates/services/src/agent/age_derivation.rs
@@ -91,14 +91,12 @@ fn bech32_encode(hrp: &str, data: &[u8]) -> String {
 /// then `createHmac("sha256", prk).update(info || 0x01).digest()[0..32]` for OKM.
 fn hkdf_sha256(ikm: &str, salt: &str, info: &str) -> [u8; 32] {
     // Extract: PRK = HMAC-SHA256(key=salt, data=ikm)
-    let mut mac =
-        HmacSha256::new_from_slice(salt.as_bytes()).expect("HMAC accepts any key length");
+    let mut mac = HmacSha256::new_from_slice(salt.as_bytes()).expect("HMAC accepts any key length");
     mac.update(ikm.as_bytes());
     let prk = mac.finalize().into_bytes();
 
     // Expand: OKM = HMAC-SHA256(key=PRK, data=(info || 0x01))[0..32]
-    let mut mac =
-        HmacSha256::new_from_slice(&prk).expect("HMAC accepts any key length");
+    let mut mac = HmacSha256::new_from_slice(&prk).expect("HMAC accepts any key length");
     mac.update(info.as_bytes());
     mac.update(&[0x01]);
     let okm = mac.finalize().into_bytes();
@@ -149,7 +147,11 @@ mod tests {
     #[test]
     fn test_derive_age_keypair_format() {
         let (recipient, identity) = derive_age_keypair("test-passphrase", "my-instance");
-        assert!(recipient.starts_with("age1"), "recipient should start with 'age1': {}", recipient);
+        assert!(
+            recipient.starts_with("age1"),
+            "recipient should start with 'age1': {}",
+            recipient
+        );
         assert!(
             identity.starts_with("AGE-SECRET-KEY-1"),
             "identity should start with 'AGE-SECRET-KEY-1': {}",
@@ -175,29 +177,56 @@ mod tests {
     #[test]
     fn test_golden_vector_1() {
         let (r, i) = derive_age_keypair("test-passphrase", "golden-test-instance");
-        assert_eq!(r, "age1x96uqc6ucwvsfeqj0p83dme4ve76xj6jh9v5q2tcez8efqg7g9zs9kdp0y");
-        assert_eq!(i, "AGE-SECRET-KEY-1S6ZSMWVK9M6MRMRQW5V5G099ZDK4PHKE9HD3QKM527E5ET4D0Y3S8GVUCK");
+        assert_eq!(
+            r,
+            "age1x96uqc6ucwvsfeqj0p83dme4ve76xj6jh9v5q2tcez8efqg7g9zs9kdp0y"
+        );
+        assert_eq!(
+            i,
+            "AGE-SECRET-KEY-1S6ZSMWVK9M6MRMRQW5V5G099ZDK4PHKE9HD3QKM527E5ET4D0Y3S8GVUCK"
+        );
     }
 
     #[test]
     fn test_golden_vector_2() {
         let (r, i) = derive_age_keypair("abc123def456", "mighty-jay");
-        assert_eq!(r, "age1shyzgr34w6cw4kkp9pny725cduu7u3xfntx79u8nzgzseh0pyguqnr882m");
-        assert_eq!(i, "AGE-SECRET-KEY-1HDD0KF7VU5HWEF4VS96Q5EQQFDXH8E8A7VN75YWGC8WZ73AZTVZQJ7V8SU");
+        assert_eq!(
+            r,
+            "age1shyzgr34w6cw4kkp9pny725cduu7u3xfntx79u8nzgzseh0pyguqnr882m"
+        );
+        assert_eq!(
+            i,
+            "AGE-SECRET-KEY-1HDD0KF7VU5HWEF4VS96Q5EQQFDXH8E8A7VN75YWGC8WZ73AZTVZQJ7V8SU"
+        );
     }
 
     #[test]
     fn test_golden_vector_3_empty_passphrase() {
         let (r, i) = derive_age_keypair("", "empty-passphrase");
-        assert_eq!(r, "age1xhfpav4rtg4286njkse6akpwyq6l80xgw7tw5cxz5m3k46l99plqp6mzke");
-        assert_eq!(i, "AGE-SECRET-KEY-13ZNRYFR3X7RQUZNNCP6FCCAJ73X82F2WUUSM3MS8NG5A8LJ90L8S46PSE5");
+        assert_eq!(
+            r,
+            "age1xhfpav4rtg4286njkse6akpwyq6l80xgw7tw5cxz5m3k46l99plqp6mzke"
+        );
+        assert_eq!(
+            i,
+            "AGE-SECRET-KEY-13ZNRYFR3X7RQUZNNCP6FCCAJ73X82F2WUUSM3MS8NG5A8LJ90L8S46PSE5"
+        );
     }
 
     #[test]
     fn test_golden_vector_4_special_chars() {
-        let (r, i) = derive_age_keypair("a]very/long+passphrase!with@special#chars$", "special-chars-test");
-        assert_eq!(r, "age12ayk7rn78uujvqp4a7cae42g6hvzjx8dgkrgcc6zulq32ffmq3ts0npdgp");
-        assert_eq!(i, "AGE-SECRET-KEY-169JM43WKP2FSJ3XX6VZA6DYHPP0TTYJUPH9UNAJ72XS4TDCX5ATQY4GGMT");
+        let (r, i) = derive_age_keypair(
+            "a]very/long+passphrase!with@special#chars$",
+            "special-chars-test",
+        );
+        assert_eq!(
+            r,
+            "age12ayk7rn78uujvqp4a7cae42g6hvzjx8dgkrgcc6zulq32ffmq3ts0npdgp"
+        );
+        assert_eq!(
+            i,
+            "AGE-SECRET-KEY-169JM43WKP2FSJ3XX6VZA6DYHPP0TTYJUPH9UNAJ72XS4TDCX5ATQY4GGMT"
+        );
     }
 
     #[test]

--- a/crates/services/src/agent/mod.rs
+++ b/crates/services/src/agent/mod.rs
@@ -1,3 +1,4 @@
+pub mod age_derivation;
 pub mod ports;
 pub mod proxy;
 pub mod service;

--- a/crates/services/src/agent/ports.rs
+++ b/crates/services/src/agent/ports.rs
@@ -382,8 +382,8 @@ pub trait AgentRepository: Send + Sync {
     /// Returns (total, migrated, pending, unknown).
     async fn get_migration_status_counts(
         &self,
-        legacy_patterns: &[&str],
-        crabshack_pattern: &str,
+        legacy_patterns: Vec<String>,
+        crabshack_pattern: String,
     ) -> anyhow::Result<(i64, i64, i64, i64)>;
 }
 

--- a/crates/services/src/agent/ports.rs
+++ b/crates/services/src/agent/ports.rs
@@ -358,6 +358,33 @@ pub trait AgentRepository: Send + Sync {
     ) -> anyhow::Result<()>;
 
     async fn get_user_total_spending(&self, user_id: UserId) -> anyhow::Result<i64>;
+
+    /// List all instances with last_usage_at from agent_balance (admin only).
+    /// Returns (instances, last_usage_at_map, total_count).
+    async fn list_all_instances_with_usage(
+        &self,
+        limit: i64,
+        offset: i64,
+    ) -> anyhow::Result<(Vec<AgentInstance>, std::collections::HashMap<Uuid, DateTime<Utc>>, i64)>;
+
+    /// Admin update instance fields for migration (agent_api_base_url, instance_url, instance_token, dashboard_url).
+    /// Only updates fields that are Some. instance_token is stored already-encrypted.
+    async fn admin_update_instance(
+        &self,
+        instance_id: Uuid,
+        agent_api_base_url: Option<String>,
+        instance_url: Option<String>,
+        encrypted_instance_token: Option<String>,
+        dashboard_url: Option<String>,
+    ) -> anyhow::Result<AgentInstance>;
+
+    /// Get migration status counts grouped by agent_api_base_url pattern.
+    /// Returns (total, migrated, pending, unknown).
+    async fn get_migration_status_counts(
+        &self,
+        legacy_pattern: &str,
+        crabshack_pattern: &str,
+    ) -> anyhow::Result<(i64, i64, i64, i64)>;
 }
 
 /// Service trait for agent business logic
@@ -585,4 +612,12 @@ pub trait AgentService: Send + Sync {
         instance_id: Uuid,
         user_id: UserId,
     ) -> anyhow::Result<Option<InstanceBalance>>;
+
+    /// Find the configured manager whose URL matches a given agent_api_base_url.
+    /// Returns the manager config (URL + token) if found.
+    fn find_manager_for_url(&self, agent_api_base_url: &str) -> Option<config::AgentManager>;
+
+    /// Find a CrabShack (non-legacy) manager suitable for import.
+    /// Returns the first manager whose URL does NOT match the legacy compose-api pattern.
+    fn find_crabshack_manager(&self) -> Option<config::AgentManager>;
 }

--- a/crates/services/src/agent/ports.rs
+++ b/crates/services/src/agent/ports.rs
@@ -361,6 +361,7 @@ pub trait AgentRepository: Send + Sync {
 
     /// List all instances with last_usage_at from agent_balance (admin only).
     /// Returns (instances, last_usage_at_map, total_count).
+    #[allow(clippy::type_complexity)]
     async fn list_all_instances_with_usage(
         &self,
         limit: i64,

--- a/crates/services/src/agent/ports.rs
+++ b/crates/services/src/agent/ports.rs
@@ -383,13 +383,12 @@ pub trait AgentRepository: Send + Sync {
         dashboard_url: Option<String>,
     ) -> anyhow::Result<AgentInstance>;
 
-    /// Get migration status counts grouped by agent_api_base_url pattern.
-    /// Returns (total, migrated, pending, unknown).
+    /// Returns (total, migrated, pending, no_url, unknown).
     async fn get_migration_status_counts(
         &self,
         legacy_patterns: Vec<String>,
         crabshack_pattern: String,
-    ) -> anyhow::Result<(i64, i64, i64, i64)>;
+    ) -> anyhow::Result<(i64, i64, i64, i64, i64)>;
 }
 
 /// Service trait for agent business logic

--- a/crates/services/src/agent/ports.rs
+++ b/crates/services/src/agent/ports.rs
@@ -621,7 +621,9 @@ pub trait AgentService: Send + Sync {
     /// Returns the manager config (URL + token) if found.
     fn find_manager_for_url(&self, agent_api_base_url: &str) -> Option<config::AgentManager>;
 
-    /// Find a CrabShack (non-legacy) manager suitable for import.
-    /// Returns the first manager whose URL does NOT match the legacy compose-api pattern.
+    /// Find a CrabShack manager by URL containing "crabshack".
     fn find_crabshack_manager(&self) -> Option<config::AgentManager>;
+
+    /// All configured manager URLs.
+    fn manager_urls(&self) -> Vec<String>;
 }

--- a/crates/services/src/agent/ports.rs
+++ b/crates/services/src/agent/ports.rs
@@ -365,7 +365,11 @@ pub trait AgentRepository: Send + Sync {
         &self,
         limit: i64,
         offset: i64,
-    ) -> anyhow::Result<(Vec<AgentInstance>, std::collections::HashMap<Uuid, DateTime<Utc>>, i64)>;
+    ) -> anyhow::Result<(
+        Vec<AgentInstance>,
+        std::collections::HashMap<Uuid, DateTime<Utc>>,
+        i64,
+    )>;
 
     /// Admin update instance fields for migration (agent_api_base_url, instance_url, instance_token, dashboard_url).
     /// Only updates fields that are Some. instance_token is stored already-encrypted.

--- a/crates/services/src/agent/ports.rs
+++ b/crates/services/src/agent/ports.rs
@@ -382,7 +382,7 @@ pub trait AgentRepository: Send + Sync {
     /// Returns (total, migrated, pending, unknown).
     async fn get_migration_status_counts(
         &self,
-        legacy_pattern: &str,
+        legacy_patterns: &[&str],
         crabshack_pattern: &str,
     ) -> anyhow::Result<(i64, i64, i64, i64)>;
 }

--- a/crates/services/src/agent/service.rs
+++ b/crates/services/src/agent/service.rs
@@ -3967,9 +3967,10 @@ impl AgentService for AgentServiceImpl {
     }
 
     fn find_manager_for_url(&self, agent_api_base_url: &str) -> Option<config::AgentManager> {
+        let normalized = agent_api_base_url.trim_end_matches('/');
         self.managers
             .iter()
-            .find(|m| m.url == agent_api_base_url)
+            .find(|m| m.url.trim_end_matches('/') == normalized)
             .cloned()
     }
 

--- a/crates/services/src/agent/service.rs
+++ b/crates/services/src/agent/service.rs
@@ -3975,18 +3975,10 @@ impl AgentService for AgentServiceImpl {
     }
 
     fn find_crabshack_manager(&self) -> Option<config::AgentManager> {
-        // Find a manager that is NOT a legacy compose-api (not non-TEE)
         self.managers
             .iter()
-            .find(|m| !m.get_is_non_tee())
+            .find(|m| m.url.contains("crabshack"))
             .cloned()
-            .or_else(|| {
-                // Fallback: find any manager whose URL does not match the non-TEE pattern
-                self.managers
-                    .iter()
-                    .find(|m| !m.url.contains(&self.non_tee_agent_url_pattern))
-                    .cloned()
-            })
     }
 }
 

--- a/crates/services/src/agent/service.rs
+++ b/crates/services/src/agent/service.rs
@@ -3965,6 +3965,30 @@ impl AgentService for AgentServiceImpl {
 
         Ok(balance)
     }
+
+    fn find_manager_for_url(&self, agent_api_base_url: &str) -> Option<config::AgentManager> {
+        self.managers
+            .iter()
+            .find(|m| m.url == agent_api_base_url)
+            .cloned()
+    }
+
+    fn find_crabshack_manager(&self) -> Option<config::AgentManager> {
+        // Find a manager that is NOT a legacy compose-api (not non-TEE)
+        self.managers
+            .iter()
+            .find(|m| !m.get_is_non_tee())
+            .cloned()
+            .or_else(|| {
+                // Fallback: find any manager whose URL does not match the non-TEE pattern
+                self.managers
+                    .iter()
+                    .find(|m| {
+                        !m.url.contains(&self.non_tee_agent_url_pattern)
+                    })
+                    .cloned()
+            })
+    }
 }
 
 /// Response structure from crabshack /images endpoint

--- a/crates/services/src/agent/service.rs
+++ b/crates/services/src/agent/service.rs
@@ -3980,6 +3980,10 @@ impl AgentService for AgentServiceImpl {
             .find(|m| m.url.contains("crabshack"))
             .cloned()
     }
+
+    fn manager_urls(&self) -> Vec<String> {
+        self.managers.iter().map(|m| m.url.clone()).collect()
+    }
 }
 
 /// Response structure from crabshack /images endpoint

--- a/crates/services/src/agent/service.rs
+++ b/crates/services/src/agent/service.rs
@@ -3984,9 +3984,7 @@ impl AgentService for AgentServiceImpl {
                 // Fallback: find any manager whose URL does not match the non-TEE pattern
                 self.managers
                     .iter()
-                    .find(|m| {
-                        !m.url.contains(&self.non_tee_agent_url_pattern)
-                    })
+                    .find(|m| !m.url.contains(&self.non_tee_agent_url_pattern))
                     .cloned()
             })
     }


### PR DESCRIPTION
One of three legacy TEE to crabsack migration PRs. See also https://github.com/Near-One/ai-infra-agent-hosting/pull/304 https://github.com/nearai/openclaw-nearai-worker/pull/225

Here we define migration flow which will encrypt agent contents, submits them to crabshack and on success switches urls to crabshack ones.

## Summary

- `GET /v1/admin/agents/instances` now returns `agent_api_base_url` and `last_usage_at` (LEFT JOIN with agent_balance)
- `PATCH /v1/admin/agents/instances/{id}` — new endpoint to update instance URLs and token for migration
- `GET /v1/admin/agents/instances/migration-status` — counts migrated/pending/unknown instances
- `POST /v1/admin/agents/instances/{id}/migrate` — orchestrates full migration flow:
  1. Verifies legacy instance, looks up/creates backup_passphrase
  2. Derives age recipient via HKDF-SHA256 + X25519 (matching CrabShack TypeScript)
  3. Decrypts + validates instance_token (detects unwrap_or fallback failures)
  4. Starts stopped instances, creates encrypted backup on compose-api
  5. Imports into CrabShack, updates chat-api DB to point to CrabShack
  6. Stores overwritten legacy URLs in extra_env for rollback reference
  7. Best-effort restart on compose-api if any step fails
- New age_derivation.rs module with HKDF + X25519 + bech32 (TODO: golden test vectors from TypeScript)
- find_manager_for_url() and find_crabshack_manager() service helpers

## Test plan

- [x] Compilation clean
- [x] 7 unit tests for age derivation (determinism, format, different inputs)
- [ ] Golden test vectors from CrabShack TypeScript (HKDF bit-for-bit match)
- [ ] E2E: migrate a dev instance via staging chat-api
- [ ] Verify admin list includes new fields
- [ ] Verify PATCH endpoint updates correctly

Part of the legacy to CrabShack migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)