### PR TITLE
fix(patroni): tolerate string "unknown" lag from stopped cluster members

### DIFF
--- a/crates/database/src/patroni_discovery.rs
+++ b/crates/database/src/patroni_discovery.rs
@@ -1,11 +1,35 @@
 use anyhow::{anyhow, Result};
 use reqwest::Client;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 use tokio::time;
 use tracing::{debug, error, info, warn};
+
+/// Patroni reports `lag` as an integer for streaming members, but emits the
+/// string `"unknown"` for members it cannot measure (e.g. `stopped`, `crashed`,
+/// or `start failed` replicas). A bare `Option<i64>` rejects that string and
+/// fails the entire `/cluster` parse, which would freeze topology discovery (or
+/// abort startup) over a single unhealthy member. Coerce any non-integer value
+/// to `None` so the rest of the cluster still parses.
+fn deserialize_lag<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Lag {
+        Int(i64),
+        Other(serde::de::IgnoredAny),
+    }
+
+    Ok(match Option::<Lag>::deserialize(deserializer)? {
+        Some(Lag::Int(n)) => Some(n),
+        // "unknown", null, or any other non-integer value -> unknown lag
+        _ => None,
+    })
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClusterMember {
@@ -14,7 +38,7 @@ pub struct ClusterMember {
     pub port: u16,
     pub role: String,
     pub state: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_lag")]
     pub lag: Option<i64>,
     #[serde(default)]
     pub timeline: Option<i64>,
@@ -401,5 +425,46 @@ mod tests {
         let info: ClusterInfo = serde_json::from_str(json).unwrap();
         assert_eq!(info.members.len(), 2);
         assert_eq!(info.scope.as_deref(), Some("pg-cluster"));
+    }
+
+    #[test]
+    fn test_member_with_string_lag_unknown() {
+        // Patroni reports `lag` as the string "unknown" for stopped/crashed
+        // members. This must not fail parsing of the member.
+        let json = r#"{
+            "name": "b5eecc86101d",
+            "host": "postgres-prod-vzeis375.dstack.internal",
+            "port": 5432,
+            "role": "replica",
+            "state": "stopped",
+            "lag": "unknown"
+        }"#;
+
+        let member: ClusterMember = serde_json::from_str(json).unwrap();
+        assert_eq!(member.state, "stopped");
+        assert!(member.lag.is_none());
+    }
+
+    #[test]
+    fn test_cluster_with_stopped_member_string_lag() {
+        // Regression: a single stopped replica reporting `"lag": "unknown"` must
+        // not poison the whole cluster parse. Exact payload that previously
+        // returned `invalid type: string "unknown", expected i64`.
+        let json = r#"{"members": [{"name": "0513d70cb4dc", "role": "replica", "state": "streaming", "api_url": "http://[postgres-ikupakqr.dstack.internal:8008]:8008/patroni", "host": "postgres-ikupakqr.dstack.internal", "port": 5432, "timeline": 3, "lag": 0}, {"name": "b5eecc86101d", "role": "replica", "state": "stopped", "api_url": "http://[postgres-prod-vzeis375.dstack.internal:8008]:8008/patroni", "host": "postgres-prod-vzeis375.dstack.internal", "port": 5432, "lag": "unknown"}, {"name": "d2fb312c9ab6", "role": "leader", "state": "running", "api_url": "http://[postgres-qr5ygiq4.dstack.internal:8008]:8008/patroni", "host": "postgres-qr5ygiq4.dstack.internal", "port": 5432, "timeline": 3}], "scope": "pg-cluster"}"#;
+
+        let info: ClusterInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.members.len(), 3);
+        let stopped = info
+            .members
+            .iter()
+            .find(|m| m.name == "b5eecc86101d")
+            .unwrap();
+        assert!(stopped.lag.is_none());
+        let streaming = info
+            .members
+            .iter()
+            .find(|m| m.name == "0513d70cb4dc")
+            .unwrap();
+        assert_eq!(streaming.lag, Some(0));
     }
 }


### PR DESCRIPTION
Author: @end · please review.

## Problem

Patroni's `/cluster` REST endpoint reports `lag` as an integer for streaming members, but emits the **string** `"unknown"` for members it cannot measure — `stopped`, `crashed`, or `start failed` replicas. Our `ClusterMember.lag: Option<i64>` rejects that string, so a **single** unhealthy member fails the **entire** `/cluster` parse:

```
Failed to parse cluster info: error decoding response body
  (invalid type: string "unknown", expected i64)
```

This fired in production today (2026-06-05) — ~96 occurrences across `chat-api`/`chat-api-worker` (and 151 on `cloud-api`) — triggered by a stopped replica (`postgres-prod-vzeis375`, `"lag": "unknown"`) appearing in the member list. It cleared the instant the replica was removed.

## Impact

- **Running service:** the background refresh logs `Failed to refresh cluster state` and `ClusterState` freezes at its last-known-good value — the service is blind to any real failover during the window.
- **Restart/deploy:** `Database::new` calls `discovery.update_cluster_state().await?`, so the parse error aborts startup with `No leader found in cluster during initialization`. A pod restarting while a stopped replica is in the list **cannot boot the DB layer at all**, despite a perfectly healthy leader.

## Fix

Custom `deserialize_lag` that accepts an integer or coerces any non-integer value (`"unknown"`, `null`, absent) to `None`. The stopped member already sorts last in `get_replicas_by_lag` (`unwrap_or(i64::MAX)`) and is excluded from selection by its non-`running`/`streaming` state, so behavior is unchanged for healthy members — the cluster just parses instead of erroring.

## Tests

- `test_member_with_string_lag_unknown` — single stopped member with `"lag": "unknown"` parses, `lag == None`.
- `test_cluster_with_stopped_member_string_lag` — the **exact** production payload that previously failed now parses all 3 members; streaming member keeps `lag == Some(0)`.

`cargo test -p database patroni` → 7 passed.

## Note

`cloud-api` has a byte-identical `patroni_discovery.rs` and the same bug — companion PR nearai/cloud-api#727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)