### PR TITLE
feat: grant crabshack ownership for migrated instances

### DIFF
--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -102,6 +102,7 @@ use utoipa::OpenApi;
         crate::routes::admin::admin_start_instance,
         crate::routes::admin::admin_stop_instance,
         crate::routes::admin::admin_restart_instance,
+        crate::routes::admin::admin_grant_instance_owner,
         crate::routes::admin::admin_sync_agent_status,
         crate::routes::admin::bi_list_users,
         crate::routes::admin::bi_users_summary,
@@ -141,6 +142,7 @@ use utoipa::OpenApi;
         services::user::ports::AccountDeletion,
         services::user::ports::AccountDeletionStatus,
         crate::routes::admin::AdminRetryAccountDeletionResponse,
+        crate::routes::admin::GrantInstanceOwnerResponse,
         crate::models::AuthResponse,
         crate::error::ApiErrorResponse,
         // Auth request models

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -30,6 +30,7 @@ const ADMIN_CHANGE_REASON_MAX_LEN: usize = 255;
 use services::model::ports::{UpdateModelParams, UpsertModelParams};
 use services::user_usage::UsageRankBy;
 use services::UserId;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use urlencoding::encode;
 use uuid::Uuid;
@@ -4080,6 +4081,153 @@ pub async fn admin_migrate_instance(
     }))
 }
 
