### PR TITLE
fix(api): machine-readable code for plan-gated model errors

### DIFF
--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -166,6 +166,7 @@ use utoipa::OpenApi;
         // Conversation share models
         crate::routes::api::ErrorResponse,
         crate::routes::api::ModelNotAllowedErrorResponse,
+        crate::routes::api::ForbiddenErrorResponse,
         crate::routes::api::ShareRecipientPayload,
         crate::routes::api::ShareTargetPayload,
         crate::routes::api::CreateConversationShareRequest,

--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -165,6 +165,7 @@ use utoipa::OpenApi;
         crate::routes::admin::TopUsageResponse,
         // Conversation share models
         crate::routes::api::ErrorResponse,
+        crate::routes::api::ModelNotAllowedErrorResponse,
         crate::routes::api::ShareRecipientPayload,
         crate::routes::api::ShareTargetPayload,
         crate::routes::api::CreateConversationShareRequest,

--- a/crates/api/src/routes/api.rs
+++ b/crates/api/src/routes/api.rs
@@ -254,6 +254,23 @@ pub struct ModelNotAllowedErrorResponse {
     pub plan: String,
 }
 
+/// `403` body for the inference/proxy endpoints. It is one of two shapes:
+/// a plan-gated rejection ([`ModelNotAllowedErrorResponse`], carrying
+/// `code = "model_not_allowed_in_plan"`), or a generic forbidden error
+/// ([`ErrorResponse`], e.g. a banned user) that exposes only `error`.
+/// Modeled as a `oneOf` so generated clients accept both bodies.
+///
+/// Documentation-only: handlers return the concrete `ModelNotAllowedErrorResponse`
+/// / `ErrorResponse` directly, so the variants are never constructed in code —
+/// this type exists purely to shape the OpenAPI `403` response.
+#[derive(Serialize, ToSchema)]
+#[serde(untagged)]
+#[allow(dead_code)]
+pub enum ForbiddenErrorResponse {
+    ModelNotAllowed(ModelNotAllowedErrorResponse),
+    Generic(ErrorResponse),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct InvalidProxyPathSegment;
 
@@ -2305,7 +2322,7 @@ async fn get_file_content(
         (status = 200, description = "Response created successfully"),
         (status = 400, description = BAD_REQUEST, body = ErrorResponse),
         (status = 401, description = UNAUTHORIZED, body = ErrorResponse),
-        (status = 403, description = "Forbidden - user banned, or model not available in the caller's plan (body carries code=model_not_allowed_in_plan)", body = ModelNotAllowedErrorResponse),
+        (status = 403, description = "Forbidden - user banned (body: error only), or model not available in the caller's plan (body adds code=model_not_allowed_in_plan, model, plan)", body = ForbiddenErrorResponse),
         (status = 502, description = OPENAI_API_ERROR, body = ErrorResponse)
     ),
     security(
@@ -3892,7 +3909,7 @@ async fn proxy_post_to_cloud_api(
         (status = 200, description = "Chat completion created successfully"),
         (status = 400, description = BAD_REQUEST, body = ErrorResponse),
         (status = 401, description = UNAUTHORIZED, body = ErrorResponse),
-        (status = 403, description = "Forbidden - user banned, or model not available in the caller's plan (body carries code=model_not_allowed_in_plan)", body = ModelNotAllowedErrorResponse),
+        (status = 403, description = "Forbidden - user banned (body: error only), or model not available in the caller's plan (body adds code=model_not_allowed_in_plan, model, plan)", body = ForbiddenErrorResponse),
         (status = 502, description = "Cloud API error", body = ErrorResponse)
     ),
     security(
@@ -4044,7 +4061,7 @@ async fn proxy_chat_completions(
         (status = 200, description = "Image generation request processed successfully"),
         (status = 400, description = BAD_REQUEST, body = ErrorResponse),
         (status = 401, description = UNAUTHORIZED, body = ErrorResponse),
-        (status = 403, description = "Forbidden - user banned, or model not available in the caller's plan (body carries code=model_not_allowed_in_plan)", body = ModelNotAllowedErrorResponse),
+        (status = 403, description = "Forbidden - user banned (body: error only), or model not available in the caller's plan (body adds code=model_not_allowed_in_plan, model, plan)", body = ForbiddenErrorResponse),
         (status = 502, description = "Cloud API error", body = ErrorResponse)
     ),
     security(
@@ -4239,7 +4256,7 @@ async fn proxy_image_generations(
         (status = 200, description = "Image edit request processed successfully"),
         (status = 400, description = BAD_REQUEST, body = ErrorResponse),
         (status = 401, description = UNAUTHORIZED, body = ErrorResponse),
-        (status = 403, description = "Forbidden - user banned, or model not available in the caller's plan (body carries code=model_not_allowed_in_plan)", body = ModelNotAllowedErrorResponse),
+        (status = 403, description = "Forbidden - user banned (body: error only), or model not available in the caller's plan (body adds code=model_not_allowed_in_plan, model, plan)", body = ForbiddenErrorResponse),
         (status = 502, description = "Cloud API error", body = ErrorResponse)
     ),
     security(

--- a/crates/api/src/routes/api.rs
+++ b/crates/api/src/routes/api.rs
@@ -3336,7 +3336,12 @@ async fn enforce_model_access(
         .await
     {
         Ok(()) => Ok(()),
-        Err(ref err @ SubscriptionError::ModelNotAllowedInPlan { ref model, ref plan }) => {
+        Err(
+            ref err @ SubscriptionError::ModelNotAllowedInPlan {
+                ref model,
+                ref plan,
+            },
+        ) => {
             // Return a stable, machine-readable `code` alongside the message so
             // clients can distinguish "model is gated behind a higher plan"
             // from a generic upstream failure, and prompt the user to upgrade

--- a/crates/api/src/routes/api.rs
+++ b/crates/api/src/routes/api.rs
@@ -3336,13 +3336,28 @@ async fn enforce_model_access(
         .await
     {
         Ok(()) => Ok(()),
-        Err(SubscriptionError::ModelNotAllowedInPlan { model, plan }) => Err((
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse {
-                error: SubscriptionError::ModelNotAllowedInPlan { model, plan }.to_string(),
-            }),
-        )
-            .into_response()),
+        Err(SubscriptionError::ModelNotAllowedInPlan { model, plan }) => {
+            // Return a stable, machine-readable `code` alongside the message so
+            // clients can distinguish "model is gated behind a higher plan"
+            // from a generic upstream failure, and prompt the user to upgrade
+            // instead of showing a misleading "model failed to respond" error.
+            // `error` is kept byte-for-byte identical for backward compatibility.
+            let error = SubscriptionError::ModelNotAllowedInPlan {
+                model: model.clone(),
+                plan: plan.clone(),
+            }
+            .to_string();
+            Err((
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({
+                    "error": error,
+                    "code": "model_not_allowed_in_plan",
+                    "model": model,
+                    "plan": plan,
+                })),
+            )
+                .into_response())
+        }
         Err(err) => {
             tracing::error!(
                 "Failed to validate model access for user_id={}, model_id={}: {}",

--- a/crates/api/src/routes/api.rs
+++ b/crates/api/src/routes/api.rs
@@ -3336,17 +3336,13 @@ async fn enforce_model_access(
         .await
     {
         Ok(()) => Ok(()),
-        Err(SubscriptionError::ModelNotAllowedInPlan { model, plan }) => {
+        Err(ref err @ SubscriptionError::ModelNotAllowedInPlan { ref model, ref plan }) => {
             // Return a stable, machine-readable `code` alongside the message so
             // clients can distinguish "model is gated behind a higher plan"
             // from a generic upstream failure, and prompt the user to upgrade
             // instead of showing a misleading "model failed to respond" error.
             // `error` is kept byte-for-byte identical for backward compatibility.
-            let error = SubscriptionError::ModelNotAllowedInPlan {
-                model: model.clone(),
-                plan: plan.clone(),
-            }
-            .to_string();
+            let error = err.to_string();
             Err((
                 StatusCode::FORBIDDEN,
                 Json(serde_json::json!({

--- a/crates/api/src/routes/api.rs
+++ b/crates/api/src/routes/api.rs
@@ -235,6 +235,25 @@ pub struct ErrorResponse {
     pub error: String,
 }
 
+/// Error body for a plan-gated `403`: returned when the requested model is not
+/// in the caller's subscription plan `allowed_models`. A superset of
+/// [`ErrorResponse`] — `error` is identical, plus a stable machine-readable
+/// `code` and the requested `model` / current `plan`, so clients can prompt an
+/// upgrade instead of rendering a generic failure. Other `403`s on these
+/// endpoints (e.g. banned user) populate only `error`.
+#[derive(Serialize, Deserialize, ToSchema)]
+pub struct ModelNotAllowedErrorResponse {
+    /// Human-readable message (identical to [`ErrorResponse::error`]).
+    pub error: String,
+    /// Stable discriminator. Always `"model_not_allowed_in_plan"`.
+    #[schema(example = "model_not_allowed_in_plan")]
+    pub code: String,
+    /// The model id that was requested.
+    pub model: String,
+    /// The subscription plan the caller is currently on.
+    pub plan: String,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct InvalidProxyPathSegment;
 
@@ -2286,7 +2305,7 @@ async fn get_file_content(
         (status = 200, description = "Response created successfully"),
         (status = 400, description = BAD_REQUEST, body = ErrorResponse),
         (status = 401, description = UNAUTHORIZED, body = ErrorResponse),
-        (status = 403, description = "Forbidden - user banned or model not available", body = ErrorResponse),
+        (status = 403, description = "Forbidden - user banned, or model not available in the caller's plan (body carries code=model_not_allowed_in_plan)", body = ModelNotAllowedErrorResponse),
         (status = 502, description = OPENAI_API_ERROR, body = ErrorResponse)
     ),
     security(
@@ -3347,15 +3366,15 @@ async fn enforce_model_access(
             // from a generic upstream failure, and prompt the user to upgrade
             // instead of showing a misleading "model failed to respond" error.
             // `error` is kept byte-for-byte identical for backward compatibility.
-            let error = err.to_string();
+            // Typed (not ad-hoc json!) so the shape is in the OpenAPI contract.
             Err((
                 StatusCode::FORBIDDEN,
-                Json(serde_json::json!({
-                    "error": error,
-                    "code": "model_not_allowed_in_plan",
-                    "model": model,
-                    "plan": plan,
-                })),
+                Json(ModelNotAllowedErrorResponse {
+                    error: err.to_string(),
+                    code: "model_not_allowed_in_plan".to_string(),
+                    model: model.clone(),
+                    plan: plan.clone(),
+                }),
             )
                 .into_response())
         }
@@ -3873,7 +3892,7 @@ async fn proxy_post_to_cloud_api(
         (status = 200, description = "Chat completion created successfully"),
         (status = 400, description = BAD_REQUEST, body = ErrorResponse),
         (status = 401, description = UNAUTHORIZED, body = ErrorResponse),
-        (status = 403, description = "Forbidden - user banned or model not available", body = ErrorResponse),
+        (status = 403, description = "Forbidden - user banned, or model not available in the caller's plan (body carries code=model_not_allowed_in_plan)", body = ModelNotAllowedErrorResponse),
         (status = 502, description = "Cloud API error", body = ErrorResponse)
     ),
     security(
@@ -4025,7 +4044,7 @@ async fn proxy_chat_completions(
         (status = 200, description = "Image generation request processed successfully"),
         (status = 400, description = BAD_REQUEST, body = ErrorResponse),
         (status = 401, description = UNAUTHORIZED, body = ErrorResponse),
-        (status = 403, description = "Forbidden - user banned", body = ErrorResponse),
+        (status = 403, description = "Forbidden - user banned, or model not available in the caller's plan (body carries code=model_not_allowed_in_plan)", body = ModelNotAllowedErrorResponse),
         (status = 502, description = "Cloud API error", body = ErrorResponse)
     ),
     security(
@@ -4220,7 +4239,7 @@ async fn proxy_image_generations(
         (status = 200, description = "Image edit request processed successfully"),
         (status = 400, description = BAD_REQUEST, body = ErrorResponse),
         (status = 401, description = UNAUTHORIZED, body = ErrorResponse),
-        (status = 403, description = "Forbidden - user banned", body = ErrorResponse),
+        (status = 403, description = "Forbidden - user banned, or model not available in the caller's plan (body carries code=model_not_allowed_in_plan)", body = ModelNotAllowedErrorResponse),
         (status = 502, description = "Cloud API error", body = ErrorResponse)
     ),
     security(

--- a/crates/api/tests/model_allowlist_tests.rs
+++ b/crates/api/tests/model_allowlist_tests.rs
@@ -524,6 +524,24 @@ async fn test_responses_endpoint_respects_model_allowlist() {
         error.contains("gpt-4o") && error.contains("not available"),
         "Error message should mention the model"
     );
+
+    // Stable machine-readable contract clients rely on to render an "upgrade
+    // your plan" prompt instead of a generic "model failed to respond" error.
+    assert_eq!(
+        body.get("code").and_then(|value| value.as_str()),
+        Some("model_not_allowed_in_plan"),
+        "Plan-gated 403 must carry the stable `code`"
+    );
+    assert_eq!(
+        body.get("model").and_then(|value| value.as_str()),
+        Some("gpt-4o"),
+        "Plan-gated 403 must echo the requested `model`"
+    );
+    assert_eq!(
+        body.get("plan").and_then(|value| value.as_str()),
+        Some("basic"),
+        "Plan-gated 403 must include the user's `plan`"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

When a user in Private Chat picks a model that isn't in their subscription plan's `allowed_models`, `enforce_model_access` returns:

```
403 {"error":"Model 'deepseek-ai/DeepSeek-V4-Flash' is not available in your plan 'starter'"}
```

The body carries only a human-readable `error` string, so clients can't distinguish a **gated-model** rejection from a generic upstream failure. The private-chat frontend therefore renders a misleading **"Model … failed to respond"** toast (it should prompt the user to upgrade).

## Change

Add a stable, machine-readable `code` (plus `model` and `plan`) to the 403 body on the `ModelNotAllowedInPlan` path:

```json
{
  "error": "Model 'deepseek-ai/DeepSeek-V4-Flash' is not available in your plan 'starter'",
  "code": "model_not_allowed_in_plan",
  "model": "deepseek-ai/DeepSeek-V4-Flash",
  "plan": "starter"
}
```

- `error` is **byte-for-byte unchanged** → fully backward compatible (existing tests assert only `body["error"]`).
- One call site (`enforce_model_access`), which covers `/v1/chat/completions`, `/v1/responses`, and image endpoints.

## Frontend counterpart

nearai/private-chat#353 consumes `code` to show an "Upgrade to access this model" dialog instead of the generic toast.

## Testing

- `cargo check -p api` ✅
- Existing `model_allowlist_tests` assert `body["error"]` only → unaffected.
