### PR TITLE
fix: SSE observability, TEE node placement, and backup_url bypass for migration

### DIFF
--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -4036,13 +4036,13 @@ pub async fn admin_migrate_instance(
         }
     };
 
-    // Verify TEE placement — query CrabShack for the created instance and check tee_platform.
+    // Best-effort TEE placement check — read actual node's tee_platform, not the echoed policy.
     let instance_check_url = format!(
         "{}/instances/{}",
         crabshack_manager.url.trim_end_matches('/'),
         urlencoding::encode(&instance_name)
     );
-    if let Ok(resp) = app_state
+    match app_state
         .http_client
         .get(&instance_check_url)
         .bearer_auth(&crabshack_manager.token)
@@ -4050,18 +4050,33 @@ pub async fn admin_migrate_instance(
         .send()
         .await
     {
-        if let Ok(body) = resp.json::<serde_json::Value>().await {
-            let tee = body
-                .pointer("/node_policy/tee")
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown");
-            if tee == "NO_TEE" {
-                tracing::warn!(
-                    "Migrate: instance landed on non-TEE node, node_policy.tee={}, instance_id={}. \
-                     CrabShack may not support node_policy yet — check deploy ordering.",
-                    tee, id,
-                );
+        Ok(resp) if resp.status().is_success() => {
+            if let Ok(body) = resp.json::<serde_json::Value>().await {
+                let has_tee = body
+                    .pointer("/running_platform/tee_platform")
+                    .is_some_and(|v| !v.is_null());
+                if !has_tee {
+                    tracing::warn!(
+                        "Migrate: instance may not be on a TEE node (running_platform.tee_platform absent), \
+                         instance_id={}",
+                        id,
+                    );
+                }
             }
+        }
+        Ok(resp) => {
+            tracing::warn!(
+                "Migrate: TEE placement check failed: status={}, instance_id={}",
+                resp.status(),
+                id,
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                "Migrate: TEE placement check failed: error={}, instance_id={}",
+                e,
+                id,
+            );
         }
     }
 

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3708,7 +3708,7 @@ pub async fn admin_migrate_instance(
         .post(&backup_url)
         .bearer_auth(&manager.token)
         .json(&backup_body)
-        .timeout(std::time::Duration::from_secs(600))
+        .timeout(SSE_MIGRATION_TOTAL_TIMEOUT)
         .send()
         .await
         .map_err(|e| {
@@ -3883,7 +3883,7 @@ pub async fn admin_migrate_instance(
         "cpus": cpus,
         "storage_size": storage_size,
         "extra_env": extra_env,
-        "node_policy": { "tee": "ANY_TEE" },
+        "node_policy": { "version": 1, "tee": "ANY_TEE" },
     });
 
     let import_resp = app_state
@@ -3891,7 +3891,7 @@ pub async fn admin_migrate_instance(
         .post(&import_url)
         .bearer_auth(&crabshack_manager.token)
         .json(&import_body)
-        .timeout(std::time::Duration::from_secs(600))
+        .timeout(SSE_MIGRATION_TOTAL_TIMEOUT)
         .send()
         .await
         .map_err(|e| {
@@ -4019,6 +4019,7 @@ pub async fn admin_migrate_instance(
 /// Maximum buffer size for SSE parsing (1 MB).
 const SSE_BUFFER_LIMIT: usize = 1024 * 1024;
 /// Total time budget for an SSE migration stream (backup or import).
+/// Applied as reqwest's per-request .timeout() on the backup/import POST calls.
 const SSE_MIGRATION_TOTAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
 /// How long to wait for a single chunk before logging a stall warning.
 /// Compose-api sends keepalives every 15s, so 30s without any data means trouble.
@@ -4049,16 +4050,9 @@ async fn parse_sse_for_backup_url(
             }
             Ok(None) => break,
             Err(_) => {
-                let silent_secs = last_chunk_at.elapsed().as_secs_f64();
-                if start.elapsed() >= SSE_MIGRATION_TOTAL_TIMEOUT {
-                    anyhow::bail!(
-                        "Timed out waiting for backup SSE ({}s total, no data for {:.0}s, {} chunks received), instance_id={}",
-                        SSE_MIGRATION_TOTAL_TIMEOUT.as_secs(), silent_secs, chunk_count, instance_id,
-                    );
-                }
                 tracing::warn!(
                     "Backup SSE: no data for {:.0}s (total elapsed={:.1}s, chunks={}), instance_id={}",
-                    silent_secs, start.elapsed().as_secs_f64(), chunk_count, instance_id,
+                    last_chunk_at.elapsed().as_secs_f64(), start.elapsed().as_secs_f64(), chunk_count, instance_id,
                 );
                 continue;
             }
@@ -4162,16 +4156,9 @@ async fn parse_sse_for_import_result(
             }
             Ok(None) => break,
             Err(_) => {
-                let silent_secs = last_chunk_at.elapsed().as_secs_f64();
-                if start.elapsed() >= SSE_MIGRATION_TOTAL_TIMEOUT {
-                    anyhow::bail!(
-                        "Timed out waiting for import SSE ({}s total, no data for {:.0}s, {} chunks received), instance_id={}",
-                        SSE_MIGRATION_TOTAL_TIMEOUT.as_secs(), silent_secs, chunk_count, instance_id,
-                    );
-                }
                 tracing::warn!(
                     "Import SSE: no data for {:.0}s (total elapsed={:.1}s, chunks={}), instance_id={}",
-                    silent_secs, start.elapsed().as_secs_f64(), chunk_count, instance_id,
+                    last_chunk_at.elapsed().as_secs_f64(), start.elapsed().as_secs_f64(), chunk_count, instance_id,
                 );
                 continue;
             }

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3656,16 +3656,33 @@ pub async fn admin_migrate_instance(
     let image = if let Some(img) = image_override {
         img
     } else if has_backup_url {
+        let compose_image = compose_data
+            .get("image")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
         let default_image = services::agent::service::get_image_for_service_type(
             service_type,
             hosting_config.as_ref(),
         );
-        let mut fallback = default_image;
-        if fallback == "docker.io/nearaidev/ironclaw-dind:latest" {
-            fallback = "docker.io/nearaidev/ironclaw-dind:0.29.1".to_string();
-        }
+        let version_from_compose = compose_image
+            .rsplit_once(':')
+            .map(|(_, tag)| tag)
+            .filter(|t| !t.is_empty() && *t != "latest");
+        let fallback = if let Some(ver) = version_from_compose {
+            let base = default_image
+                .rsplit_once(':')
+                .map(|(b, _)| b)
+                .unwrap_or(&default_image);
+            format!("{}:{}", base, ver)
+        } else {
+            let mut img = default_image;
+            if img == "docker.io/nearaidev/ironclaw-dind:latest" {
+                img = "docker.io/nearaidev/ironclaw-dind:0.29.1".to_string();
+            }
+            img
+        };
         tracing::info!(
-            "Migrate: backup_url provided, using default image={}, instance_id={}",
+            "Migrate: backup_url provided, image derived from compose metadata={}, instance_id={}",
             fallback,
             id
         );

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3550,6 +3550,12 @@ pub async fn admin_migrate_instance(
     // can reach the running container.
     let image_override = request.image.filter(|s| !s.is_empty());
     let provided_backup_url = request.backup_url.filter(|s| !s.is_empty());
+    let has_backup_url = provided_backup_url.is_some();
+    if let Some(ref url) = provided_backup_url {
+        if !url.starts_with("https://") {
+            return Err(ApiError::bad_request("backup_url must use https scheme"));
+        }
+    }
     let mem_limit = compose_data
         .get("mem_limit")
         .and_then(|v| v.as_str())
@@ -3569,6 +3575,13 @@ pub async fn admin_migrate_instance(
         .unwrap_or("unknown");
 
     let was_running = compose_status != "stopped" && compose_status != "exited";
+
+    if has_backup_url && was_running {
+        return Err(ApiError::bad_request(
+            "backup_url requires the legacy instance to be stopped first — \
+             stop it before taking an external backup to avoid data loss",
+        ));
+    }
 
     // Preflight: ironclaw instances must have SECRETS_MASTER_KEY available.
     // compose-api reads it via docker exec at startup — stopped containers are
@@ -3594,7 +3607,7 @@ pub async fn admin_migrate_instance(
     // When backup_url is provided, skip starting the instance and querying /version —
     // the admin already obtained the backup externally (e.g. direct compose-api call)
     // and the instance should stay stopped to avoid accepting writes after the backup.
-    if provided_backup_url.is_none() && !was_running {
+    if !has_backup_url && !was_running {
         tracing::info!(
             "Migrate: instance stopped, starting before backup, elapsed={:.1}s, instance_id={}",
             migrate_start.elapsed().as_secs_f64(),
@@ -3642,7 +3655,7 @@ pub async fn admin_migrate_instance(
     // otherwise fall back to the configured default.
     let image = if let Some(img) = image_override {
         img
-    } else if provided_backup_url.is_some() {
+    } else if has_backup_url {
         let default_image = services::agent::service::get_image_for_service_type(
             service_type,
             hosting_config.as_ref(),
@@ -3806,52 +3819,55 @@ pub async fn admin_migrate_instance(
         }
     };
 
-    tracing::info!(
-        "Migrate: backup complete, stopping legacy instance, elapsed={:.1}s, instance_id={}",
-        migrate_start.elapsed().as_secs_f64(),
-        id,
-    );
-    let stop_url = format!("{}/instances/{}/stop", compose_api_url, encoded_name);
-    let stop_resp = app_state
-        .http_client
-        .post(&stop_url)
-        .bearer_auth(&manager.token)
-        .timeout(std::time::Duration::from_secs(60))
-        .send()
-        .await;
-
-    let stop_failed = match &stop_resp {
-        Err(e) => {
-            tracing::error!(
-                "Failed to stop instance on compose-api: instance_id={}, error={}",
-                id,
-                e
-            );
-            true
-        }
-        Ok(resp) if !resp.status().is_success() => {
-            tracing::error!(
-                "Compose-api stop returned non-success: instance_id={}, status={}",
-                id,
-                resp.status()
-            );
-            true
-        }
-        _ => false,
-    };
-    if stop_failed {
-        restore_on_failure(
-            &app_state,
-            compose_api_url,
-            &encoded_name,
-            &manager.token,
-            was_running,
-            "stop",
-            &instance_name,
+    // Skip stop when backup_url was provided — instance is already stopped (enforced above).
+    if !has_backup_url {
+        tracing::info!(
+            "Migrate: backup complete, stopping legacy instance, elapsed={:.1}s, instance_id={}",
+            migrate_start.elapsed().as_secs_f64(),
+            id,
         );
-        return Err(ApiError::internal_server_error(
-            "Failed to stop legacy instance before import",
-        ));
+        let stop_url = format!("{}/instances/{}/stop", compose_api_url, encoded_name);
+        let stop_resp = app_state
+            .http_client
+            .post(&stop_url)
+            .bearer_auth(&manager.token)
+            .timeout(std::time::Duration::from_secs(60))
+            .send()
+            .await;
+
+        let stop_failed = match &stop_resp {
+            Err(e) => {
+                tracing::error!(
+                    "Failed to stop instance on compose-api: instance_id={}, error={}",
+                    id,
+                    e
+                );
+                true
+            }
+            Ok(resp) if !resp.status().is_success() => {
+                tracing::error!(
+                    "Compose-api stop returned non-success: instance_id={}, status={}",
+                    id,
+                    resp.status()
+                );
+                true
+            }
+            _ => false,
+        };
+        if stop_failed {
+            restore_on_failure(
+                &app_state,
+                compose_api_url,
+                &encoded_name,
+                &manager.token,
+                was_running,
+                "stop",
+                &instance_name,
+            );
+            return Err(ApiError::internal_server_error(
+                "Failed to stop legacy instance before import",
+            ));
+        }
     }
 
     tracing::info!(
@@ -3904,6 +3920,8 @@ pub async fn admin_migrate_instance(
             ApiError::internal_server_error("No CrabShack manager configured")
         })?;
 
+    // Deploy ordering: node_policy requires CrabShack PR #327 to be deployed first.
+    // Without it, CrabShack ignores the field (pre-#327 import silently drops unknown fields).
     let import_url = format!("{}/instances/import", crabshack_manager.url);
     let import_body = serde_json::json!({
         "name": instance.name,

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3341,6 +3341,9 @@ pub struct MigrateInstanceRequest {
     /// Skip the backup phase entirely and use this presigned URL instead.
     /// Useful when backup was obtained directly from compose-api (e.g. the
     /// SSE stream stalls through chat-api but works when called directly).
+    /// The backup must be age-encrypted with the recipient derived from the
+    /// user's stored passphrase + instance name. The legacy instance will NOT
+    /// be started — stop it before taking the external backup to avoid data loss.
     pub backup_url: Option<String>,
 }
 
@@ -3588,7 +3591,10 @@ pub async fn admin_migrate_instance(
         ));
     }
 
-    if !was_running {
+    // When backup_url is provided, skip starting the instance and querying /version —
+    // the admin already obtained the backup externally (e.g. direct compose-api call)
+    // and the instance should stay stopped to avoid accepting writes after the backup.
+    if provided_backup_url.is_none() && !was_running {
         tracing::info!(
             "Migrate: instance stopped, starting before backup, elapsed={:.1}s, instance_id={}",
             migrate_start.elapsed().as_secs_f64(),
@@ -3632,9 +3638,25 @@ pub async fn admin_migrate_instance(
         .flatten()
         .and_then(|c| c.agent_hosting);
 
-    // Resolve image now that the container is running and the version endpoint is reachable.
+    // Resolve image: use override if provided, query /version if instance is running,
+    // otherwise fall back to the configured default.
     let image = if let Some(img) = image_override {
         img
+    } else if provided_backup_url.is_some() {
+        let default_image = services::agent::service::get_image_for_service_type(
+            service_type,
+            hosting_config.as_ref(),
+        );
+        let mut fallback = default_image;
+        if fallback == "docker.io/nearaidev/ironclaw-dind:latest" {
+            fallback = "docker.io/nearaidev/ironclaw-dind:0.29.1".to_string();
+        }
+        tracing::info!(
+            "Migrate: backup_url provided, using default image={}, instance_id={}",
+            fallback,
+            id
+        );
+        fallback
     } else {
         let version_url = format!("{}/instances/{}/version", compose_api_url, encoded_name);
         let version = async {

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3412,11 +3412,21 @@ pub async fn admin_migrate_instance(
             ApiError::internal_server_error("Failed to get user credentials")
         })?;
 
+    let request_has_backup_url = body
+        .as_ref()
+        .and_then(|b| b.backup_url.as_ref())
+        .is_some_and(|s| !s.is_empty());
+
     let backup_passphrase = match creds {
         Some((_auth_secret, passphrase)) => passphrase,
+        None if request_has_backup_url => {
+            return Err(ApiError::bad_request(
+                "backup_url requires existing passkey credentials — run a normal \
+                 migration first (without backup_url) to generate them, or use the \
+                 passkey enrollment endpoint",
+            ));
+        }
         None => {
-            // Generate and store a new passphrase
-            // Generate random 32-byte hex strings using two UUIDv4 (16 bytes each)
             let passphrase = format!(
                 "{}{}",
                 Uuid::new_v4().as_simple(),
@@ -4025,6 +4035,35 @@ pub async fn admin_migrate_instance(
             ));
         }
     };
+
+    // Verify TEE placement — query CrabShack for the created instance and check tee_platform.
+    let instance_check_url = format!(
+        "{}/instances/{}",
+        crabshack_manager.url.trim_end_matches('/'),
+        urlencoding::encode(&instance_name)
+    );
+    if let Ok(resp) = app_state
+        .http_client
+        .get(&instance_check_url)
+        .bearer_auth(&crabshack_manager.token)
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await
+    {
+        if let Ok(body) = resp.json::<serde_json::Value>().await {
+            let tee = body
+                .pointer("/node_policy/tee")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            if tee == "NO_TEE" {
+                tracing::warn!(
+                    "Migrate: instance landed on non-TEE node, node_policy.tee={}, instance_id={}. \
+                     CrabShack may not support node_policy yet — check deploy ordering.",
+                    tee, id,
+                );
+            }
+        }
+    }
 
     // Construct instance_url from CrabShack manager domain + instance name + token.
     // CrabShack doesn't emit URLs — same pattern as the normal create flow (service.rs:1584-1597).

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3666,33 +3666,16 @@ pub async fn admin_migrate_instance(
     let image = if let Some(img) = image_override {
         img
     } else if has_backup_url {
-        let compose_image = compose_data
-            .get("image")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
         let default_image = services::agent::service::get_image_for_service_type(
             service_type,
             hosting_config.as_ref(),
         );
-        let version_from_compose = compose_image
-            .rsplit_once(':')
-            .map(|(_, tag)| tag)
-            .filter(|t| !t.is_empty() && *t != "latest");
-        let fallback = if let Some(ver) = version_from_compose {
-            let base = default_image
-                .rsplit_once(':')
-                .map(|(b, _)| b)
-                .unwrap_or(&default_image);
-            format!("{}:{}", base, ver)
-        } else {
-            let mut img = default_image;
-            if img == "docker.io/nearaidev/ironclaw-dind:latest" {
-                img = "docker.io/nearaidev/ironclaw-dind:0.29.1".to_string();
-            }
-            img
-        };
+        let mut fallback = default_image;
+        if fallback == "docker.io/nearaidev/ironclaw-dind:latest" {
+            fallback = "docker.io/nearaidev/ironclaw-dind:0.29.1".to_string();
+        }
         tracing::info!(
-            "Migrate: backup_url provided, image derived from compose metadata={}, instance_id={}",
+            "Migrate: backup_url provided, using default image={}, instance_id={}",
             fallback,
             id
         );

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3338,6 +3338,10 @@ pub struct MigrateInstanceRequest {
     /// Override the Docker image for the CrabShack instance.
     /// If not provided, uses the configured default for the service type.
     pub image: Option<String>,
+    /// Skip the backup phase entirely and use this presigned URL instead.
+    /// Useful when backup was obtained directly from compose-api (e.g. the
+    /// SSE stream stalls through chat-api but works when called directly).
+    pub backup_url: Option<String>,
 }
 
 /// Response for migrate endpoint
@@ -3542,6 +3546,7 @@ pub async fn admin_migrate_instance(
     // is deferred until after the "start if stopped" block so the version query
     // can reach the running container.
     let image_override = request.image.filter(|s| !s.is_empty());
+    let provided_backup_url = request.backup_url.filter(|s| !s.is_empty());
     let mem_limit = compose_data
         .get("mem_limit")
         .and_then(|v| v.as_str())
@@ -3690,70 +3695,55 @@ pub async fn admin_migrate_instance(
         }
     };
 
-    tracing::info!(
-        "Migrate: requesting backup, was_running={}, elapsed={:.1}s, instance_id={}",
-        was_running,
-        migrate_start.elapsed().as_secs_f64(),
-        id,
-    );
-    let backup_url = format!("{}/instances/{}/backup", compose_api_url, encoded_name);
-    let backup_body = serde_json::json!({
-        "age_recipient": age_recipient,
-        "expiry_secs": 7200,
-        "full_export": true
-    });
-
-    let backup_resp = app_state
-        .http_client
-        .post(&backup_url)
-        .bearer_auth(&manager.token)
-        .json(&backup_body)
-        .timeout(SSE_MIGRATION_TOTAL_TIMEOUT)
-        .send()
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to create backup: instance_id={}, error={}", id, e);
-            restore_on_failure(
-                &app_state,
-                compose_api_url,
-                &encoded_name,
-                &manager.token,
-                was_running,
-                "stop",
-                &instance_name,
-            );
-            ApiError::internal_server_error("Failed to initiate backup on legacy compose-api")
-        })?;
-
-    if !backup_resp.status().is_success() {
-        let status = backup_resp.status();
-        tracing::error!(
-            "Compose-api backup failed: instance_id={}, status={}",
+    let backup_presigned_url = if let Some(url) = provided_backup_url {
+        tracing::info!(
+            "Migrate: using provided backup_url, skipping backup phase, elapsed={:.1}s, instance_id={}",
+            migrate_start.elapsed().as_secs_f64(),
             id,
-            status
         );
-        restore_on_failure(
-            &app_state,
-            compose_api_url,
-            &encoded_name,
-            &manager.token,
+        url
+    } else {
+        tracing::info!(
+            "Migrate: requesting backup, was_running={}, elapsed={:.1}s, instance_id={}",
             was_running,
-            "stop",
-            &instance_name,
+            migrate_start.elapsed().as_secs_f64(),
+            id,
         );
-        return Err(ApiError::internal_server_error(
-            "Failed to create backup on legacy compose-api",
-        ));
-    }
+        let backup_url = format!("{}/instances/{}/backup", compose_api_url, encoded_name);
+        let backup_body = serde_json::json!({
+            "age_recipient": age_recipient,
+            "expiry_secs": 7200,
+            "full_export": true
+        });
 
-    // Parse SSE stream to get backup presigned URL
-    let backup_presigned_url = match parse_sse_for_backup_url(backup_resp, &id_str).await {
-        Ok(url) => url,
-        Err(e) => {
+        let backup_resp = app_state
+            .http_client
+            .post(&backup_url)
+            .bearer_auth(&manager.token)
+            .json(&backup_body)
+            .timeout(SSE_MIGRATION_TOTAL_TIMEOUT)
+            .send()
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to create backup: instance_id={}, error={}", id, e);
+                restore_on_failure(
+                    &app_state,
+                    compose_api_url,
+                    &encoded_name,
+                    &manager.token,
+                    was_running,
+                    "stop",
+                    &instance_name,
+                );
+                ApiError::internal_server_error("Failed to initiate backup on legacy compose-api")
+            })?;
+
+        if !backup_resp.status().is_success() {
+            let status = backup_resp.status();
             tracing::error!(
-                "Failed to parse backup SSE stream: instance_id={}, error={}",
+                "Compose-api backup failed: instance_id={}, status={}",
                 id,
-                e
+                status
             );
             restore_on_failure(
                 &app_state,
@@ -3765,8 +3755,32 @@ pub async fn admin_migrate_instance(
                 &instance_name,
             );
             return Err(ApiError::internal_server_error(
-                "Failed to get backup URL from legacy compose-api",
+                "Failed to create backup on legacy compose-api",
             ));
+        }
+
+        // Parse SSE stream to get backup presigned URL
+        match parse_sse_for_backup_url(backup_resp, &id_str).await {
+            Ok(url) => url,
+            Err(e) => {
+                tracing::error!(
+                    "Failed to parse backup SSE stream: instance_id={}, error={}",
+                    id,
+                    e
+                );
+                restore_on_failure(
+                    &app_state,
+                    compose_api_url,
+                    &encoded_name,
+                    &manager.token,
+                    was_running,
+                    "stop",
+                    &instance_name,
+                );
+                return Err(ApiError::internal_server_error(
+                    "Failed to get backup URL from legacy compose-api",
+                ));
+            }
         }
     };
 

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -4036,50 +4036,6 @@ pub async fn admin_migrate_instance(
         }
     };
 
-    // Best-effort TEE placement check — read actual node's tee_platform, not the echoed policy.
-    let instance_check_url = format!(
-        "{}/instances/{}",
-        crabshack_manager.url.trim_end_matches('/'),
-        urlencoding::encode(&instance_name)
-    );
-    match app_state
-        .http_client
-        .get(&instance_check_url)
-        .bearer_auth(&crabshack_manager.token)
-        .timeout(std::time::Duration::from_secs(10))
-        .send()
-        .await
-    {
-        Ok(resp) if resp.status().is_success() => {
-            if let Ok(body) = resp.json::<serde_json::Value>().await {
-                let has_tee = body
-                    .pointer("/running_platform/tee_platform")
-                    .is_some_and(|v| !v.is_null());
-                if !has_tee {
-                    tracing::warn!(
-                        "Migrate: instance may not be on a TEE node (running_platform.tee_platform absent), \
-                         instance_id={}",
-                        id,
-                    );
-                }
-            }
-        }
-        Ok(resp) => {
-            tracing::warn!(
-                "Migrate: TEE placement check failed: status={}, instance_id={}",
-                resp.status(),
-                id,
-            );
-        }
-        Err(e) => {
-            tracing::warn!(
-                "Migrate: TEE placement check failed: error={}, instance_id={}",
-                e,
-                id,
-            );
-        }
-    }
-
     // Construct instance_url from CrabShack manager domain + instance name + token.
     // CrabShack doesn't emit URLs — same pattern as the normal create flow (service.rs:1584-1597).
     let new_instance_url = url::Url::parse(&crabshack_manager.url)

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3883,6 +3883,7 @@ pub async fn admin_migrate_instance(
         "cpus": cpus,
         "storage_size": storage_size,
         "extra_env": extra_env,
+        "node_policy": { "tee": "ANY_TEE" },
     });
 
     let import_resp = app_state
@@ -4017,11 +4018,11 @@ pub async fn admin_migrate_instance(
 
 /// Maximum buffer size for SSE parsing (1 MB).
 const SSE_BUFFER_LIMIT: usize = 1024 * 1024;
-/// Timeout for receiving each SSE chunk during migration.
-/// Backup involves docker-exec tar + encrypt + S3 upload (can take minutes for large instances).
-/// Import involves image pull + backup download + decrypt + extract + container start.
-/// With compose-api keepalives every 5-15s, this timeout catches dead connections only.
-const SSE_MIGRATION_CHUNK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+/// Total time budget for an SSE migration stream (backup or import).
+const SSE_MIGRATION_TOTAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+/// How long to wait for a single chunk before logging a stall warning.
+/// Compose-api sends keepalives every 15s, so 30s without any data means trouble.
+const SSE_STALL_DETECT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Parse an SSE response stream to extract the backup presigned URL from the "complete" event.
 async fn parse_sse_for_backup_url(
@@ -4033,6 +4034,7 @@ async fn parse_sse_for_backup_url(
     let mut buffer = String::new();
     let start = std::time::Instant::now();
     let mut chunk_count: u64 = 0;
+    let mut last_chunk_at = std::time::Instant::now();
 
     tracing::info!(
         "Backup SSE: starting stream parse: instance_id={}",
@@ -4040,15 +4042,26 @@ async fn parse_sse_for_backup_url(
     );
 
     loop {
-        let chunk = match tokio::time::timeout(SSE_MIGRATION_CHUNK_TIMEOUT, stream.next()).await {
-            Ok(Some(chunk)) => chunk?,
+        let chunk = match tokio::time::timeout(SSE_STALL_DETECT_INTERVAL, stream.next()).await {
+            Ok(Some(chunk)) => {
+                last_chunk_at = std::time::Instant::now();
+                chunk?
+            }
             Ok(None) => break,
-            Err(_) => anyhow::bail!(
-                "Timed out waiting for SSE chunk from backup stream ({}s, received {} chunks in {:.1}s)",
-                SSE_MIGRATION_CHUNK_TIMEOUT.as_secs(),
-                chunk_count,
-                start.elapsed().as_secs_f64(),
-            ),
+            Err(_) => {
+                let silent_secs = last_chunk_at.elapsed().as_secs_f64();
+                if start.elapsed() >= SSE_MIGRATION_TOTAL_TIMEOUT {
+                    anyhow::bail!(
+                        "Timed out waiting for backup SSE ({}s total, no data for {:.0}s, {} chunks received), instance_id={}",
+                        SSE_MIGRATION_TOTAL_TIMEOUT.as_secs(), silent_secs, chunk_count, instance_id,
+                    );
+                }
+                tracing::warn!(
+                    "Backup SSE: no data for {:.0}s (total elapsed={:.1}s, chunks={}), instance_id={}",
+                    silent_secs, start.elapsed().as_secs_f64(), chunk_count, instance_id,
+                );
+                continue;
+            }
         };
         chunk_count += 1;
         buffer.push_str(&String::from_utf8_lossy(&chunk));
@@ -4063,6 +4076,16 @@ async fn parse_sse_for_backup_url(
         while let Some(newline_pos) = buffer.find('\n') {
             let line = buffer[..newline_pos].trim_end_matches('\r').to_string();
             buffer.drain(..=newline_pos);
+
+            if line.starts_with(':') {
+                tracing::info!(
+                    "Backup SSE: keepalive, elapsed={:.1}s, chunks={}, instance_id={}",
+                    start.elapsed().as_secs_f64(),
+                    chunk_count,
+                    instance_id,
+                );
+                continue;
+            }
 
             if let Some(data) = line.strip_prefix("data: ") {
                 if let Ok(event) = serde_json::from_str::<serde_json::Value>(data) {
@@ -4124,6 +4147,7 @@ async fn parse_sse_for_import_result(
     let mut buffer = String::new();
     let start = std::time::Instant::now();
     let mut chunk_count: u64 = 0;
+    let mut last_chunk_at = std::time::Instant::now();
 
     tracing::info!(
         "Import SSE: starting stream parse: instance_id={}",
@@ -4131,15 +4155,26 @@ async fn parse_sse_for_import_result(
     );
 
     loop {
-        let chunk = match tokio::time::timeout(SSE_MIGRATION_CHUNK_TIMEOUT, stream.next()).await {
-            Ok(Some(chunk)) => chunk?,
+        let chunk = match tokio::time::timeout(SSE_STALL_DETECT_INTERVAL, stream.next()).await {
+            Ok(Some(chunk)) => {
+                last_chunk_at = std::time::Instant::now();
+                chunk?
+            }
             Ok(None) => break,
-            Err(_) => anyhow::bail!(
-                "Timed out waiting for SSE chunk from import stream ({}s, received {} chunks in {:.1}s)",
-                SSE_MIGRATION_CHUNK_TIMEOUT.as_secs(),
-                chunk_count,
-                start.elapsed().as_secs_f64(),
-            ),
+            Err(_) => {
+                let silent_secs = last_chunk_at.elapsed().as_secs_f64();
+                if start.elapsed() >= SSE_MIGRATION_TOTAL_TIMEOUT {
+                    anyhow::bail!(
+                        "Timed out waiting for import SSE ({}s total, no data for {:.0}s, {} chunks received), instance_id={}",
+                        SSE_MIGRATION_TOTAL_TIMEOUT.as_secs(), silent_secs, chunk_count, instance_id,
+                    );
+                }
+                tracing::warn!(
+                    "Import SSE: no data for {:.0}s (total elapsed={:.1}s, chunks={}), instance_id={}",
+                    silent_secs, start.elapsed().as_secs_f64(), chunk_count, instance_id,
+                );
+                continue;
+            }
         };
         chunk_count += 1;
         buffer.push_str(&String::from_utf8_lossy(&chunk));
@@ -4154,6 +4189,16 @@ async fn parse_sse_for_import_result(
         while let Some(newline_pos) = buffer.find('\n') {
             let line = buffer[..newline_pos].trim_end_matches('\r').to_string();
             buffer.drain(..=newline_pos);
+
+            if line.starts_with(':') {
+                tracing::info!(
+                    "Import SSE: keepalive, elapsed={:.1}s, chunks={}, instance_id={}",
+                    start.elapsed().as_secs_f64(),
+                    chunk_count,
+                    instance_id,
+                );
+                continue;
+            }
 
             if let Some(data) = line.strip_prefix("data: ") {
                 if let Ok(event) = serde_json::from_str::<serde_json::Value>(data) {


### PR DESCRIPTION
## Summary

- **SSE stall detection**: replace the single 600s silent timeout with 30s stall-detection warnings visible in Datadog. Total budget enforced by reqwest `.timeout()`
- **Keepalive logging**: log SSE comment lines (`: keep-alive`) at INFO to fill the ~55s Datadog gap during backup/import
- **TEE node placement**: pass `node_policy: {version: 1, tee: "ANY_TEE"}` in the CrabShack import body so migrated instances land on TEE nodes
- **`backup_url` parameter**: optional field in request body — if provided, skip the entire backup SSE phase and use the URL directly. Sidesteps compose-api SSE stalls without needing `tokio::spawn` or `reuse_backup` complexity

## Context

During E2E migration testing (sessions 4-6), the backup SSE stream through chat-api stalls silently — likely because connection drops cancel the handler, which drops the reqwest stream to compose-api, leaving compose-api in a bad state. Direct compose-api `/backup` calls work fine.

The `backup_url` param lets the admin obtain the backup URL directly from compose-api, then pass it to `/migrate` to skip the problematic SSE relay entirely.

Companion PR: https://github.com/Near-One/ai-infra-agent-hosting/pull/327 (CrabShack side — accept `node_policy` in import, default to `ANY_TEE`)

## Test plan

- [x] `cargo check -p api` / `cargo fmt` / `cargo clippy` clean
- [x] 101 unit tests pass
- [ ] Deploy to staging, trigger migration with and without `backup_url`
- [ ] Verify stall-detect WARN and keepalive INFO lines in Datadog
- [ ] Verify migrated instance lands on TEE node (`staging-tdx-cvm-01`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)