+/// Response for the grant-owner endpoint.
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct GrantInstanceOwnerResponse {
+    pub status: String,
+    pub instance_name: String,
+    /// The CrabShack user id (sha256 of the hex-decoded auth_secret) granted owner access.
+    pub owner_user_id: String,
+}
+
+/// Admin endpoint: Grant CrabShack owner access for an already-migrated instance.
+///
+/// Migration (`admin_migrate_instance`) imports the instance and seeds the CrabShack backup
+/// vault, but never establishes an owner access row — CrabShack imports run with the admin
+/// token, so the instance lands ownerless. Without an owner, CrabShack's scheduled backups skip
+/// the instance ("no owner") and the owning user can't see it in the portal.
+///
+/// This reconciles ownership: it derives the CrabShack user id the same way CrabShack does on
+/// login (`sha256(hex_decode(auth_secret))`, mirroring orchestrator-api's `userIdFromAuthSecret`)
+/// and calls CrabShack's admin access-grant endpoint. Idempotent — CrabShack's grant is
+/// last-write-wins, so re-running is safe.
+///
+/// Guarded on the instance already pointing at CrabShack (`agent_api_base_url == crabshack url`),
+/// which chat-api only sets after a fully successful migration. This prevents granting ownership
+/// to a half-migrated instance whose data restore may still be running (a backup of it would
+/// capture an incomplete volume).
+pub async fn admin_grant_instance_owner(
+    State(app_state): State<AppState>,
+    Extension(_user): Extension<AuthenticatedUser>,
+    Path(instance_id): Path<String>,
+) -> Result<Json<GrantInstanceOwnerResponse>, ApiError> {
+    let id = Uuid::parse_str(&instance_id)
+        .map_err(|_| ApiError::bad_request("Invalid instance ID format"))?;
+
+    let instance = app_state
+        .agent_repository
+        .get_instance(id)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "grant-owner: failed to get instance: instance_id={}, error={}",
+                id,
+                e
+            );
+            ApiError::internal_server_error("Failed to get instance")
+        })?
+        .ok_or_else(|| ApiError::not_found("Instance not found"))?;
+
+    let instance_name = instance.name.clone();
+
+    // Require the instance to already be on CrabShack. chat-api flips agent_api_base_url to the
+    // CrabShack url only after a fully successful migration, so this is the "migration complete"
+    // signal — granting before it would risk owning a still-restoring instance.
+    let crabshack_manager = app_state
+        .agent_service
+        .find_crabshack_manager()
+        .ok_or_else(|| ApiError::internal_server_error("No CrabShack manager configured"))?;
+    let agent_api_base_url = instance
+        .agent_api_base_url
+        .as_deref()
+        .ok_or_else(|| ApiError::bad_request("Instance has no agent_api_base_url"))?;
+    if agent_api_base_url.trim_end_matches('/') != crabshack_manager.url.trim_end_matches('/') {
+        return Err(ApiError::bad_request(
+            "Instance is not on CrabShack — migrate it first",
+        ));
+    }
+
+    // Look up the owning user's passkey credentials. The auth_secret is the root of the CrabShack
+    // user identity. Never mint new credentials here: fresh creds would derive a different identity
+    // and backup key than the migrated backup was encrypted with.
+    let auth_secret = match app_state
+        .agent_repository
+        .get_user_passkey_credentials(instance.user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "grant-owner: failed to get passkey credentials: user_id={}, error={}",
+                instance.user_id,
+                e
+            );
+            ApiError::internal_server_error("Failed to get user credentials")
+        })? {
+        Some((auth_secret, _backup_passphrase)) => auth_secret,
+        None => {
+            return Err(ApiError::bad_request(
+                "User has no passkey credentials — cannot derive CrabShack owner id",
+            ));
+        }
+    };
+
+    // CrabShack user id = hex(sha256(hex_decode(auth_secret))).
+    // Mirrors CrabShack's userIdFromAuthSecret (orchestrator-api/src/auth/user-queries.ts).
+    let auth_secret_bytes = hex::decode(auth_secret.trim()).map_err(|e| {
+        tracing::error!(
+            "grant-owner: stored auth_secret is not valid hex: instance_id={}, error={}",
+            id,
+            e
+        );
+        ApiError::internal_server_error("Stored auth_secret is not valid hex")
+    })?;
+    let owner_user_id = hex::encode(Sha256::digest(&auth_secret_bytes));
+
+    // Grant owner access on CrabShack (admin endpoint). Idempotent: last-write-wins.
+    let grant_url = format!(
+        "{}/instances/{}/access",
+        crabshack_manager.url.trim_end_matches('/'),
+        encode(&instance.name)
+    );
+    let resp = app_state
+        .http_client
+        .post(&grant_url)
+        .bearer_auth(&crabshack_manager.token)
+        .json(&serde_json::json!({ "user_id": owner_user_id, "role": "owner" }))
+        .timeout(std::time::Duration::from_secs(30))
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "grant-owner: CrabShack access call failed: instance_id={}, error={}",
+                id,
+                e
+            );
+            ApiError::internal_server_error("Failed to call CrabShack access endpoint")
+        })?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        tracing::error!(
+            "grant-owner: CrabShack access returned non-success: instance_id={}, status={}",
+            id,
+            status
+        );
+        return Err(ApiError::internal_server_error(
+            "CrabShack rejected the access grant",
+        ));
+    }
+
+    tracing::info!(
+        "grant-owner: granted CrabShack owner: instance_id={}, owner_user_id={}",
+        id,
+        owner_user_id
+    );
+    Ok(Json(GrantInstanceOwnerResponse {
+        status: "success".to_string(),
+        instance_name,
+        owner_user_id,
+    }))
+}
+
 /// Maximum buffer size for SSE parsing (1 MB).
 const SSE_BUFFER_LIMIT: usize = 1024 * 1024;
 /// Total time budget for an SSE migration stream (backup or import).
@@ -4405,6 +4553,10 @@ pub fn create_admin_router() -> Router<AppState> {
                 .route("/instances/{id}/stop", post(admin_stop_instance))
                 .route("/instances/{id}/restart", post(admin_restart_instance))
                 .route("/instances/{id}/migrate", post(admin_migrate_instance))
+                .route(
+                    "/instances/{id}/grant-owner",
+                    post(admin_grant_instance_owner),
+                )
                 .route("/instances/{id}/backup", post(admin_create_backup))
                 .route("/instances/{id}/backups", get(admin_list_backups))
                 .route("/instances/{id}/backups/{backup_id}", get(admin_get_backup))

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -4111,6 +4111,23 @@ pub struct GrantInstanceOwnerResponse {
 /// which chat-api only sets after a fully successful migration. This prevents granting ownership
 /// to a half-migrated instance whose data restore may still be running (a backup of it would
 /// capture an incomplete volume).
+#[utoipa::path(
+    post,
+    path = "/v1/admin/agents/instances/{id}/grant-owner",
+    tag = "Admin",
+    params(
+        ("id" = String, Path, description = "Instance ID")
+    ),
+    responses(
+        (status = 200, description = "Owner access granted", body = GrantInstanceOwnerResponse),
+        (status = 400, description = "Bad request", body = crate::error::ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = crate::error::ApiErrorResponse),
+        (status = 403, description = "Forbidden - admin only", body = crate::error::ApiErrorResponse),
+        (status = 404, description = "Instance not found", body = crate::error::ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = crate::error::ApiErrorResponse)
+    ),
+    security(("session_token" = []))
+)]
 pub async fn admin_grant_instance_owner(
     State(app_state): State<AppState>,
     Extension(_user): Extension<AuthenticatedUser>,

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -4226,16 +4226,22 @@ pub async fn admin_grant_instance_owner(
             );
             ApiError::internal_server_error("Failed to call CrabShack access endpoint")
         })?;
