### PR TITLE
fix: migration image mapping, env passthrough, restore logging

### DIFF
--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3561,6 +3561,28 @@ pub async fn admin_migrate_instance(
         .unwrap_or("unknown");
 
     let was_running = compose_status != "stopped" && compose_status != "exited";
+
+    // Preflight: ironclaw instances must have SECRETS_MASTER_KEY available.
+    // compose-api reads it via docker exec at startup — stopped containers are
+    // unreachable so the key is missing. Fail early before any side effects.
+    let has_master_key = compose_data
+        .get("extra_env")
+        .and_then(|v| v.get("SECRETS_MASTER_KEY"))
+        .and_then(|v| v.as_str())
+        .is_some_and(|s| !s.is_empty());
+    if !has_master_key && (service_type == "ironclaw" || service_type.starts_with("ironclaw-")) {
+        tracing::error!(
+            "Migrate: SECRETS_MASTER_KEY not found — aborting before side effects. \
+             Start all instances and restart compose-api first. instance_id={}, name={}",
+            id,
+            instance_name
+        );
+        return Err(ApiError::bad_request(
+            "SECRETS_MASTER_KEY not available — start all instances and restart \
+             compose-api before migration",
+        ));
+    }
+
     if !was_running {
         tracing::info!(
             "Migrate: instance stopped, starting before backup, elapsed={:.1}s, instance_id={}",
@@ -3813,20 +3835,6 @@ pub async fn admin_migrate_instance(
                 extra_env_map.insert(k.clone(), v.clone());
             }
         }
-    }
-    // compose-api populates SECRETS_MASTER_KEY via docker exec at startup.
-    // Instances that were stopped at that time won't have it — start all stopped
-    // instances and restart compose-api before running migrations.
-    if !extra_env_map.contains_key("SECRETS_MASTER_KEY")
-        && (service_type == "ironclaw" || service_type.starts_with("ironclaw-"))
-    {
-        tracing::warn!(
-            "Migrate: SECRETS_MASTER_KEY not found for ironclaw instance — \
-             channels may fail to decrypt. Ensure instance was running when \
-             compose-api started. instance_id={}, name={}",
-            id,
-            instance_name
-        );
     }
     extra_env_map.insert(
         "LEGACY_API_BASE_URL".into(),

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3523,63 +3523,12 @@ pub async fn admin_migrate_instance(
         .get("nearai_api_url")
         .and_then(|v| v.as_str())
         .ok_or_else(|| ApiError::bad_request("Instance has no nearai_api_url — cannot migrate"))?;
-    // Image: use explicit override from request body, or query the running instance's
-    // app version and construct a matching ironclaw-dind/openclaw tag. Falls back to
-    // the configured default if the version query fails.
     let request = body.map(|b| b.0).unwrap_or_default();
     let service_type = instance.service_type.as_deref().unwrap_or("openclaw");
-    let image = if let Some(img) = request.image {
-        img
-    } else {
-        // Try to get the app version from the running legacy container
-        let version_url = format!("{}/instances/{}/version", compose_api_url, encoded_name);
-        let version = async {
-            let resp = app_state
-                .http_client
-                .get(&version_url)
-                .bearer_auth(&manager.token)
-                .timeout(std::time::Duration::from_secs(10))
-                .send()
-                .await
-                .ok()?;
-            if !resp.status().is_success() {
-                return None;
-            }
-            let body: serde_json::Value = resp.json().await.ok()?;
-            body.get("version")?.as_str().map(|s| s.to_string())
-        }
-        .await;
-
-        if let Some(ver) = version {
-            let is_ironclaw = service_type == "ironclaw" || service_type.starts_with("ironclaw-");
-            let image_name = if is_ironclaw {
-                "docker.io/nearaidev/ironclaw-dind"
-            } else {
-                "docker.io/nearaidev/openclaw-nearai-worker"
-            };
-            tracing::info!(
-                "Migrate: resolved app version={}, using image {}:{}, instance_id={}",
-                ver,
-                image_name,
-                ver,
-                id
-            );
-            format!("{}:{}", image_name, ver)
-        } else {
-            let is_ironclaw = service_type == "ironclaw" || service_type.starts_with("ironclaw-");
-            let fallback = if is_ironclaw {
-                "docker.io/nearaidev/ironclaw-dind:0.29.1".to_string()
-            } else {
-                "docker.io/nearaidev/openclaw-nearai-worker:latest".to_string()
-            };
-            tracing::info!(
-                "Migrate: version query failed, using default image={}, instance_id={}",
-                fallback,
-                id
-            );
-            fallback
-        }
-    };
+    // Image override from request body (validated non-empty). Actual resolution
+    // is deferred until after the "start if stopped" block so the version query
+    // can reach the running container.
+    let image_override = request.image.filter(|s| !s.is_empty());
     let mem_limit = compose_data
         .get("mem_limit")
         .and_then(|v| v.as_str())
@@ -3633,6 +3582,59 @@ pub async fn admin_migrate_instance(
             ));
         }
     }
