### PR TITLE
chore(soc2): add CODEOWNERS (R1)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Required reviewers. The @nearai/agent-hosting team must have WRITE access to this repo
+# for CODEOWNERS to take effect (GitHub requirement for code owners).
+*       @nearai/agent-hosting


### PR DESCRIPTION
SOC 2 CC8.1: codify required reviewers via CODEOWNERS (`* @nearai/agent-hosting`). Team needs WRITE access; advisory until require_code_owner_review is set in the ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)