-    if !resp.status().is_success() {
-        let status = resp.status();
+    let status = resp.status();
+    if !status.is_success() {
+        // Read the body for diagnosis and surface CrabShack's status to the caller, so a
+        // misconfigured-admin-token 401 or a CrabShack 5xx is distinguishable from a generic
+        // failure. (CrabShack's grant is idempotent and does not check instance existence, so it
+        // never returns 404/409 here — only 4xx for a malformed request or auth/transport errors.)
+        let body = resp.text().await.unwrap_or_default();
         tracing::error!(
-            "grant-owner: CrabShack access returned non-success: instance_id={}, status={}",
+            "grant-owner: CrabShack access grant failed: instance_id={}, status={}, body={}",
             id,
-            status
+            status,
+            body.chars().take(300).collect::<String>()
         );
-        return Err(ApiError::internal_server_error(
-            "CrabShack rejected the access grant",
-        ));
+        return Err(ApiError::internal_server_error(format!(
+            "CrabShack rejected the access grant (status {status})"
+        )));
     }
 
     tracing::info!(

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -4082,12 +4082,17 @@ pub async fn admin_migrate_instance(
 }
 
 /// Response for the grant-owner endpoint.
+///
+/// Intentionally omits the derived owner user id. It is computed from the user's
+/// `auth_secret`, and chat-api does not surface credential-derived identity to API
+/// callers (even admins) — the caller can't obtain it any other way. When the granted
+/// owner needs verifying, read it from CrabShack's own access endpoint
+/// (`GET /instances/{name}/access`), which is the source of truth.
 #[derive(Serialize, utoipa::ToSchema)]
 pub struct GrantInstanceOwnerResponse {
     pub status: String,
     pub instance_name: String,
-    /// The CrabShack user id (sha256 of the hex-decoded auth_secret) granted owner access.
-    pub owner_user_id: String,
+    pub message: String,
 }
 
 /// Admin endpoint: Grant CrabShack owner access for an already-migrated instance.
@@ -4224,7 +4229,7 @@ pub async fn admin_grant_instance_owner(
     Ok(Json(GrantInstanceOwnerResponse {
         status: "success".to_string(),
         instance_name,
-        owner_user_id,
+        message: "Owner access granted on CrabShack".to_string(),
     }))
 }
 


### PR DESCRIPTION
## Problem

This adds **`POST /v1/admin/agents/instances/{id}/grant-owner`** (`admin_grant_instance_owner`).

After we migrate legacy instance, we should set owner on crabshack infra to enable scheduled backups.
I wouldn't do it in the process of migration, because backups can interfere with it, but instead create a separate endpoint to grant ownership, to be called once instance is fully migrated.

There is no change on user side, and the logic is straightforward, it just needs to derive user id correctly. CrabShack user id as `sha256(hex_decode(auth_secret))`, mirroring orchestrator-api's `userIdFromAuthSecret`.

## Verification

- `cargo fmt -p api` + `cargo check -p api` clean.
- `user_id` derivation cross-checked against CrabShack's `userIdFromAuthSecret` on a sample `auth_secret` — both produce the same hash, so granted owner ids match what CrabShack computes on login.
- No credentials logged (only instance id and the derived owner id, which is a hash).
- Validated live on CrabShack staging against a real owned instance: ran the endpoint's exact grant (derived owner `user_id`), after which the instance appeared as `role=owner` in the owner's own session and an owner-attributed backup completed (`ready`).

Not run: full integration suite (needs Postgres + `--features test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
