### PR TITLE
chore(soc2): add Dependabot config (R2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,30 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    # Let releases bake ~1 week so a compromised release can be flagged before it reaches the
+    # lockfile. Security updates are exempt from cooldown and are never delayed.
+    cooldown:
+      default-days: 7
+    groups:
+      # Batch minor + patch bumps into one reviewable PR; majors stay individual for human review.
+      cargo-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    # Let releases bake ~1 week so a compromised release can be flagged before it reaches the
+    # lockfile. Security updates are exempt from cooldown and are never delayed.
+    cooldown:
+      default-days: 7
+    groups:
+      # Batch minor + patch bumps into one reviewable PR; majors stay individual for human review.
+      actions-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
SOC 2 CC7.1: proactive dependency version-update PRs. Alerts + security updates already enabled in settings; this adds the version-update config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)