+
+    // Resolve image now that the container is running and the version endpoint is reachable.
+    let image = if let Some(img) = image_override {
+        img
+    } else {
+        let version_url = format!("{}/instances/{}/version", compose_api_url, encoded_name);
+        let version = async {
+            let resp = app_state
+                .http_client
+                .get(&version_url)
+                .bearer_auth(&manager.token)
+                .timeout(std::time::Duration::from_secs(10))
+                .send()
+                .await
+                .ok()?;
+            if !resp.status().is_success() {
+                return None;
+            }
+            let body: serde_json::Value = resp.json().await.ok()?;
+            body.get("version")?.as_str().map(|s| s.to_string())
+        }
+        .await;
+
+        if let Some(ver) = version {
+            let img = format!(
+                "{}:{}",
+                services::agent::service::get_image_for_service_type(service_type, None)
+                    .rsplit_once(':')
+                    .map(|(base, _)| base)
+                    .unwrap_or("docker.io/nearaidev/ironclaw-dind"),
+                ver
+            );
+            tracing::info!("Migrate: resolved image={}, instance_id={}", img, id);
+            img
+        } else {
+            let mut fallback =
+                services::agent::service::get_image_for_service_type(service_type, None);
+            // For migration, prefer a known-good version over :latest
+            if fallback.ends_with(":latest") {
+                let is_ironclaw =
+                    service_type == "ironclaw" || service_type.starts_with("ironclaw-");
+                if is_ironclaw {
+                    fallback = fallback.replace(":latest", ":0.29.1");
+                }
+            }
+            tracing::info!(
+                "Migrate: version query failed, using default image={}, instance_id={}",
+                fallback,
+                id
+            );
+            fallback
+        }
+    };
 
     tracing::info!(
         "Migrate: requesting backup, was_running={}, elapsed={:.1}s, instance_id={}",
@@ -3775,7 +3777,9 @@ pub async fn admin_migrate_instance(
     let mut extra_env_map = serde_json::Map::new();
     if let Some(legacy_extra) = compose_data.get("extra_env").and_then(|v| v.as_object()) {
         for (k, v) in legacy_extra {
-            extra_env_map.insert(k.clone(), v.clone());
+            if v.is_string() {
+                extra_env_map.insert(k.clone(), v.clone());
+            }
         }
     }
     extra_env_map.insert(

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3656,9 +3656,8 @@ pub async fn admin_migrate_instance(
             img
         } else {
             let mut fallback = default_image;
-            // For ironclaw migration, prefer a known-good version over :latest
-            if fallback.ends_with(":latest") && fallback.contains("ironclaw") {
-                fallback = fallback.replace(":latest", ":0.29.1");
+            if fallback == "docker.io/nearaidev/ironclaw-dind:latest" {
+                fallback = "docker.io/nearaidev/ironclaw-dind:0.29.1".to_string();
             }
             tracing::info!(
                 "Migrate: version query failed, using default image={}, instance_id={}",

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3523,24 +3523,64 @@ pub async fn admin_migrate_instance(
         .get("nearai_api_url")
         .and_then(|v| v.as_str())
         .ok_or_else(|| ApiError::bad_request("Instance has no nearai_api_url — cannot migrate"))?;
-    // Image: use explicit override from request body, or fall back to the configured
-    // CrabShack image for this service type. Legacy image refs (e.g. ironclaw-nearai-worker)
-    // are rejected by CrabShack's allowlist, so we never pass them through.
+    // Image: use explicit override from request body, or query the running instance's
+    // app version and construct a matching ironclaw-dind/openclaw tag. Falls back to
+    // the configured default if the version query fails.
     let request = body.map(|b| b.0).unwrap_or_default();
     let service_type = instance.service_type.as_deref().unwrap_or("openclaw");
     let image = if let Some(img) = request.image {
         img
     } else {
-        let configs = app_state
-            .system_configs_service
-            .get_configs()
-            .await
-            .ok()
-            .flatten();
-        services::agent::service::get_image_for_service_type(
-            service_type,
-            configs.as_ref().and_then(|c| c.agent_hosting.as_ref()),
-        )
+        // Try to get the app version from the running legacy container
+        let version_url = format!("{}/instances/{}/version", compose_api_url, encoded_name);
+        let version = async {
+            let resp = app_state
+                .http_client
+                .get(&version_url)
+                .bearer_auth(&manager.token)
+                .timeout(std::time::Duration::from_secs(10))
+                .send()
+                .await
+                .ok()?;
+            if !resp.status().is_success() {
+                return None;
+            }
+            let body: serde_json::Value = resp.json().await.ok()?;
+            body.get("version")?.as_str().map(|s| s.to_string())
+        }
+        .await;
+
+        if let Some(ver) = version {
+            let image_name = match service_type {
+                "ironclaw" => "docker.io/nearaidev/ironclaw-dind",
+                _ => "docker.io/nearaidev/openclaw-nearai-worker",
+            };
+            tracing::info!(
+                "Migrate: resolved app version={}, using image {}:{}, instance_id={}",
+                ver,
+                image_name,
+                ver,
+                id
+            );
+            format!("{}:{}", image_name, ver)
+        } else {
+            let configs = app_state
+                .system_configs_service
+                .get_configs()
+                .await
+                .ok()
+                .flatten();
+            let fallback = services::agent::service::get_image_for_service_type(
+                service_type,
+                configs.as_ref().and_then(|c| c.agent_hosting.as_ref()),
+            );
+            tracing::info!(
+                "Migrate: version query failed, using default image={}, instance_id={}",
+                fallback,
+                id
+            );
+            fallback
+        }
     };
     let mem_limit = compose_data
         .get("mem_limit")

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3551,9 +3551,11 @@ pub async fn admin_migrate_instance(
         .await;
 
         if let Some(ver) = version {
-            let image_name = match service_type {
-                "ironclaw" => "docker.io/nearaidev/ironclaw-dind",
-                _ => "docker.io/nearaidev/openclaw-nearai-worker",
+            let is_ironclaw = service_type == "ironclaw" || service_type.starts_with("ironclaw-");
+            let image_name = if is_ironclaw {
+                "docker.io/nearaidev/ironclaw-dind"
+            } else {
+                "docker.io/nearaidev/openclaw-nearai-worker"
             };
             tracing::info!(
                 "Migrate: resolved app version={}, using image {}:{}, instance_id={}",
@@ -3564,9 +3566,11 @@ pub async fn admin_migrate_instance(
             );
             format!("{}:{}", image_name, ver)
         } else {
-            let fallback = match service_type {
-                "ironclaw" => "docker.io/nearaidev/ironclaw-dind:0.29.1".to_string(),
-                _ => "docker.io/nearaidev/openclaw-nearai-worker:latest".to_string(),
+            let is_ironclaw = service_type == "ironclaw" || service_type.starts_with("ironclaw-");
+            let fallback = if is_ironclaw {
+                "docker.io/nearaidev/ironclaw-dind:0.29.1".to_string()
+            } else {
+                "docker.io/nearaidev/openclaw-nearai-worker:latest".to_string()
             };
             tracing::info!(
                 "Migrate: version query failed, using default image={}, instance_id={}",

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3583,6 +3583,15 @@ pub async fn admin_migrate_instance(
         }
     }
 
+    // Load system configs for image/service-type resolution (same source as normal create flow).
+    let hosting_config = app_state
+        .system_configs_service
+        .get_configs()
+        .await
+        .ok()
+        .flatten()
+        .and_then(|c| c.agent_hosting);
+
     // Resolve image now that the container is running and the version endpoint is reachable.
     let image = if let Some(img) = image_override {
         img
@@ -3608,17 +3617,22 @@ pub async fn admin_migrate_instance(
         if let Some(ver) = version {
             let img = format!(
                 "{}:{}",
-                services::agent::service::get_image_for_service_type(service_type, None)
-                    .rsplit_once(':')
-                    .map(|(base, _)| base)
-                    .unwrap_or("docker.io/nearaidev/ironclaw-dind"),
+                services::agent::service::get_image_for_service_type(
+                    service_type,
+                    hosting_config.as_ref(),
+                )
+                .rsplit_once(':')
+                .map(|(base, _)| base)
+                .unwrap_or("docker.io/nearaidev/ironclaw-dind"),
                 ver
             );
             tracing::info!("Migrate: resolved image={}, instance_id={}", img, id);
             img
         } else {
-            let mut fallback =
-                services::agent::service::get_image_for_service_type(service_type, None);
+            let mut fallback = services::agent::service::get_image_for_service_type(
+                service_type,
+                hosting_config.as_ref(),
+            );
             // For migration, prefer a known-good version over :latest
             if fallback.ends_with(":latest") {
                 let is_ironclaw =
@@ -3770,7 +3784,7 @@ pub async fn admin_migrate_instance(
         id,
     );
     let crabshack_service_type =
-        services::agent::service::service_type_for_crabshack(service_type, None);
+        services::agent::service::service_type_for_crabshack(service_type, hosting_config.as_ref());
 
     // Build extra_env: start with legacy instance's extra env vars (includes
     // SECRETS_MASTER_KEY, NEARAI_MODEL, etc.), then overlay migration-specific keys.

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3332,6 +3332,14 @@ pub async fn admin_migration_status(
     }))
 }
 
+/// Optional request body for migrate endpoint
+#[derive(Deserialize, Default, utoipa::ToSchema)]
+pub struct MigrateInstanceRequest {
+    /// Override the Docker image for the CrabShack instance.
+    /// If not provided, uses the configured default for the service type.
+    pub image: Option<String>,
+}
+
 /// Response for migrate endpoint
 #[derive(Serialize, utoipa::ToSchema)]
 pub struct MigrateInstanceResponse {
@@ -3345,6 +3353,7 @@ pub async fn admin_migrate_instance(
     State(app_state): State<AppState>,
     Extension(_user): Extension<AuthenticatedUser>,
     Path(instance_id): Path<String>,
+    body: Option<Json<MigrateInstanceRequest>>,
 ) -> Result<Json<MigrateInstanceResponse>, ApiError> {
     let id = Uuid::parse_str(&instance_id)
         .map_err(|_| ApiError::bad_request("Invalid instance ID format"))?;
@@ -3514,11 +3523,25 @@ pub async fn admin_migrate_instance(
         .get("nearai_api_url")
         .and_then(|v| v.as_str())
         .ok_or_else(|| ApiError::bad_request("Instance has no nearai_api_url — cannot migrate"))?;
-    // Fallbacks match create_instance_from_agent_api defaults (service.rs unwrap_or values)
-    let image = compose_data
-        .get("image")
-        .and_then(|v| v.as_str())
-        .unwrap_or("docker.io/nearaidev/ironclaw-dind:latest");
+    // Image: use explicit override from request body, or fall back to the configured
+    // CrabShack image for this service type. Legacy image refs (e.g. ironclaw-nearai-worker)
+    // are rejected by CrabShack's allowlist, so we never pass them through.
+    let request = body.map(|b| b.0).unwrap_or_default();
+    let service_type = instance.service_type.as_deref().unwrap_or("openclaw");
+    let image = if let Some(img) = request.image {
+        img
+    } else {
+        let configs = app_state
+            .system_configs_service
+            .get_configs()
+            .await
+            .ok()
+            .flatten();
+        services::agent::service::get_image_for_service_type(
+            service_type,
+            configs.as_ref().and_then(|c| c.agent_hosting.as_ref()),
+        )
+    };
     let mem_limit = compose_data
         .get("mem_limit")
         .and_then(|v| v.as_str())
@@ -3603,6 +3626,7 @@ pub async fn admin_migrate_instance(
                 &manager.token,
                 was_running,
                 "stop",
+                &instance_name,
             );
             ApiError::internal_server_error("Failed to initiate backup on legacy compose-api")
         })?;
@@ -3621,6 +3645,7 @@ pub async fn admin_migrate_instance(
             &manager.token,
             was_running,
             "stop",
+            &instance_name,
         );
         return Err(ApiError::internal_server_error(
             "Failed to create backup on legacy compose-api",
@@ -3643,6 +3668,7 @@ pub async fn admin_migrate_instance(
                 &manager.token,
                 was_running,
                 "stop",
+                &instance_name,
             );
             return Err(ApiError::internal_server_error(
                 "Failed to get backup URL from legacy compose-api",
@@ -3691,6 +3717,7 @@ pub async fn admin_migrate_instance(
             &manager.token,
             was_running,
             "stop",
+            &instance_name,
         );
         return Err(ApiError::internal_server_error(
             "Failed to stop legacy instance before import",
@@ -3702,15 +3729,30 @@ pub async fn admin_migrate_instance(
         migrate_start.elapsed().as_secs_f64(),
         id,
     );
-    let service_type = instance.service_type.as_deref().unwrap_or("openclaw");
     let crabshack_service_type =
         services::agent::service::service_type_for_crabshack(service_type, None);
 
-    // Store overwritten values in extra_env for rollback reference
-    let extra_env = serde_json::json!({
-        "LEGACY_API_BASE_URL": agent_api_base_url,
-        "LEGACY_INSTANCE_URL": instance.instance_url.as_deref().unwrap_or(""),
-    });
+    // Build extra_env: start with legacy instance's extra env vars (includes
+    // SECRETS_MASTER_KEY, NEARAI_MODEL, etc.), then overlay migration-specific keys.
+    let mut extra_env_map = serde_json::Map::new();
+    if let Some(legacy_extra) = compose_data.get("extra_env").and_then(|v| v.as_object()) {
+        for (k, v) in legacy_extra {
+            extra_env_map.insert(k.clone(), v.clone());
+        }
+    }
+    extra_env_map.insert(
+        "LEGACY_API_BASE_URL".into(),
+        serde_json::Value::String(agent_api_base_url.to_string()),
+    );
+    extra_env_map.insert(
+        "LEGACY_INSTANCE_URL".into(),
+        serde_json::Value::String(instance.instance_url.as_deref().unwrap_or("").to_string()),
+    );
+    extra_env_map.insert(
+        "LEGACY_INSTANCE_NAME".into(),
+        serde_json::Value::String(instance.name.clone()),
+    );
+    let extra_env = serde_json::Value::Object(extra_env_map);
 
     // Find a CrabShack (non-legacy) manager for import
     let crabshack_manager = app_state
@@ -3725,6 +3767,7 @@ pub async fn admin_migrate_instance(
                 &manager.token,
                 was_running,
                 "start",
+                &instance_name,
             );
             ApiError::internal_server_error("No CrabShack manager configured")
         })?;
@@ -3767,6 +3810,7 @@ pub async fn admin_migrate_instance(
                 &manager.token,
                 was_running,
                 "start",
+                &instance_name,
             );
             ApiError::internal_server_error("Failed to import into CrabShack")
         })?;
@@ -3785,6 +3829,7 @@ pub async fn admin_migrate_instance(
             &manager.token,
             was_running,
             "start",
+            &instance_name,
         );
         return Err(ApiError::internal_server_error("CrabShack import failed"));
     }
@@ -3805,6 +3850,7 @@ pub async fn admin_migrate_instance(
                 &manager.token,
                 was_running,
                 "start",
+                &instance_name,
             );
             return Err(ApiError::internal_server_error(
                 "Failed to parse CrabShack import response",
@@ -3852,6 +3898,7 @@ pub async fn admin_migrate_instance(
             &manager.token,
             was_running,
             "start",
+            &instance_name,
         );
         return Err(ApiError::internal_server_error(
             "Migration succeeded but failed to update DB — legacy instance restarted",
@@ -4066,6 +4113,7 @@ fn restore_on_failure(
     token: &str,
     was_running: bool,
     action: &str,
+    instance_name: &str,
 ) {
     let should_restore = match action {
         "stop" => !was_running,
@@ -4079,6 +4127,7 @@ fn restore_on_failure(
     let client = app_state.http_client.clone();
     let token = token.to_string();
     let action = action.to_string();
+    let name = instance_name.to_string();
     tokio::spawn(async move {
         match client
             .post(&url)
@@ -4089,20 +4138,23 @@ fn restore_on_failure(
         {
             Ok(resp) if resp.status().is_success() => {
                 tracing::info!(
-                    "Restored legacy instance after migration failure: action={}",
+                    "Restored legacy instance after migration failure: name={}, action={}",
+                    name,
                     action
                 );
             }
             Ok(resp) => {
                 tracing::warn!(
-                    "Failed to restore legacy instance: action={}, status={}",
+                    "Failed to restore legacy instance: name={}, action={}, status={}",
+                    name,
                     action,
                     resp.status()
                 );
             }
             Err(e) => {
                 tracing::warn!(
-                    "Failed to restore legacy instance: action={}, error={}",
+                    "Failed to restore legacy instance: name={}, action={}, error={}",
+                    name,
                     action,
                     e
                 );

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3564,16 +3564,10 @@ pub async fn admin_migrate_instance(
             );
             format!("{}:{}", image_name, ver)
         } else {
-            let configs = app_state
-                .system_configs_service
-                .get_configs()
-                .await
-                .ok()
-                .flatten();
-            let fallback = services::agent::service::get_image_for_service_type(
-                service_type,
-                configs.as_ref().and_then(|c| c.agent_hosting.as_ref()),
-            );
+            let fallback = match service_type {
+                "ironclaw" => "docker.io/nearaidev/ironclaw-dind:0.29.1".to_string(),
+                _ => "docker.io/nearaidev/openclaw-nearai-worker:latest".to_string(),
+            };
             tracing::info!(
                 "Migrate: version query failed, using default image={}, instance_id={}",
                 fallback,

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3598,15 +3598,30 @@ pub async fn admin_migrate_instance(
     } else {
         let version_url = format!("{}/instances/{}/version", compose_api_url, encoded_name);
         let version = async {
-            let resp = app_state
+            let resp = match app_state
                 .http_client
                 .get(&version_url)
                 .bearer_auth(&manager.token)
                 .timeout(std::time::Duration::from_secs(10))
                 .send()
                 .await
-                .ok()?;
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::debug!(
+                        "Migrate: version query failed: instance_id={}, error={}",
+                        id,
+                        e
+                    );
+                    return None;
+                }
+            };
             if !resp.status().is_success() {
+                tracing::debug!(
+                    "Migrate: version query returned status={}, instance_id={}",
+                    resp.status(),
+                    id
+                );
                 return None;
             }
             let body: serde_json::Value = resp.json().await.ok()?;
@@ -3614,32 +3629,23 @@ pub async fn admin_migrate_instance(
         }
         .await;
 
+        let default_image = services::agent::service::get_image_for_service_type(
+            service_type,
+            hosting_config.as_ref(),
+        );
         if let Some(ver) = version {
-            let img = format!(
-                "{}:{}",
-                services::agent::service::get_image_for_service_type(
-                    service_type,
-                    hosting_config.as_ref(),
-                )
+            let base = default_image
                 .rsplit_once(':')
-                .map(|(base, _)| base)
-                .unwrap_or("docker.io/nearaidev/ironclaw-dind"),
-                ver
-            );
+                .map(|(b, _)| b)
+                .unwrap_or(&default_image);
+            let img = format!("{}:{}", base, ver);
             tracing::info!("Migrate: resolved image={}, instance_id={}", img, id);
             img
         } else {
-            let mut fallback = services::agent::service::get_image_for_service_type(
-                service_type,
-                hosting_config.as_ref(),
-            );
-            // For migration, prefer a known-good version over :latest
-            if fallback.ends_with(":latest") {
-                let is_ironclaw =
-                    service_type == "ironclaw" || service_type.starts_with("ironclaw-");
-                if is_ironclaw {
-                    fallback = fallback.replace(":latest", ":0.29.1");
-                }
+            let mut fallback = default_image;
+            // For ironclaw migration, prefer a known-good version over :latest
+            if fallback.ends_with(":latest") && fallback.contains("ironclaw") {
+                fallback = fallback.replace(":latest", ":0.29.1");
             }
             tracing::info!(
                 "Migrate: version query failed, using default image={}, instance_id={}",

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3524,7 +3524,20 @@ pub async fn admin_migrate_instance(
         .and_then(|v| v.as_str())
         .ok_or_else(|| ApiError::bad_request("Instance has no nearai_api_url — cannot migrate"))?;
     let request = body.map(|b| b.0).unwrap_or_default();
-    let service_type = instance.service_type.as_deref().unwrap_or("openclaw");
+    // Infer service type from compose-api image name when the DB value is null
+    // (all legacy instances have service_type=null).
+    let service_type = instance.service_type.as_deref().unwrap_or_else(|| {
+        let is_ironclaw = compose_data
+            .get("image")
+            .and_then(|v| v.as_str())
+            .map(|img| img.contains("ironclaw"))
+            .unwrap_or(false);
+        if is_ironclaw {
+            "ironclaw"
+        } else {
+            "openclaw"
+        }
+    });
     // Image override from request body (validated non-empty). Actual resolution
     // is deferred until after the "start if stopped" block so the version query
     // can reach the running container.
@@ -3801,6 +3814,20 @@ pub async fn admin_migrate_instance(
                 extra_env_map.insert(k.clone(), v.clone());
             }
         }
+    }
+    // compose-api populates SECRETS_MASTER_KEY via docker exec at startup.
+    // Instances that were stopped at that time won't have it — start all stopped
+    // instances and restart compose-api before running migrations.
+    if !extra_env_map.contains_key("SECRETS_MASTER_KEY")
+        && (service_type == "ironclaw" || service_type.starts_with("ironclaw-"))
+    {
+        tracing::warn!(
+            "Migrate: SECRETS_MASTER_KEY not found for ironclaw instance — \
+             channels may fail to decrypt. Ensure instance was running when \
+             compose-api started. instance_id={}, name={}",
+            id,
+            instance_name
+        );
     }
     extra_env_map.insert(
         "LEGACY_API_BASE_URL".into(),

--- a/crates/services/src/agent/service.rs
+++ b/crates/services/src/agent/service.rs
@@ -193,7 +193,7 @@ pub fn get_image_for_service_type(
     hosting: Option<&AgentHostingConfig>,
 ) -> String {
     match service_type {
-        "ironclaw" => hosting
+        s if s == "ironclaw" || s.starts_with("ironclaw-") => hosting
             .and_then(|h| h.crabshack.ironclaw_image.clone())
             .unwrap_or_else(|| "docker.io/nearaidev/ironclaw-dind:latest".to_string()),
         _ => hosting

--- a/crates/services/src/agent/service.rs
+++ b/crates/services/src/agent/service.rs
@@ -188,7 +188,10 @@ fn compare_semantic_versions(a: &str, b: &str) -> std::cmp::Ordering {
 ///
 /// Does not apply crabshack `deploy_latest_version_tag` flags; use
 /// `AgentServiceImpl::resolve_non_tee_worker_image_ref` for non-TEE deploys.
-fn get_image_for_service_type(service_type: &str, hosting: Option<&AgentHostingConfig>) -> String {
+pub fn get_image_for_service_type(
+    service_type: &str,
+    hosting: Option<&AgentHostingConfig>,
+) -> String {
     match service_type {
         "ironclaw" => hosting
             .and_then(|h| h.crabshack.ironclaw_image.clone())

--- a/crates/services/src/agent/service.rs
+++ b/crates/services/src/agent/service.rs
@@ -211,7 +211,7 @@ pub fn service_type_for_crabshack(
     hosting_config: Option<&crate::system_configs::ports::AgentHostingConfig>,
 ) -> String {
     match canonical_type {
-        "ironclaw" => hosting_config
+        s if s == "ironclaw" || s.starts_with("ironclaw-") => hosting_config
             .and_then(|cfg| cfg.crabshack.ironclaw_service_type.clone())
             .unwrap_or_else(|| "ironclaw-dind".to_string()),
         "openclaw" => hosting_config


### PR DESCRIPTION
Fixing the following issues:

1. **Image mapping**. I forgot that the legacy infra uses not `ironclaw-dind` but `ironclaw-nearai-worker`. Hence we need to derive the correct version. Moreover, `chat-api` can't do it and it requires a separate request to `compose-api` which is implemented in https://github.com/nearai/openclaw-nearai-worker/pull/230. Also I add optional `{"image": "..."}` request body for admin override.
2. **SECRETS_MASTER_KEY + NEARAI_MODEL passthrough**. Telegram pairing was broken after migration because the new instance couldn't read the secrets. Now we reads `extra_env` from compose-api response (also added in https://github.com/nearai/openclaw-nearai-worker/pull/230) and merges into CrabShack import payload (includes LEGACY_INSTANCE_NAME).
3. **restore_on_failure logging** — Added instance name to all log messages (9 call sites) for Datadog searchability.

## Test plan

- [ ] Deploy companion compose-api PR first
- [ ] Migrate a legacy instance — verify CrabShack accepts the image
- [ ] Verify SECRETS_MASTER_KEY arrives in CrabShack instance env
- [ ] Verify NEARAI_MODEL arrives in CrabShack instance env
- [ ] Verify Datadog logs show instance name in restore_on_failure messages
- [ ] Call migrate with `{"image": "docker.io/nearaidev/ironclaw-dind:0.29.1"}` body override
- [ ] Call migrate with no body (should use configured default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)