### PR TITLE
feat: allow validated mobile auth callbacks

### DIFF
--- a/crates/api/src/routes/oauth.rs
+++ b/crates/api/src/routes/oauth.rs
@@ -26,8 +26,7 @@ use utoipa::ToSchema;
 
 const FRONTEND_CALLBACK_ALLOWED_ORIGINS_ENV: &str = "FRONTEND_CALLBACK_ALLOWED_ORIGINS";
 const OAUTH_CALLBACK_PATH: &str = "/auth/callback";
-const PRIVATE_CHAT_UNIVERSAL_LINK_HOST: &str = "app.privatechat.com";
-const MOBILE_FRONTEND_CALLBACK_SCHEMES: &[&str] = &["nearprivatechat", "privatechat"];
+const MOBILE_FRONTEND_CALLBACK_SCHEMES: &[&str] = &["nearprivatechat"];
 const MOBILE_FRONTEND_CALLBACK_HOST: &str = "auth";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -137,7 +136,7 @@ fn validate_frontend_callback_url(
     let trimmed_url = raw_url.trim();
     let url = Url::parse(trimmed_url).map_err(|_| FrontendCallbackValidationError::Malformed)?;
 
-    if is_allowed_mobile_callback_url(&url)? || is_private_chat_universal_link_callback_url(&url)? {
+    if is_allowed_mobile_callback_url(&url)? {
         return Ok(normalize_validated_callback_url(url));
     }
 
@@ -165,7 +164,7 @@ fn build_oauth_frontend_redirect(
         .map(|(_, value)| value.into_owned())
         .collect();
 
-    if !is_mobile_callback_base(&url) && !is_private_chat_universal_link_callback_base(&url) {
+    if !is_mobile_callback_base(&url) {
         let base_path = url.path().trim_end_matches('/');
         let callback_path = if base_path.is_empty() {
             OAUTH_CALLBACK_PATH.to_string()
@@ -271,26 +270,6 @@ fn is_mobile_callback_base(url: &Url) -> bool {
         && url.password().is_none()
 }
 
-fn is_private_chat_universal_link_callback_url(
-    url: &Url,
-) -> Result<bool, FrontendCallbackValidationError> {
-    if !is_private_chat_universal_link_callback_base(url) {
-        return Ok(false);
-    }
-
-    validate_mobile_callback_query(url)?;
-    Ok(true)
-}
-
-fn is_private_chat_universal_link_callback_base(url: &Url) -> bool {
-    url.scheme() == "https"
-        && url.host_str() == Some(PRIVATE_CHAT_UNIVERSAL_LINK_HOST)
-        && url.path() == OAUTH_CALLBACK_PATH
-        && url.port().is_none()
-        && url.username().is_empty()
-        && url.password().is_none()
-}
-
 fn validate_mobile_callback_query(url: &Url) -> Result<(), FrontendCallbackValidationError> {
     if url.fragment().is_some() {
         return Err(FrontendCallbackValidationError::MobileCallbackQueryNotAllowed);
@@ -329,8 +308,18 @@ fn url_origin(url: &Url) -> String {
     url.origin().ascii_serialization()
 }
 
-fn normalize_validated_callback_url(url: Url) -> String {
-    trim_trailing_slash(url.as_str())
+fn normalize_validated_callback_url(mut url: Url) -> String {
+    let path = url.path();
+    if path == "/" && url.query().is_none() && url.fragment().is_none() {
+        return trim_trailing_slash(url.as_str());
+    }
+
+    if path.len() > 1 && path.ends_with('/') {
+        let trimmed_path = path.trim_end_matches('/').to_string();
+        url.set_path(&trimmed_path);
+    }
+
+    url.to_string()
 }
 
 fn trim_trailing_slash(value: &str) -> String {
@@ -1506,26 +1495,23 @@ mod tests {
         .unwrap();
         assert_eq!(near_callback, "nearprivatechat://auth?state=ios-state-1");
 
-        let private_chat_callback =
-            validate_frontend_callback_url("privatechat://auth?state=mobile-state-1", Some(&[]))
-                .unwrap();
-        assert_eq!(
-            private_chat_callback,
-            "privatechat://auth?state=mobile-state-1"
-        );
+        let err = validate_frontend_callback_url(
+            "privatechat://auth?state=mobile-state-1",
+            Some(&allowlist()),
+        )
+        .unwrap_err();
+        assert_eq!(err, FrontendCallbackValidationError::UnsupportedScheme);
     }
 
     #[test]
-    fn validates_exact_private_chat_universal_link_callback() {
+    fn preserves_mobile_callback_state_trailing_slash() {
         let callback = validate_frontend_callback_url(
-            "https://app.privatechat.com/auth/callback?state=universal-state-1",
-            Some(&[]),
+            "nearprivatechat://auth?state=state-with-slash/",
+            Some(&allowlist()),
         )
         .unwrap();
-        assert_eq!(
-            callback,
-            "https://app.privatechat.com/auth/callback?state=universal-state-1"
-        );
+
+        assert_eq!(callback, "nearprivatechat://auth?state=state-with-slash/");
     }
 
     #[test]
@@ -1541,8 +1527,6 @@ mod tests {
             "nearprivatechat://evil?state=s",
             "nearprivatechat://auth/other?state=s",
             "privatechat.evil://auth?state=s",
-            "https://app.privatechat.com.evil.example/auth/callback?state=s",
-            "https://app.privatechat.com/other?state=s",
         ];
 
         for callback in rejected {
@@ -1646,7 +1630,7 @@ mod tests {
     #[test]
     fn builds_oauth_redirect_for_mobile_callback_without_path_mutation() {
         let redirect = build_oauth_frontend_redirect(
-            "privatechat://auth?state=mobile-state-1",
+            "nearprivatechat://auth?state=mobile-state-1",
             "tok en",
             "session-1",
             "2026-05-27T00:00:00Z",
@@ -1656,24 +1640,7 @@ mod tests {
 
         assert_eq!(
             redirect,
-            "privatechat://auth?token=tok+en&session_id=session-1&expires_at=2026-05-27T00%3A00%3A00Z&state=mobile-state-1&is_new_user=true"
-        );
-    }
-
-    #[test]
-    fn builds_oauth_redirect_for_universal_link_without_double_callback_path() {
-        let redirect = build_oauth_frontend_redirect(
-            "https://app.privatechat.com/auth/callback?state=mobile-state-1",
-            "tok en",
-            "session-1",
-            "2026-05-27T00:00:00Z",
-            false,
-        )
-        .unwrap();
-
-        assert_eq!(
-            redirect,
-            "https://app.privatechat.com/auth/callback?token=tok+en&session_id=session-1&expires_at=2026-05-27T00%3A00%3A00Z&state=mobile-state-1"
+            "nearprivatechat://auth?token=tok+en&session_id=session-1&expires_at=2026-05-27T00%3A00%3A00Z&state=mobile-state-1&is_new_user=true"
         );
     }
 

--- a/crates/api/src/routes/oauth.rs
+++ b/crates/api/src/routes/oauth.rs
@@ -25,8 +25,8 @@ use url::{Host, Url};
 use utoipa::ToSchema;
 
 const FRONTEND_CALLBACK_ALLOWED_ORIGINS_ENV: &str = "FRONTEND_CALLBACK_ALLOWED_ORIGINS";
+const OAUTH_CALLBACK_PATH: &str = "/auth/callback";
 const PRIVATE_CHAT_UNIVERSAL_LINK_HOST: &str = "app.privatechat.com";
-const PRIVATE_CHAT_UNIVERSAL_LINK_PATH: &str = "/auth/callback";
 const MOBILE_FRONTEND_CALLBACK_SCHEMES: &[&str] = &["nearprivatechat", "privatechat"];
 const MOBILE_FRONTEND_CALLBACK_HOST: &str = "auth";
 
@@ -37,6 +37,7 @@ enum FrontendCallbackValidationError {
     MissingHost,
     CredentialsNotAllowed,
     QueryOrFragmentNotAllowed,
+    MobileCallbackQueryNotAllowed,
     Insecure,
     UntrustedOrigin,
 }
@@ -50,6 +51,9 @@ impl std::fmt::Display for FrontendCallbackValidationError {
             Self::CredentialsNotAllowed => "credentials are not allowed in callback URLs",
             Self::QueryOrFragmentNotAllowed => {
                 "query strings and fragments are not allowed in callback URLs"
+            }
+            Self::MobileCallbackQueryNotAllowed => {
+                "mobile callback URLs may only include a non-empty state query parameter and no fragment"
             }
             Self::Insecure => "callback URL must use HTTPS",
             Self::UntrustedOrigin => "callback URL origin is not allowlisted",
@@ -164,11 +168,11 @@ fn build_oauth_frontend_redirect(
     if !is_mobile_callback_base(&url) && !is_private_chat_universal_link_callback_base(&url) {
         let base_path = url.path().trim_end_matches('/');
         let callback_path = if base_path.is_empty() {
-            PRIVATE_CHAT_UNIVERSAL_LINK_PATH.to_string()
-        } else if base_path.ends_with(PRIVATE_CHAT_UNIVERSAL_LINK_PATH) {
+            OAUTH_CALLBACK_PATH.to_string()
+        } else if base_path.ends_with(OAUTH_CALLBACK_PATH) {
             base_path.to_string()
         } else {
-            format!("{base_path}{PRIVATE_CHAT_UNIVERSAL_LINK_PATH}")
+            format!("{base_path}{OAUTH_CALLBACK_PATH}")
         };
 
         url.set_path(&callback_path);
@@ -281,7 +285,7 @@ fn is_private_chat_universal_link_callback_url(
 fn is_private_chat_universal_link_callback_base(url: &Url) -> bool {
     url.scheme() == "https"
         && url.host_str() == Some(PRIVATE_CHAT_UNIVERSAL_LINK_HOST)
-        && url.path() == PRIVATE_CHAT_UNIVERSAL_LINK_PATH
+        && url.path() == OAUTH_CALLBACK_PATH
         && url.port().is_none()
         && url.username().is_empty()
         && url.password().is_none()
@@ -289,12 +293,12 @@ fn is_private_chat_universal_link_callback_base(url: &Url) -> bool {
 
 fn validate_mobile_callback_query(url: &Url) -> Result<(), FrontendCallbackValidationError> {
     if url.fragment().is_some() {
-        return Err(FrontendCallbackValidationError::QueryOrFragmentNotAllowed);
+        return Err(FrontendCallbackValidationError::MobileCallbackQueryNotAllowed);
     }
 
     for (name, value) in url.query_pairs() {
         if name != "state" || value.trim().is_empty() {
-            return Err(FrontendCallbackValidationError::QueryOrFragmentNotAllowed);
+            return Err(FrontendCallbackValidationError::MobileCallbackQueryNotAllowed);
         }
     }
 
@@ -1536,8 +1540,6 @@ mod tests {
         let rejected = [
             "nearprivatechat://evil?state=s",
             "nearprivatechat://auth/other?state=s",
-            "nearprivatechat://auth?token=preseeded",
-            "nearprivatechat://auth#state=s",
             "privatechat.evil://auth?state=s",
             "https://app.privatechat.com.evil.example/auth/callback?state=s",
             "https://app.privatechat.com/other?state=s",
@@ -1549,6 +1551,27 @@ mod tests {
                 "expected callback to be rejected: {callback}"
             );
         }
+    }
+
+    #[test]
+    fn rejects_mobile_callback_extra_query_with_specific_error() {
+        assert_eq!(
+            validate_frontend_callback_url(
+                "nearprivatechat://auth?token=preseeded",
+                Some(&allowlist())
+            )
+            .unwrap_err(),
+            FrontendCallbackValidationError::MobileCallbackQueryNotAllowed
+        );
+        assert_eq!(
+            validate_frontend_callback_url("nearprivatechat://auth#state=s", Some(&allowlist()))
+                .unwrap_err(),
+            FrontendCallbackValidationError::MobileCallbackQueryNotAllowed
+        );
+        assert_eq!(
+            FrontendCallbackValidationError::MobileCallbackQueryNotAllowed.to_string(),
+            "mobile callback URLs may only include a non-empty state query parameter and no fragment"
+        );
     }
 
     #[test]

--- a/crates/api/src/routes/oauth.rs
+++ b/crates/api/src/routes/oauth.rs
@@ -25,6 +25,10 @@ use url::{Host, Url};
 use utoipa::ToSchema;
 
 const FRONTEND_CALLBACK_ALLOWED_ORIGINS_ENV: &str = "FRONTEND_CALLBACK_ALLOWED_ORIGINS";
+const PRIVATE_CHAT_UNIVERSAL_LINK_HOST: &str = "app.privatechat.com";
+const PRIVATE_CHAT_UNIVERSAL_LINK_PATH: &str = "/auth/callback";
+const MOBILE_FRONTEND_CALLBACK_SCHEMES: &[&str] = &["nearprivatechat", "privatechat"];
+const MOBILE_FRONTEND_CALLBACK_HOST: &str = "auth";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FrontendCallbackValidationError {
@@ -126,40 +130,65 @@ fn validate_frontend_callback_url(
     raw_url: &str,
     allowed_origins: Option<&[String]>,
 ) -> Result<String, FrontendCallbackValidationError> {
+    let trimmed_url = raw_url.trim();
+    let url = Url::parse(trimmed_url).map_err(|_| FrontendCallbackValidationError::Malformed)?;
+
+    if is_allowed_mobile_callback_url(&url)? || is_private_chat_universal_link_callback_url(&url)? {
+        return Ok(normalize_validated_callback_url(url));
+    }
+
     if let Some(origins) = allowed_origins {
         if origins.is_empty() {
             return Err(FrontendCallbackValidationError::UntrustedOrigin);
         }
     }
 
-    validate_frontend_url(raw_url, allowed_origins.unwrap_or(&[]))
-        .map(|url| trim_trailing_slash(url.as_str()))
+    validate_frontend_url(trimmed_url, allowed_origins.unwrap_or(&[]))
+        .map(normalize_validated_callback_url)
 }
 
 fn build_oauth_frontend_redirect(
-    frontend_base_url: &str,
+    frontend_callback_url: &str,
     token: &str,
     session_id: &str,
     expires_at: &str,
     is_new_user: bool,
 ) -> Result<String, url::ParseError> {
-    let mut url = Url::parse(frontend_base_url)?;
-    let base_path = url.path().trim_end_matches('/');
-    let callback_path = if base_path.is_empty() {
-        "/auth/callback".to_string()
-    } else {
-        format!("{base_path}/auth/callback")
-    };
+    let mut url = Url::parse(frontend_callback_url)?;
+    let existing_state_values: Vec<String> = url
+        .query_pairs()
+        .filter(|(name, _)| name == "state")
+        .map(|(_, value)| value.into_owned())
+        .collect();
 
-    url.set_path(&callback_path);
-    url.query_pairs_mut()
-        .clear()
-        .append_pair("token", token)
-        .append_pair("session_id", session_id)
-        .append_pair("expires_at", expires_at);
+    if !is_mobile_callback_base(&url) && !is_private_chat_universal_link_callback_base(&url) {
+        let base_path = url.path().trim_end_matches('/');
+        let callback_path = if base_path.is_empty() {
+            PRIVATE_CHAT_UNIVERSAL_LINK_PATH.to_string()
+        } else if base_path.ends_with(PRIVATE_CHAT_UNIVERSAL_LINK_PATH) {
+            base_path.to_string()
+        } else {
+            format!("{base_path}{PRIVATE_CHAT_UNIVERSAL_LINK_PATH}")
+        };
 
-    if is_new_user {
-        url.query_pairs_mut().append_pair("is_new_user", "true");
+        url.set_path(&callback_path);
+    }
+
+    {
+        let mut query = url.query_pairs_mut();
+        query
+            .clear()
+            .append_pair("token", token)
+            .append_pair("session_id", session_id)
+            .append_pair("expires_at", expires_at);
+
+        for state in existing_state_values {
+            query.append_pair("state", &state);
+        }
+
+        if is_new_user {
+            query.append_pair("is_new_user", "true");
+        }
     }
 
     Ok(url.to_string())
@@ -211,6 +240,67 @@ fn validate_frontend_url(
     Ok(url)
 }
 
+fn is_allowed_mobile_callback_url(url: &Url) -> Result<bool, FrontendCallbackValidationError> {
+    if !MOBILE_FRONTEND_CALLBACK_SCHEMES
+        .iter()
+        .any(|scheme| url.scheme().eq_ignore_ascii_case(scheme))
+    {
+        return Ok(false);
+    }
+
+    if !is_mobile_callback_base(url) {
+        return Err(FrontendCallbackValidationError::UntrustedOrigin);
+    }
+
+    validate_mobile_callback_query(url)?;
+    Ok(true)
+}
+
+fn is_mobile_callback_base(url: &Url) -> bool {
+    MOBILE_FRONTEND_CALLBACK_SCHEMES
+        .iter()
+        .any(|scheme| url.scheme().eq_ignore_ascii_case(scheme))
+        && url.host_str() == Some(MOBILE_FRONTEND_CALLBACK_HOST)
+        && url.path().is_empty()
+        && url.port().is_none()
+        && url.username().is_empty()
+        && url.password().is_none()
+}
+
+fn is_private_chat_universal_link_callback_url(
+    url: &Url,
+) -> Result<bool, FrontendCallbackValidationError> {
+    if !is_private_chat_universal_link_callback_base(url) {
+        return Ok(false);
+    }
+
+    validate_mobile_callback_query(url)?;
+    Ok(true)
+}
+
+fn is_private_chat_universal_link_callback_base(url: &Url) -> bool {
+    url.scheme() == "https"
+        && url.host_str() == Some(PRIVATE_CHAT_UNIVERSAL_LINK_HOST)
+        && url.path() == PRIVATE_CHAT_UNIVERSAL_LINK_PATH
+        && url.port().is_none()
+        && url.username().is_empty()
+        && url.password().is_none()
+}
+
+fn validate_mobile_callback_query(url: &Url) -> Result<(), FrontendCallbackValidationError> {
+    if url.fragment().is_some() {
+        return Err(FrontendCallbackValidationError::QueryOrFragmentNotAllowed);
+    }
+
+    for (name, value) in url.query_pairs() {
+        if name != "state" || value.trim().is_empty() {
+            return Err(FrontendCallbackValidationError::QueryOrFragmentNotAllowed);
+        }
+    }
+
+    Ok(())
+}
+
 fn is_loopback_http_url(url: &Url) -> bool {
     if url.scheme() != "http" {
         return false;
@@ -233,6 +323,10 @@ fn insert_origin(origins: &mut Vec<String>, seen: &mut HashSet<String>, url: &Ur
 
 fn url_origin(url: &Url) -> String {
     url.origin().ascii_serialization()
+}
+
+fn normalize_validated_callback_url(url: Url) -> String {
+    trim_trailing_slash(url.as_str())
 }
 
 fn trim_trailing_slash(value: &str) -> String {
@@ -1400,10 +1494,61 @@ mod tests {
     }
 
     #[test]
+    fn validates_exact_mobile_callbacks_with_state() {
+        let near_callback = validate_frontend_callback_url(
+            "nearprivatechat://auth?state=ios-state-1",
+            Some(&allowlist()),
+        )
+        .unwrap();
+        assert_eq!(near_callback, "nearprivatechat://auth?state=ios-state-1");
+
+        let private_chat_callback =
+            validate_frontend_callback_url("privatechat://auth?state=mobile-state-1", Some(&[]))
+                .unwrap();
+        assert_eq!(
+            private_chat_callback,
+            "privatechat://auth?state=mobile-state-1"
+        );
+    }
+
+    #[test]
+    fn validates_exact_private_chat_universal_link_callback() {
+        let callback = validate_frontend_callback_url(
+            "https://app.privatechat.com/auth/callback?state=universal-state-1",
+            Some(&[]),
+        )
+        .unwrap();
+        assert_eq!(
+            callback,
+            "https://app.privatechat.com/auth/callback?state=universal-state-1"
+        );
+    }
+
+    #[test]
     fn rejects_untrusted_callback_origin() {
         let err = validate_frontend_callback_url("https://evil.example/auth", Some(&allowlist()))
             .unwrap_err();
         assert_eq!(err, FrontendCallbackValidationError::UntrustedOrigin);
+    }
+
+    #[test]
+    fn rejects_mobile_callback_lookalikes() {
+        let rejected = [
+            "nearprivatechat://evil?state=s",
+            "nearprivatechat://auth/other?state=s",
+            "nearprivatechat://auth?token=preseeded",
+            "nearprivatechat://auth#state=s",
+            "privatechat.evil://auth?state=s",
+            "https://app.privatechat.com.evil.example/auth/callback?state=s",
+            "https://app.privatechat.com/other?state=s",
+        ];
+
+        for callback in rejected {
+            assert!(
+                validate_frontend_callback_url(callback, Some(&allowlist())).is_err(),
+                "expected callback to be rejected: {callback}"
+            );
+        }
     }
 
     #[test]
@@ -1472,6 +1617,40 @@ mod tests {
         assert_eq!(
             redirect,
             "https://app.near.ai/app/auth/callback?token=tok+en&session_id=session-1&expires_at=2026-05-27T00%3A00%3A00Z&is_new_user=true"
+        );
+    }
+
+    #[test]
+    fn builds_oauth_redirect_for_mobile_callback_without_path_mutation() {
+        let redirect = build_oauth_frontend_redirect(
+            "privatechat://auth?state=mobile-state-1",
+            "tok en",
+            "session-1",
+            "2026-05-27T00:00:00Z",
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(
+            redirect,
+            "privatechat://auth?token=tok+en&session_id=session-1&expires_at=2026-05-27T00%3A00%3A00Z&state=mobile-state-1&is_new_user=true"
+        );
+    }
+
+    #[test]
+    fn builds_oauth_redirect_for_universal_link_without_double_callback_path() {
+        let redirect = build_oauth_frontend_redirect(
+            "https://app.privatechat.com/auth/callback?state=mobile-state-1",
+            "tok en",
+            "session-1",
+            "2026-05-27T00:00:00Z",
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            redirect,
+            "https://app.privatechat.com/auth/callback?token=tok+en&session_id=session-1&expires_at=2026-05-27T00%3A00%3A00Z&state=mobile-state-1"
         );
     }
 

--- a/crates/api/src/routes/oauth.rs
+++ b/crates/api/src/routes/oauth.rs
@@ -26,7 +26,11 @@ use utoipa::ToSchema;
 
 const FRONTEND_CALLBACK_ALLOWED_ORIGINS_ENV: &str = "FRONTEND_CALLBACK_ALLOWED_ORIGINS";
 const OAUTH_CALLBACK_PATH: &str = "/auth/callback";
-const MOBILE_FRONTEND_CALLBACK_SCHEMES: &[&str] = &["nearprivatechat"];
+// Mobile app-scheme callbacks are not URL origins, so they cannot be validated
+// through FRONTEND_CALLBACK_ALLOWED_ORIGINS. Keep this list exact and short.
+// nearprivatechat is accepted temporarily for already-shipped mobile builds;
+// new mobile clients should send nearai://auth.
+const MOBILE_FRONTEND_CALLBACK_SCHEMES: &[&str] = &["nearai", "nearprivatechat"];
 const MOBILE_FRONTEND_CALLBACK_HOST: &str = "auth";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1488,12 +1492,20 @@ mod tests {
 
     #[test]
     fn validates_exact_mobile_callbacks_with_state() {
-        let near_callback = validate_frontend_callback_url(
-            "nearprivatechat://auth?state=ios-state-1",
+        let near_callback =
+            validate_frontend_callback_url("nearai://auth?state=ios-state-1", Some(&allowlist()))
+                .unwrap();
+        assert_eq!(near_callback, "nearai://auth?state=ios-state-1");
+
+        let legacy_callback = validate_frontend_callback_url(
+            "nearprivatechat://auth?state=legacy-ios-state-1",
             Some(&allowlist()),
         )
         .unwrap();
-        assert_eq!(near_callback, "nearprivatechat://auth?state=ios-state-1");
+        assert_eq!(
+            legacy_callback,
+            "nearprivatechat://auth?state=legacy-ios-state-1"
+        );
 
         let err = validate_frontend_callback_url(
             "privatechat://auth?state=mobile-state-1",
@@ -1506,12 +1518,12 @@ mod tests {
     #[test]
     fn preserves_mobile_callback_state_trailing_slash() {
         let callback = validate_frontend_callback_url(
-            "nearprivatechat://auth?state=state-with-slash/",
+            "nearai://auth?state=state-with-slash/",
             Some(&allowlist()),
         )
         .unwrap();
 
-        assert_eq!(callback, "nearprivatechat://auth?state=state-with-slash/");
+        assert_eq!(callback, "nearai://auth?state=state-with-slash/");
     }
 
     #[test]
@@ -1524,6 +1536,8 @@ mod tests {
     #[test]
     fn rejects_mobile_callback_lookalikes() {
         let rejected = [
+            "nearai://evil?state=s",
+            "nearai://auth/other?state=s",
             "nearprivatechat://evil?state=s",
             "nearprivatechat://auth/other?state=s",
             "privatechat.evil://auth?state=s",
@@ -1540,15 +1554,12 @@ mod tests {
     #[test]
     fn rejects_mobile_callback_extra_query_with_specific_error() {
         assert_eq!(
-            validate_frontend_callback_url(
-                "nearprivatechat://auth?token=preseeded",
-                Some(&allowlist())
-            )
-            .unwrap_err(),
+            validate_frontend_callback_url("nearai://auth?token=preseeded", Some(&allowlist()))
+                .unwrap_err(),
             FrontendCallbackValidationError::MobileCallbackQueryNotAllowed
         );
         assert_eq!(
-            validate_frontend_callback_url("nearprivatechat://auth#state=s", Some(&allowlist()))
+            validate_frontend_callback_url("nearai://auth#state=s", Some(&allowlist()))
                 .unwrap_err(),
             FrontendCallbackValidationError::MobileCallbackQueryNotAllowed
         );
@@ -1629,19 +1640,21 @@ mod tests {
 
     #[test]
     fn builds_oauth_redirect_for_mobile_callback_without_path_mutation() {
-        let redirect = build_oauth_frontend_redirect(
-            "nearprivatechat://auth?state=mobile-state-1",
-            "tok en",
-            "session-1",
-            "2026-05-27T00:00:00Z",
-            true,
-        )
-        .unwrap();
+        for scheme in ["nearai", "nearprivatechat"] {
+            let redirect = build_oauth_frontend_redirect(
+                &format!("{scheme}://auth?state=mobile-state-1"),
+                "tok en",
+                "session-1",
+                "2026-05-27T00:00:00Z",
+                true,
+            )
+            .unwrap();
 
-        assert_eq!(
-            redirect,
-            "nearprivatechat://auth?token=tok+en&session_id=session-1&expires_at=2026-05-27T00%3A00%3A00Z&state=mobile-state-1&is_new_user=true"
-        );
+            assert_eq!(
+                redirect,
+                format!("{scheme}://auth?token=tok+en&session_id=session-1&expires_at=2026-05-27T00%3A00%3A00Z&state=mobile-state-1&is_new_user=true")
+            );
+        }
     }
 
     #[test]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -230,8 +230,10 @@ pub struct CorsConfig {
 
 impl Default for CorsConfig {
     fn default() -> Self {
-        let raw_origins = std::env::var("CORS_ALLOWED_ORIGINS")
-            .unwrap_or_else(|_| "http://localhost:3000,https://near.ai,*.near.ai".to_string());
+        let raw_origins = std::env::var("CORS_ALLOWED_ORIGINS").unwrap_or_else(|_| {
+            "http://localhost:3000,https://near.ai,*.near.ai,https://app.privatechat.com"
+                .to_string()
+        });
 
         let mut exact_matches = Vec::new();
         let mut wildcard_suffixes = Vec::new();

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -230,10 +230,8 @@ pub struct CorsConfig {
 
 impl Default for CorsConfig {
     fn default() -> Self {
-        let raw_origins = std::env::var("CORS_ALLOWED_ORIGINS").unwrap_or_else(|_| {
-            "http://localhost:3000,https://near.ai,*.near.ai,https://app.privatechat.com"
-                .to_string()
-        });
+        let raw_origins = std::env::var("CORS_ALLOWED_ORIGINS")
+            .unwrap_or_else(|_| "http://localhost:3000,https://near.ai,*.near.ai".to_string());
 
         let mut exact_matches = Vec::new();
         let mut wildcard_suffixes = Vec::new();

--- a/env.example
+++ b/env.example
@@ -64,8 +64,9 @@ FRONTEND_URL=http://localhost:3000
 # Optional comma-separated exact bare origins allowed for user-provided OAuth frontend_callback.
 # If unset, callback origins are unrestricted; this is useful for staging frontend tests.
 # Entries must not include a path, query string, or fragment.
-# Remote callback origins must use HTTPS. The iOS/Android custom-scheme callback
-# is separately restricted to nearprivatechat://auth.
+# Remote callback origins must use HTTPS. The mobile custom-scheme callback
+# is separately restricted to nearai://auth, with nearprivatechat://auth
+# temporarily accepted for already-shipped app builds.
 # Example: https://app.yourdomain.com,https://admin.yourdomain.com
 FRONTEND_CALLBACK_ALLOWED_ORIGINS=http://localhost:3000
 

--- a/env.example
+++ b/env.example
@@ -64,10 +64,10 @@ FRONTEND_URL=http://localhost:3000
 # Optional comma-separated exact bare origins allowed for user-provided OAuth frontend_callback.
 # If unset, callback origins are unrestricted; this is useful for staging frontend tests.
 # Entries must not include a path, query string, or fragment.
-# Remote callback origins must use HTTPS. Mobile callbacks are separately restricted
-# to nearprivatechat://auth, privatechat://auth, and https://app.privatechat.com/auth/callback.
-# Example: https://app.yourdomain.com,https://admin.yourdomain.com,https://app.privatechat.com
-FRONTEND_CALLBACK_ALLOWED_ORIGINS=http://localhost:3000,https://app.privatechat.com
+# Remote callback origins must use HTTPS. The iOS/Android custom-scheme callback
+# is separately restricted to nearprivatechat://auth.
+# Example: https://app.yourdomain.com,https://admin.yourdomain.com
+FRONTEND_CALLBACK_ALLOWED_ORIGINS=http://localhost:3000
 
 # OpenAI/Cloud API Configuration
 # REQUIRED: API key for the NEAR AI Cloud. Get your API key at https://cloud-api.near.ai
@@ -94,8 +94,8 @@ LOG_FORMAT=json
 
 # CORS Configuration (comma-separated list of allowed origins)
 # For development, you can use: http://localhost:3000,http://localhost:3001
-# For production, use your actual frontend domains: https://app.yourdomain.com,https://app.privatechat.com
-CORS_ALLOWED_ORIGINS=http://localhost:3000,https://app.privatechat.com
+# For production, use your actual frontend domains: https://app.yourdomain.com
+CORS_ALLOWED_ORIGINS=http://localhost:3000
 
 # NEAR Authentication (NEP-413)
 # Allowed recipients (host or host:port) for signed messages. Comma-separated for multiple frontends.

--- a/env.example
+++ b/env.example
@@ -64,9 +64,10 @@ FRONTEND_URL=http://localhost:3000
 # Optional comma-separated exact bare origins allowed for user-provided OAuth frontend_callback.
 # If unset, callback origins are unrestricted; this is useful for staging frontend tests.
 # Entries must not include a path, query string, or fragment.
-# Remote callback origins must use HTTPS.
-# Example: https://app.yourdomain.com,https://admin.yourdomain.com
-FRONTEND_CALLBACK_ALLOWED_ORIGINS=http://localhost:3000
+# Remote callback origins must use HTTPS. Mobile callbacks are separately restricted
+# to nearprivatechat://auth, privatechat://auth, and https://app.privatechat.com/auth/callback.
+# Example: https://app.yourdomain.com,https://admin.yourdomain.com,https://app.privatechat.com
+FRONTEND_CALLBACK_ALLOWED_ORIGINS=http://localhost:3000,https://app.privatechat.com
 
 # OpenAI/Cloud API Configuration
 # REQUIRED: API key for the NEAR AI Cloud. Get your API key at https://cloud-api.near.ai
@@ -93,8 +94,8 @@ LOG_FORMAT=json
 
 # CORS Configuration (comma-separated list of allowed origins)
 # For development, you can use: http://localhost:3000,http://localhost:3001
-# For production, use your actual frontend domains: https://app.yourdomain.com
-CORS_ALLOWED_ORIGINS=http://localhost:3000
+# For production, use your actual frontend domains: https://app.yourdomain.com,https://app.privatechat.com
+CORS_ALLOWED_ORIGINS=http://localhost:3000,https://app.privatechat.com
 
 # NEAR Authentication (NEP-413)
 # Allowed recipients (host or host:port) for signed messages. Comma-separated for multiple frontends.


### PR DESCRIPTION
## Summary
- Allow exact mobile OAuth `frontend_callback` URLs for the current iOS/Android scheme `nearprivatechat://auth`, the new shared scheme `privatechat://auth`, and the universal link `https://app.privatechat.com/auth/callback`.
- Preserve the mobile `state` query while appending session token fields, so the app can complete its active pending sign-in instead of opening into a state-validation failure.
- Avoid appending `/auth/callback` onto custom-scheme or already-exact universal-link callbacks.
- Update CORS/callback environment examples and the default CORS origin list for `https://app.privatechat.com`.

## Validation
- `cargo fmt`
- `cargo test -p api routes::oauth::tests --features test`
- `cargo test -p config cors_config`
- `git diff --check`
- `cargo check -p api --features test`
