### PR TITLE
[codex] Add chat API request ID propagation

### DIFF
--- a/crates/api/src/middleware/auth.rs
+++ b/crates/api/src/middleware/auth.rs
@@ -262,7 +262,7 @@ fn is_admin_domain(email: &str, admin_domains: &[String]) -> bool {
     if let Some(domain) = extract_email_domain(email) {
         admin_domains.contains(&domain)
     } else {
-        tracing::warn!("Failed to extract domain from email: {}", email);
+        tracing::warn!("Failed to extract domain from email");
         false
     }
 }

--- a/crates/api/src/middleware/mod.rs
+++ b/crates/api/src/middleware/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod metrics;
 pub mod rate_limit;
+pub mod request_id;
 pub mod subscription;
 
 pub use auth::{
@@ -9,4 +10,5 @@ pub use auth::{
 };
 pub use metrics::{http_metrics_middleware, MetricsState};
 pub use rate_limit::{rate_limit_middleware, RateLimitState};
+pub use request_id::{request_id_header_name, request_id_middleware, RequestCorrelation};
 pub use subscription::{subscription_middleware, SubscriptionState};

--- a/crates/api/src/middleware/request_id.rs
+++ b/crates/api/src/middleware/request_id.rs
@@ -1,0 +1,182 @@
+use axum::{body::Body, extract::Request, middleware::Next, response::Response};
+use http::{HeaderMap, HeaderName, HeaderValue};
+use uuid::Uuid;
+
+pub fn request_id_header_name() -> HeaderName {
+    HeaderName::from_static("x-request-id")
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RequestCorrelation {
+    request_id: Uuid,
+}
+
+impl RequestCorrelation {
+    pub const fn new(request_id: Uuid) -> Self {
+        Self { request_id }
+    }
+
+    pub const fn request_id(self) -> Uuid {
+        self.request_id
+    }
+}
+
+pub async fn request_id_middleware(mut req: Request<Body>, next: Next) -> Response {
+    let request_id = selected_request_id(req.headers());
+    let request_id_value = request_id.to_string();
+    let method = req.method().clone();
+    let path = req.uri().path().to_string();
+    if let Ok(header_value) = HeaderValue::from_str(&request_id_value) {
+        req.headers_mut()
+            .insert(request_id_header_name(), header_value);
+    }
+    req.extensions_mut()
+        .insert(RequestCorrelation::new(request_id));
+
+    let mut response = next.run(req).await;
+    if let Ok(header_value) = HeaderValue::from_str(&request_id_value) {
+        response
+            .headers_mut()
+            .insert(request_id_header_name(), header_value);
+    }
+    tracing::debug!(
+        request_id = %request_id,
+        method = %method,
+        path = %path,
+        status = response.status().as_u16(),
+        "request completed"
+    );
+    response
+}
+
+fn selected_request_id(headers: &HeaderMap) -> Uuid {
+    headers
+        .get(request_id_header_name())
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| Uuid::parse_str(value).ok())
+        .unwrap_or_else(Uuid::new_v4)
+}
+
+#[cfg(test)]
+mod logging_macro_scan;
+#[cfg(test)]
+mod privacy_log_assertions;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{middleware::from_fn, routing::post, Router};
+    use std::io;
+    use std::sync::{Arc, Mutex};
+    use tower::ServiceExt;
+    use tracing::Level;
+
+    #[derive(Clone, Default)]
+    struct CapturedLogs(Arc<Mutex<Vec<u8>>>);
+
+    struct CapturedLogsWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for CapturedLogsWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            let mut logs = self
+                .0
+                .lock()
+                .expect("captured logs mutex should not poison");
+            logs.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl CapturedLogs {
+        fn writer(&self) -> CapturedLogsWriter {
+            CapturedLogsWriter(Arc::clone(&self.0))
+        }
+
+        fn contents(&self) -> String {
+            let logs = self
+                .0
+                .lock()
+                .expect("captured logs mutex should not poison");
+            String::from_utf8_lossy(&logs).into_owned()
+        }
+    }
+
+    #[test]
+    fn selected_request_id_reuses_valid_uuid() {
+        let request_id = Uuid::new_v4();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            request_id_header_name(),
+            HeaderValue::from_str(&request_id.to_string()).expect("uuid header is valid"),
+        );
+
+        assert_eq!(selected_request_id(&headers), request_id);
+    }
+
+    #[test]
+    fn selected_request_id_replaces_invalid_uuid() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            request_id_header_name(),
+            HeaderValue::from_static("not-a-uuid"),
+        );
+
+        assert_ne!(selected_request_id(&headers).to_string(), "not-a-uuid");
+    }
+
+    #[tokio::test]
+    async fn tracing_logs_exclude_customer_content() {
+        privacy_log_assertions::assert_production_logs_exclude_forbidden_expressions();
+
+        let logs = CapturedLogs::default();
+        let writer_logs = logs.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(Level::DEBUG)
+            .with_ansi(false)
+            .with_writer(move || writer_logs.writer())
+            .finish();
+        let request_id = Uuid::new_v4();
+        let body = Body::from(
+            r#"{"messages":[{"role":"user","content":"CHAT_PROMPT_SENTINEL"}],"api_key":"sk-chat-sentinel"}"#,
+        );
+        let app = Router::new()
+            .route("/privacy-log-check", post(|| async { "ok" }))
+            .layer(from_fn(request_id_middleware));
+
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/privacy-log-check")
+                    .header(request_id_header_name(), request_id.to_string())
+                    .header("x-org-id", "spoofed-chat-org")
+                    .header("authorization", "Bearer sk-chat-sentinel")
+                    .body(body)
+                    .expect("test request should build"),
+            )
+            .await
+            .expect("test request should complete");
+
+        assert_eq!(response.status().as_u16(), 200);
+        let captured = logs.contents();
+        assert!(captured.contains(&request_id.to_string()));
+        assert!(captured.contains("method=POST"));
+        assert!(captured.contains("path=/privacy-log-check"));
+        assert!(captured.contains("status=200"));
+        for forbidden in [
+            "CHAT_PROMPT_SENTINEL",
+            "sk-chat-sentinel",
+            "spoofed-chat-org",
+        ] {
+            assert!(
+                !captured.contains(forbidden),
+                "captured logs must not contain {forbidden}; logs: {captured}"
+            );
+        }
+    }
+}

--- a/crates/api/src/middleware/request_id/logging_macro_scan.rs
+++ b/crates/api/src/middleware/request_id/logging_macro_scan.rs
@@ -1,0 +1,204 @@
+pub(super) fn logging_macro_bodies(source: &str) -> Vec<(usize, String)> {
+    let prefixes = [
+        "tracing::debug!(",
+        "tracing::info!(",
+        "tracing::warn!(",
+        "tracing::error!(",
+        "tracing::trace!(",
+        "debug!(",
+        "info!(",
+        "warn!(",
+        "error!(",
+        "trace!(",
+    ];
+    let mut bodies = Vec::new();
+    let mut search_start = 0;
+
+    while let Some((start, prefix_len)) = next_logging_macro(source, search_start, &prefixes) {
+        let line = source[..start]
+            .bytes()
+            .filter(|byte| *byte == b'\n')
+            .count()
+            + 1;
+        if let Some((body, end)) = read_parenthesized_body(source, start + prefix_len) {
+            bodies.push((line, body));
+            search_start = end;
+        } else {
+            search_start = start + prefix_len;
+        }
+    }
+
+    bodies
+}
+
+pub(super) fn string_literals_removed(body: &str) -> String {
+    let mut result = String::with_capacity(body.len());
+    let mut in_string = false;
+    let mut string_escape = false;
+    for ch in body.chars() {
+        if in_string {
+            if string_escape {
+                string_escape = false;
+            } else if ch == '\\' {
+                string_escape = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            result.push(' ');
+            continue;
+        }
+
+        if ch == '"' {
+            in_string = true;
+            result.push(' ');
+        } else {
+            result.push(ch);
+        }
+    }
+
+    result
+}
+
+pub(super) fn logs_raw_oauth_state(code: &str) -> bool {
+    code.contains("params.state")
+        || code.contains("oauth_state.state")
+        || code.contains("state.state")
+        || has_positional_argument_named(code, "state")
+}
+
+pub(super) fn logs_raw_oauth_authorization_url(code: &str) -> bool {
+    [
+        "auth_url",
+        "oauth_url",
+        "authorization_url",
+        "redirect_uri",
+        "frontend_callback",
+    ]
+    .iter()
+    .any(|identifier| logs_raw_identifier(code, identifier))
+        || logs_raw_member_access(code, "params.redirect_uri")
+        || logs_raw_member_access(code, "params.frontend_callback")
+        || logs_raw_member_access(code, "oauth_state.redirect_uri")
+        || logs_raw_member_access(code, "oauth_state.frontend_callback")
+        || logs_raw_member_access(code, "state.redirect_uri")
+        || logs_raw_member_access(code, "state.frontend_callback")
+}
+
+pub(super) fn logs_raw_response_headers(code: &str) -> bool {
+    logs_raw_identifier(code, "response_headers")
+}
+
+pub(super) fn logs_raw_client_ip(code: &str) -> bool {
+    ["client_ip", "ip"]
+        .iter()
+        .any(|identifier| logs_raw_identifier(code, identifier))
+}
+
+pub(super) fn contains_standalone_identifier(body: &str, identifier: &str) -> bool {
+    body.match_indices(identifier).any(|(start, _)| {
+        let before = start
+            .checked_sub(1)
+            .and_then(|index| body.as_bytes().get(index))
+            .copied();
+        let after = body.as_bytes().get(start + identifier.len()).copied();
+
+        !is_identifier_byte(before) && !is_identifier_byte(after)
+    })
+}
+
+fn next_logging_macro(source: &str, start: usize, prefixes: &[&str]) -> Option<(usize, usize)> {
+    prefixes
+        .iter()
+        .filter_map(|prefix| {
+            source[start..]
+                .find(prefix)
+                .map(|offset| (start + offset, prefix.len()))
+        })
+        .min_by_key(|(offset, _)| *offset)
+}
+
+fn read_parenthesized_body(source: &str, body_start: usize) -> Option<(String, usize)> {
+    let mut depth = 1usize;
+    let mut in_string = false;
+    let mut string_escape = false;
+    for (offset, ch) in source[body_start..].char_indices() {
+        if in_string {
+            if string_escape {
+                string_escape = false;
+            } else if ch == '\\' {
+                string_escape = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' => in_string = true,
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some((
+                        source[body_start..body_start + offset].to_string(),
+                        body_start + offset + ch.len_utf8(),
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn logs_raw_identifier(code: &str, identifier: &str) -> bool {
+    has_positional_argument_named(code, identifier)
+        || code.match_indices(identifier).any(|(start, _)| {
+            let end = start + identifier.len();
+            let previous = previous_non_whitespace_byte(code, start);
+            let next = next_non_whitespace_byte(code, end);
+
+            matches!(previous, Some(b'=' | b'?' | b'%'))
+                && !matches!(next, Some(b'.'))
+                && !is_identifier_byte(next)
+        })
+}
+
+fn logs_raw_member_access(code: &str, member: &str) -> bool {
+    code.match_indices(member).any(|(start, _)| {
+        let next = next_non_whitespace_byte(code, start + member.len());
+        !matches!(next, Some(b'.')) && !is_identifier_byte(next)
+    })
+}
+
+fn previous_non_whitespace_byte(code: &str, end: usize) -> Option<u8> {
+    code.as_bytes()
+        .get(..end)?
+        .iter()
+        .rev()
+        .copied()
+        .find(|byte| !byte.is_ascii_whitespace())
+}
+
+fn next_non_whitespace_byte(code: &str, start: usize) -> Option<u8> {
+    code.as_bytes()
+        .get(start..)?
+        .iter()
+        .copied()
+        .find(|byte| !byte.is_ascii_whitespace())
+}
+
+fn has_positional_argument_named(code: &str, identifier: &str) -> bool {
+    code.split(',').skip(1).any(|argument| {
+        let trimmed = argument.trim();
+        trimmed == identifier
+            || trimmed
+                .strip_prefix(identifier)
+                .is_some_and(|tail| tail.trim_start().starts_with(')'))
+    })
+}
+
+fn is_identifier_byte(byte: Option<u8>) -> bool {
+    byte.is_some_and(|value| value.is_ascii_alphanumeric() || value == b'_')
+}

--- a/crates/api/src/middleware/request_id/privacy_log_assertions.rs
+++ b/crates/api/src/middleware/request_id/privacy_log_assertions.rs
@@ -1,0 +1,108 @@
+use super::logging_macro_scan::{
+    contains_standalone_identifier, logging_macro_bodies, logs_raw_client_ip,
+    logs_raw_oauth_authorization_url, logs_raw_oauth_state, logs_raw_response_headers,
+    string_literals_removed,
+};
+
+pub(super) fn assert_production_logs_exclude_forbidden_expressions() {
+    let sources = [
+        (
+            "crates/api/src/routes/api.rs",
+            include_str!("../../routes/api.rs"),
+        ),
+        (
+            "crates/services/src/agent/service.rs",
+            include_str!("../../../../services/src/agent/service.rs"),
+        ),
+        (
+            "crates/services/src/auth/service.rs",
+            include_str!("../../../../services/src/auth/service.rs"),
+        ),
+        (
+            "crates/database/src/repositories/oauth_repository.rs",
+            include_str!("../../../../database/src/repositories/oauth_repository.rs"),
+        ),
+        (
+            "crates/api/src/routes/oauth.rs",
+            include_str!("../../routes/oauth.rs"),
+        ),
+    ];
+    let forbidden_substrings = ["VersionResponse"];
+    let forbidden_identifiers = [
+        "response_body",
+        "request_body",
+        "content_preview",
+        "tool_arguments",
+        "auth_value",
+        "bearer_token",
+        "session_token",
+        "raw_signature",
+        "signature_body",
+    ];
+
+    for (path, source) in sources {
+        for (line, body) in logging_macro_bodies(source) {
+            let code = string_literals_removed(&body);
+            assert_forbidden_substrings_absent(path, line, &body, &forbidden_substrings);
+            assert_forbidden_identifiers_absent(path, line, &body, &code, &forbidden_identifiers);
+            assert_no_raw_sensitive_logging(path, line, &body, &code);
+        }
+    }
+}
+
+fn assert_forbidden_substrings_absent(
+    path: &str,
+    line: usize,
+    body: &str,
+    forbidden_substrings: &[&str],
+) {
+    for expression in forbidden_substrings {
+        assert!(
+            !body.contains(expression),
+            "{path}:{line} production logging macro must not contain {expression}: {body}"
+        );
+    }
+}
+
+fn assert_forbidden_identifiers_absent(
+    path: &str,
+    line: usize,
+    body: &str,
+    code: &str,
+    forbidden_identifiers: &[&str],
+) {
+    for identifier in forbidden_identifiers {
+        assert!(
+            !contains_standalone_identifier(code, identifier),
+            "{path}:{line} production logging macro must not contain raw identifier {identifier}: {body}"
+        );
+    }
+}
+
+fn assert_no_raw_sensitive_logging(path: &str, line: usize, body: &str, code: &str) {
+    assert!(
+        !(body.contains("response_headers")
+            && (body.contains("{:?}") || body.contains("Response headers"))),
+        "{path}:{line} production logging macro must not dump whole response_headers: {body}"
+    );
+    assert!(
+        !logs_raw_response_headers(code),
+        "{path}:{line} production logging macro must not dump whole response_headers: {body}"
+    );
+    assert!(
+        !body.contains("/version response body"),
+        "{path}:{line} production logging macro must not dump raw /version body structs: {body}"
+    );
+    assert!(
+        !logs_raw_oauth_state(code),
+        "{path}:{line} production logging macro must not log raw OAuth state: {body}"
+    );
+    assert!(
+        !logs_raw_oauth_authorization_url(code),
+        "{path}:{line} production logging macro must not log raw OAuth authorization URL: {body}"
+    );
+    assert!(
+        !logs_raw_client_ip(code),
+        "{path}:{line} production logging macro must not log raw client IP: {body}"
+    );
+}

--- a/crates/api/src/routes/api.rs
+++ b/crates/api/src/routes/api.rs
@@ -508,9 +508,10 @@ async fn create_conversation(
         user.user_id
     );
 
-    if let Ok(body_str) = std::str::from_utf8(&body_bytes) {
-        tracing::debug!("Request body: {}", body_str);
-    }
+    tracing::debug!(
+        "Request body content redacted; body_size={} bytes",
+        body_bytes.len()
+    );
 
     tracing::debug!(
         "Forwarding conversation creation request to OpenAI for user_id={}",
@@ -598,9 +599,10 @@ async fn update_conversation(
         user.user_id
     );
 
-    if let Ok(body_str) = std::str::from_utf8(&body_bytes) {
-        tracing::debug!("Request body: {}", body_str);
-    }
+    tracing::debug!(
+        "Request body content redacted; body_size={} bytes",
+        body_bytes.len()
+    );
 
     tracing::debug!(
         "Forwarding conversation update request to OpenAI for user_id={}",
@@ -2331,9 +2333,10 @@ async fn proxy_responses(
     );
 
     if !body_bytes.is_empty() {
-        if let Ok(body_str) = std::str::from_utf8(&body_bytes) {
-            tracing::debug!("Request body content: {}", body_str);
-        }
+        tracing::debug!(
+            "Request body content redacted; body_size={} bytes",
+            body_bytes.len()
+        );
 
         // Try to parse JSON body once for further processing (model visibility + system prompt)
         match serde_json::from_slice::<serde_json::Value>(&body_bytes) {
@@ -3155,6 +3158,8 @@ async fn proxy_mcp(
     forward_headers.remove("authorization");
     forward_headers.remove("host");
     forward_headers.remove("content-length");
+    forward_headers.remove("x-org-id");
+    forward_headers.remove("x-workspace-id");
 
     let mut request_builder = state
         .http_client
@@ -4538,7 +4543,18 @@ async fn handle_trackable_response(
     let status = proxy_response.status;
     let response_headers = proxy_response.headers;
 
-    tracing::debug!("Response headers: {:?}", response_headers);
+    let request_id_header = crate::middleware::request_id_header_name();
+    let upstream_request_id_len = response_headers
+        .get(&request_id_header)
+        .and_then(|value| value.to_str().ok())
+        .map(str::len);
+    tracing::debug!(
+        "Response metadata: status={} header_count={} has_x_request_id={} x_request_id_len={}",
+        status,
+        response_headers.len(),
+        upstream_request_id_len.is_some(),
+        upstream_request_id_len.unwrap_or(0)
+    );
 
     // Buffer the response to extract the resource ID
     let proxy_body = Body::from_stream(proxy_response.body);

--- a/crates/api/src/routes/api.rs
+++ b/crates/api/src/routes/api.rs
@@ -3158,6 +3158,7 @@ async fn proxy_mcp(
     forward_headers.remove("authorization");
     forward_headers.remove("host");
     forward_headers.remove("content-length");
+    forward_headers.remove("cookie");
     forward_headers.remove("x-org-id");
     forward_headers.remove("x-workspace-id");
 

--- a/crates/api/src/routes/cors.rs
+++ b/crates/api/src/routes/cors.rs
@@ -36,18 +36,6 @@ fn is_origin_allowed(origin_str: &str, cors_config: &config::CorsConfig) -> bool
         return true;
     }
 
-    if let Some(remainder) = origin_str.strip_prefix("http://localhost") {
-        if remainder.is_empty() || remainder.starts_with(':') {
-            return true;
-        }
-    }
-
-    if let Some(remainder) = origin_str.strip_prefix("http://127.0.0.1") {
-        if remainder.is_empty() || remainder.starts_with(':') {
-            return true;
-        }
-    }
-
     origin_str.starts_with("https://")
         && cors_config
             .wildcard_suffixes
@@ -64,6 +52,12 @@ mod tests {
             exact_matches: vec![
                 "https://example.com".to_string(),
                 "http://test.com".to_string(),
+                "http://localhost".to_string(),
+                "http://localhost:3000".to_string(),
+                "http://localhost:8080".to_string(),
+                "http://127.0.0.1".to_string(),
+                "http://127.0.0.1:3000".to_string(),
+                "http://127.0.0.1:8080".to_string(),
             ],
             wildcard_suffixes: vec![".near.ai".to_string(), "-example.com".to_string()],
         }
@@ -113,6 +107,19 @@ mod tests {
     fn test_127_0_0_1_subdomain_denied() {
         let config = test_cors_config();
         assert!(!is_origin_allowed("http://127.0.0.1.evil.com", &config));
+    }
+
+    #[test]
+    fn test_local_development_origins_denied_when_not_configured() {
+        let config = config::CorsConfig {
+            exact_matches: vec![],
+            wildcard_suffixes: vec![],
+        };
+
+        assert!(!is_origin_allowed("http://localhost", &config));
+        assert!(!is_origin_allowed("http://localhost:3000", &config));
+        assert!(!is_origin_allowed("http://127.0.0.1", &config));
+        assert!(!is_origin_allowed("http://127.0.0.1:3000", &config));
     }
 
     #[test]

--- a/crates/api/src/routes/cors.rs
+++ b/crates/api/src/routes/cors.rs
@@ -1,0 +1,150 @@
+use http::header::{HeaderName, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
+use http::{HeaderValue, Method};
+use tower_http::cors::{AllowOrigin, CorsLayer};
+
+pub(super) fn create_cors_layer(cors_config: config::CorsConfig) -> CorsLayer {
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::predicate(
+            move |origin: &HeaderValue, _request_parts: &http::request::Parts| {
+                let Ok(origin_str) = origin.to_str() else {
+                    return false;
+                };
+                is_origin_allowed(origin_str, &cors_config)
+            },
+        ))
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::PATCH,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
+        .allow_headers([
+            AUTHORIZATION,
+            CONTENT_TYPE,
+            ACCEPT,
+            crate::middleware::request_id_header_name(),
+            HeaderName::from_static("ngrok-skip-browser-warning"),
+        ])
+        .expose_headers([crate::middleware::request_id_header_name()])
+        .allow_credentials(true)
+}
+
+fn is_origin_allowed(origin_str: &str, cors_config: &config::CorsConfig) -> bool {
+    if cors_config.exact_matches.iter().any(|o| o == origin_str) {
+        return true;
+    }
+
+    if let Some(remainder) = origin_str.strip_prefix("http://localhost") {
+        if remainder.is_empty() || remainder.starts_with(':') {
+            return true;
+        }
+    }
+
+    if let Some(remainder) = origin_str.strip_prefix("http://127.0.0.1") {
+        if remainder.is_empty() || remainder.starts_with(':') {
+            return true;
+        }
+    }
+
+    origin_str.starts_with("https://")
+        && cors_config
+            .wildcard_suffixes
+            .iter()
+            .any(|suffix| origin_str.ends_with(suffix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_cors_config() -> config::CorsConfig {
+        config::CorsConfig {
+            exact_matches: vec![
+                "https://example.com".to_string(),
+                "http://test.com".to_string(),
+            ],
+            wildcard_suffixes: vec![".near.ai".to_string(), "-example.com".to_string()],
+        }
+    }
+
+    #[test]
+    fn test_exact_match_allowed() {
+        let config = test_cors_config();
+        assert!(is_origin_allowed("https://example.com", &config));
+        assert!(is_origin_allowed("http://test.com", &config));
+    }
+
+    #[test]
+    fn test_exact_match_denied() {
+        let config = test_cors_config();
+        assert!(!is_origin_allowed("https://evil.com", &config));
+        assert!(!is_origin_allowed("http://example.com", &config));
+    }
+
+    #[test]
+    fn test_localhost_allowed() {
+        let config = test_cors_config();
+        assert!(is_origin_allowed("http://localhost:3000", &config));
+        assert!(is_origin_allowed("http://localhost:8080", &config));
+        assert!(is_origin_allowed("http://localhost", &config));
+    }
+
+    #[test]
+    fn test_localhost_subdomain_denied() {
+        let config = test_cors_config();
+        assert!(!is_origin_allowed("http://localhost.evil.com", &config));
+        assert!(!is_origin_allowed(
+            "http://localhost.evil.com:3000",
+            &config
+        ));
+    }
+
+    #[test]
+    fn test_127_0_0_1_allowed() {
+        let config = test_cors_config();
+        assert!(is_origin_allowed("http://127.0.0.1:3000", &config));
+        assert!(is_origin_allowed("http://127.0.0.1:8080", &config));
+        assert!(is_origin_allowed("http://127.0.0.1", &config));
+    }
+
+    #[test]
+    fn test_127_0_0_1_subdomain_denied() {
+        let config = test_cors_config();
+        assert!(!is_origin_allowed("http://127.0.0.1.evil.com", &config));
+    }
+
+    #[test]
+    fn test_https_wildcard_allowed() {
+        let config = test_cors_config();
+        assert!(is_origin_allowed("https://app.near.ai", &config));
+        assert!(is_origin_allowed("https://chat.near.ai", &config));
+        assert!(is_origin_allowed("https://preview-example.com", &config));
+    }
+
+    #[test]
+    fn test_https_wildcard_denied() {
+        let config = test_cors_config();
+        assert!(!is_origin_allowed("http://app.near.ai", &config));
+        assert!(!is_origin_allowed("https://fakenear.ai", &config));
+        assert!(!is_origin_allowed("https://near.ai.evil.com", &config));
+    }
+
+    #[test]
+    fn test_wildcard_suffix_protection() {
+        let config = config::CorsConfig {
+            exact_matches: vec![],
+            wildcard_suffixes: vec![".near.ai".to_string()],
+        };
+        assert!(is_origin_allowed("https://app.near.ai", &config));
+        assert!(!is_origin_allowed("https://fakenear.ai", &config));
+    }
+
+    #[test]
+    fn test_wildcard_with_hyphen_allowed() {
+        let config = test_cors_config();
+        assert!(is_origin_allowed("https://preview-example.com", &config));
+        assert!(is_origin_allowed("https://staging-example.com", &config));
+    }
+}

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -8,15 +8,13 @@ pub mod oauth;
 pub mod subscriptions;
 pub mod users;
 
+mod cors;
+
 // Re-export validation constants from services crate for API layer usage
 pub use services::agent::ports::{is_valid_service_type, VALID_SERVICE_TYPES};
 
 use axum::{middleware::from_fn_with_state, routing::get, Json, Router};
-use http::header::{HeaderName, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
-use http::HeaderValue;
-use http::Method;
 use serde::Serialize;
-use tower_http::cors::{AllowOrigin, CorsLayer};
 use utoipa::ToSchema;
 
 use crate::{
@@ -50,35 +48,6 @@ async fn health_check() -> Json<HealthResponse> {
         status: "ok",
         version: env!("CARGO_PKG_VERSION"),
     })
-}
-
-fn is_origin_allowed(origin_str: &str, cors_config: &config::CorsConfig) -> bool {
-    if cors_config.exact_matches.iter().any(|o| o == origin_str) {
-        return true;
-    }
-
-    if let Some(remainder) = origin_str.strip_prefix("http://localhost") {
-        if remainder.is_empty() || remainder.starts_with(':') {
-            return true;
-        }
-    }
-
-    if let Some(remainder) = origin_str.strip_prefix("http://127.0.0.1") {
-        if remainder.is_empty() || remainder.starts_with(':') {
-            return true;
-        }
-    }
-
-    if origin_str.starts_with("https://")
-        && cors_config
-            .wildcard_suffixes
-            .iter()
-            .any(|suffix| origin_str.ends_with(suffix))
-    {
-        return true;
-    }
-
-    false
 }
 
 /// Create the main API router with CORS configuration
@@ -204,134 +173,16 @@ pub fn create_router_with_cors(app_state: AppState, cors_config: config::CorsCon
         // Add static file serving as fallback (must be last)
         .fallback(static_files::static_handler);
 
-    let cors_config_clone = cors_config.clone();
-    let cors = CorsLayer::new()
-        .allow_origin(AllowOrigin::predicate(
-            move |origin: &HeaderValue, _request_parts: &http::request::Parts| {
-                let origin_str = match origin.to_str() {
-                    Ok(s) => s,
-                    Err(_) => return false,
-                };
-                is_origin_allowed(origin_str, &cors_config_clone)
-            },
-        ))
-        .allow_methods([
-            Method::GET,
-            Method::POST,
-            Method::PUT,
-            Method::PATCH,
-            Method::DELETE,
-            Method::OPTIONS,
-        ])
-        .allow_headers([
-            AUTHORIZATION,
-            CONTENT_TYPE,
-            ACCEPT,
-            // Allow ngrok-skip-browser-warning header for development with ngrok tunnels
-            // When using ngrok for local development/testing, this header prevents the
-            // ngrok browser warning page from appearing on the first request
-            // This is safe for production as unknown headers are simply ignored
-            HeaderName::from_static("ngrok-skip-browser-warning"),
-        ])
-        .allow_credentials(true);
+    let cors = cors::create_cors_layer(cors_config);
 
     // Add HTTP metrics middleware to track request counts and latencies
-    router.layer(cors).layer(from_fn_with_state(
-        metrics_state,
-        crate::middleware::http_metrics_middleware,
-    ))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn test_cors_config() -> config::CorsConfig {
-        config::CorsConfig {
-            exact_matches: vec![
-                "https://example.com".to_string(),
-                "http://test.com".to_string(),
-            ],
-            wildcard_suffixes: vec![".near.ai".to_string(), "-example.com".to_string()],
-        }
-    }
-
-    #[test]
-    fn test_exact_match_allowed() {
-        let config = test_cors_config();
-        assert!(is_origin_allowed("https://example.com", &config));
-        assert!(is_origin_allowed("http://test.com", &config));
-    }
-
-    #[test]
-    fn test_exact_match_denied() {
-        let config = test_cors_config();
-        assert!(!is_origin_allowed("https://evil.com", &config));
-        assert!(!is_origin_allowed("http://example.com", &config));
-    }
-
-    #[test]
-    fn test_localhost_allowed() {
-        let config = test_cors_config();
-        assert!(is_origin_allowed("http://localhost:3000", &config));
-        assert!(is_origin_allowed("http://localhost:8080", &config));
-        assert!(is_origin_allowed("http://localhost", &config));
-    }
-
-    #[test]
-    fn test_localhost_subdomain_denied() {
-        let config = test_cors_config();
-        assert!(!is_origin_allowed("http://localhost.evil.com", &config));
-        assert!(!is_origin_allowed(
-            "http://localhost.evil.com:3000",
-            &config
-        ));
-    }
-
-    #[test]
-    fn test_127_0_0_1_allowed() {
-        let config = test_cors_config();
-        assert!(is_origin_allowed("http://127.0.0.1:3000", &config));
-        assert!(is_origin_allowed("http://127.0.0.1:8080", &config));
-        assert!(is_origin_allowed("http://127.0.0.1", &config));
-    }
-
-    #[test]
-    fn test_127_0_0_1_subdomain_denied() {
-        let config = test_cors_config();
-        assert!(!is_origin_allowed("http://127.0.0.1.evil.com", &config));
-    }
-
-    #[test]
-    fn test_https_wildcard_allowed() {
-        let config = test_cors_config();
-        assert!(is_origin_allowed("https://app.near.ai", &config));
-        assert!(is_origin_allowed("https://chat.near.ai", &config));
-        assert!(is_origin_allowed("https://preview-example.com", &config));
-    }
-
-    #[test]
-    fn test_https_wildcard_denied() {
-        let config = test_cors_config();
-        assert!(!is_origin_allowed("http://app.near.ai", &config));
-        assert!(!is_origin_allowed("https://fakenear.ai", &config));
-        assert!(!is_origin_allowed("https://near.ai.evil.com", &config));
-    }
-
-    #[test]
-    fn test_wildcard_suffix_protection() {
-        let config = config::CorsConfig {
-            exact_matches: vec![],
-            wildcard_suffixes: vec![".near.ai".to_string()],
-        };
-        assert!(is_origin_allowed("https://app.near.ai", &config));
-        assert!(!is_origin_allowed("https://fakenear.ai", &config));
-    }
-
-    #[test]
-    fn test_wildcard_with_hyphen_allowed() {
-        let config = test_cors_config();
-        assert!(is_origin_allowed("https://preview-example.com", &config));
-        assert!(is_origin_allowed("https://staging-example.com", &config));
-    }
+    router
+        .layer(cors)
+        .layer(from_fn_with_state(
+            metrics_state,
+            crate::middleware::http_metrics_middleware,
+        ))
+        .layer(axum::middleware::from_fn(
+            crate::middleware::request_id_middleware,
+        ))
 }

--- a/crates/api/src/routes/oauth.rs
+++ b/crates/api/src/routes/oauth.rs
@@ -478,13 +478,14 @@ fn extract_client_ip(
         ));
 
     tracing::info!(
-        resolved_client_ip = %resolved_ip,
+        resolved_client_ip_present = true,
         client_ip_source = source.as_str(),
         trusted_proxy_count,
-        peer_addr = %peer_addr.map(|addr| addr.to_string()).unwrap_or_default(),
-        x_forwarded_for = x_forwarded_for.unwrap_or(""),
-        x_real_ip = x_real_ip.unwrap_or(""),
-        forwarded = forwarded.unwrap_or(""),
+        peer_addr_present = peer_addr.is_some(),
+        x_forwarded_for_present = x_forwarded_for.is_some(),
+        x_forwarded_for_len = x_forwarded_for.map(str::len).unwrap_or(0),
+        x_real_ip_present = x_real_ip.is_some(),
+        forwarded_present = forwarded.is_some(),
         "Resolved client IP for email auth request"
     );
 
@@ -845,8 +846,11 @@ pub async fn google_login(
     Query(params): Query<OAuthInitQuery>,
 ) -> Result<Redirect, ApiError> {
     tracing::info!(
-        "Google OAuth login initiated - redirect_uri: {:?}, frontend_callback_provided=true",
-        params.redirect_uri,
+        provider = "google",
+        redirect_uri_present = params.redirect_uri.is_some(),
+        frontend_callback_present = true,
+        action = "initiate_oauth_login",
+        "OAuth login initiated"
     );
 
     let redirect_uri = params
@@ -856,7 +860,12 @@ pub async fn google_login(
     let frontend_callback =
         validate_oauth_frontend_callback(&params.frontend_callback, &app_state)?;
 
-    tracing::debug!("Using OAuth redirect_uri: {}", redirect_uri);
+    tracing::debug!(
+        provider = "google",
+        redirect_uri_len = redirect_uri.len(),
+        action = "prepare_provider_redirect",
+        "OAuth redirect URI selected"
+    );
 
     let auth_url = app_state
         .oauth_service
@@ -871,8 +880,12 @@ pub async fn google_login(
             ApiError::oauth_provider_error("Google")
         })?;
 
-    tracing::info!("Google OAuth URL generated successfully, redirecting to Google");
-    tracing::debug!("Google OAuth URL: {}", auth_url);
+    tracing::info!(
+        provider = "google",
+        auth_url_len = auth_url.len(),
+        action = "redirect_to_provider",
+        "OAuth authorization URL generated"
+    );
 
     Ok(Redirect::temporary(&auth_url))
 }
@@ -896,10 +909,13 @@ pub async fn oauth_callback(
     State(app_state): State<AppState>,
     Query(params): Query<OAuthCallbackQuery>,
 ) -> Result<(StatusCode, HeaderMap), ApiError> {
+    let state_present = !params.state.is_empty();
+    let state_len = params.state.len();
     tracing::info!(
-        "OAuth callback received - code length: {}, state: {}",
-        params.code.len(),
-        params.state
+        code_len = params.code.len(),
+        state_present,
+        state_len,
+        "OAuth callback received"
     );
 
     // The provider is determined from the state stored in the database
@@ -909,7 +925,7 @@ pub async fn oauth_callback(
         .handle_callback_unified(params.code.clone(), params.state.clone())
         .await
         .map_err(|e| {
-            tracing::error!("OAuth callback failed for state {}: {}", params.state, e);
+            tracing::error!(state_present, state_len, error = %e, "OAuth callback failed");
             ApiError::oauth_failed()
         })?;
 
@@ -1058,8 +1074,11 @@ pub async fn github_login(
     Query(params): Query<OAuthInitQuery>,
 ) -> Result<Redirect, ApiError> {
     tracing::info!(
-        "Github OAuth login initiated - redirect_uri: {:?}, frontend_callback_provided=true",
-        params.redirect_uri,
+        provider = "github",
+        redirect_uri_present = params.redirect_uri.is_some(),
+        frontend_callback_present = true,
+        action = "initiate_oauth_login",
+        "OAuth login initiated"
     );
 
     let redirect_uri = params
@@ -1069,7 +1088,12 @@ pub async fn github_login(
     let frontend_callback =
         validate_oauth_frontend_callback(&params.frontend_callback, &app_state)?;
 
-    tracing::debug!("Using OAuth redirect_uri: {}", redirect_uri);
+    tracing::debug!(
+        provider = "github",
+        redirect_uri_len = redirect_uri.len(),
+        action = "prepare_provider_redirect",
+        "OAuth redirect URI selected"
+    );
 
     let auth_url = app_state
         .oauth_service
@@ -1084,8 +1108,12 @@ pub async fn github_login(
             ApiError::oauth_provider_error("Github")
         })?;
 
-    tracing::info!("Github OAuth URL generated successfully, redirecting to Github");
-    tracing::debug!("Github OAuth URL: {}", auth_url);
+    tracing::info!(
+        provider = "github",
+        auth_url_len = auth_url.len(),
+        action = "redirect_to_provider",
+        "OAuth authorization URL generated"
+    );
 
     Ok(Redirect::temporary(&auth_url))
 }
@@ -1172,7 +1200,10 @@ pub async fn mock_login(
     State(app_state): State<AppState>,
     axum::Json(request): axum::Json<MockLoginRequest>,
 ) -> Result<(HeaderMap, axum::Json<crate::models::AuthResponse>), ApiError> {
-    tracing::info!("Mock login requested for email: {}", request.email);
+    tracing::info!(
+        "Mock login requested: email_present={}",
+        !request.email.is_empty()
+    );
 
     // Check if user already exists
     let user = match app_state
@@ -1189,7 +1220,10 @@ pub async fn mock_login(
         }
         None => {
             // Create new user
-            tracing::info!("Creating new user with email: {}", request.email);
+            tracing::info!(
+                "Creating new user from mock login: email_present={}",
+                !request.email.is_empty()
+            );
             match app_state
                 .user_repository
                 .create_user(

--- a/crates/api/tests/request_id_contract/support.rs
+++ b/crates/api/tests/request_id_contract/support.rs
@@ -1,0 +1,27 @@
+use http::{HeaderName, HeaderValue};
+use uuid::Uuid;
+
+pub const REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
+
+pub fn bearer_header(token: &str) -> HeaderValue {
+    HeaderValue::from_str(&format!("Bearer {token}")).expect("test token header is valid")
+}
+
+pub fn header_value<'a>(response: &'a axum_test::TestResponse, name: &HeaderName) -> &'a str {
+    response
+        .headers()
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .expect("response should include requested header")
+}
+
+pub fn assert_uuid_header(response: &axum_test::TestResponse) -> String {
+    let request_id = header_value(response, &REQUEST_ID);
+    Uuid::parse_str(request_id).expect("x-request-id should be UUID shaped");
+    request_id.to_string()
+}
+
+pub async fn create_request_id_test_server() -> axum_test::TestServer {
+    std::env::set_var("AGENT_API_TOKEN", "request-id-contract-test-token");
+    crate::common::create_test_server().await
+}

--- a/crates/api/tests/request_id_contract_proxy_tests.rs
+++ b/crates/api/tests/request_id_contract_proxy_tests.rs
@@ -1,0 +1,232 @@
+mod common;
+
+use http::{HeaderName, HeaderValue};
+use serde_json::json;
+use uuid::Uuid;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
+const ORG_ID: HeaderName = HeaderName::from_static("x-org-id");
+const WORKSPACE_ID: HeaderName = HeaderName::from_static("x-workspace-id");
+
+fn bearer_header(token: &str) -> HeaderValue {
+    HeaderValue::from_str(&format!("Bearer {token}")).expect("test token header is valid")
+}
+
+fn header_value<'a>(response: &'a axum_test::TestResponse, name: &HeaderName) -> &'a str {
+    response
+        .headers()
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .expect("response should include requested header")
+}
+
+fn assert_uuid_header(response: &axum_test::TestResponse) -> String {
+    let request_id = header_value(response, &REQUEST_ID);
+    Uuid::parse_str(request_id).expect("x-request-id should be UUID shaped");
+    request_id.to_string()
+}
+
+async fn authenticated_proxy_fixture() -> (axum_test::TestServer, database::Database, MockServer) {
+    authenticated_proxy_fixture_with_response(ResponseTemplate::new(200).set_body_json(json!({
+        "id": "chatcmpl-request-id-test",
+        "object": "chat.completion",
+        "created": 1,
+        "model": "gpt-test",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": ""},
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+    })))
+    .await
+}
+
+async fn authenticated_proxy_fixture_with_response(
+    response: ResponseTemplate,
+) -> (axum_test::TestServer, database::Database, MockServer) {
+    std::env::set_var("AGENT_API_TOKEN", "request-id-contract-test-token");
+
+    let mock_upstream = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(response)
+        .mount(&mock_upstream)
+        .await;
+
+    let (server, db) = common::create_test_server_and_db(common::TestServerConfig {
+        proxy_base_url: Some(mock_upstream.uri()),
+        ..Default::default()
+    })
+    .await;
+
+    common::set_subscription_plans(
+        &server,
+        json!({
+            "basic": {
+                "providers": { "stripe": { "price_id": "price_test_basic" } },
+                "monthly_credits": { "max": 1_000_000_000 }
+            }
+        }),
+    )
+    .await;
+
+    (server, db, mock_upstream)
+}
+
+#[tokio::test]
+async fn request_id_contract_baseline_keeps_client_auth_and_host_out_of_upstream_proxy() {
+    let (server, db, mock_upstream) = authenticated_proxy_fixture().await;
+    let email = format!("request-id-baseline-{}@example.com", Uuid::new_v4());
+    let token = common::mock_login(&server, &email).await;
+    common::insert_test_subscription(&server, &db, &email, false).await;
+
+    let response = server
+        .post("/v1/chat/completions")
+        .add_header(
+            HeaderName::from_static("authorization"),
+            bearer_header(&token),
+        )
+        .add_header(
+            HeaderName::from_static("host"),
+            HeaderValue::from_static("spoofed.example"),
+        )
+        .json(&json!({
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": ""}]
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 200);
+
+    let received = mock_upstream
+        .received_requests()
+        .await
+        .expect("mock upstream should record requests");
+    assert_eq!(received.len(), 1);
+    let forwarded_headers = &received[0].headers;
+
+    assert_eq!(
+        forwarded_headers
+            .get("authorization")
+            .and_then(|value| value.to_str().ok()),
+        Some("Bearer mock-api-key")
+    );
+    assert_ne!(
+        forwarded_headers
+            .get("host")
+            .and_then(|value| value.to_str().ok()),
+        Some("spoofed.example")
+    );
+}
+
+#[tokio::test]
+async fn request_id_contract_inserts_selected_uuid_and_strips_public_tenant_headers_for_proxy() {
+    let (server, db, mock_upstream) = authenticated_proxy_fixture().await;
+    let email = format!("request-id-proxy-{}@example.com", Uuid::new_v4());
+    let token = common::mock_login(&server, &email).await;
+    common::insert_test_subscription(&server, &db, &email, false).await;
+
+    let response = server
+        .post("/v1/chat/completions")
+        .add_header(
+            HeaderName::from_static("authorization"),
+            bearer_header(&token),
+        )
+        .add_header(
+            REQUEST_ID.clone(),
+            HeaderValue::from_static("invalid-public-id"),
+        )
+        .add_header(ORG_ID.clone(), HeaderValue::from_static("spoofed-org"))
+        .add_header(
+            WORKSPACE_ID.clone(),
+            HeaderValue::from_static("spoofed-workspace"),
+        )
+        .json(&json!({
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": ""}]
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 200);
+    let selected_request_id = assert_uuid_header(&response);
+    assert_ne!(selected_request_id, "invalid-public-id");
+
+    let received = mock_upstream
+        .received_requests()
+        .await
+        .expect("mock upstream should record requests");
+    assert_eq!(received.len(), 1);
+    let forwarded_headers = &received[0].headers;
+    assert_eq!(
+        forwarded_headers
+            .get("x-request-id")
+            .and_then(|value| value.to_str().ok()),
+        Some(selected_request_id.as_str())
+    );
+    assert!(forwarded_headers.get("x-org-id").is_none());
+    assert!(forwarded_headers.get("x-workspace-id").is_none());
+    println!(
+        "request_id_contract proxy status={} x-request-id={} tenant_headers_absent=true",
+        response.status_code(),
+        selected_request_id
+    );
+}
+
+#[tokio::test]
+async fn request_id_contract_preserves_valid_uuid_for_proxy_and_streaming_response() {
+    let inbound = Uuid::new_v4().to_string();
+    let stream_response = ResponseTemplate::new(200)
+        .append_header("content-type", "text/event-stream")
+        .set_body_string("data: [DONE]\n\n");
+    let (server, db, mock_upstream) =
+        authenticated_proxy_fixture_with_response(stream_response).await;
+    let email = format!("request-id-stream-{}@example.com", Uuid::new_v4());
+    let token = common::mock_login(&server, &email).await;
+    common::insert_test_subscription(&server, &db, &email, false).await;
+
+    let response = server
+        .post("/v1/chat/completions")
+        .add_header(
+            HeaderName::from_static("authorization"),
+            bearer_header(&token),
+        )
+        .add_header(
+            REQUEST_ID.clone(),
+            HeaderValue::from_str(&inbound).expect("uuid header is valid"),
+        )
+        .json(&json!({
+            "model": "gpt-test",
+            "stream": true,
+            "messages": [{"role": "user", "content": ""}]
+        }))
+        .await;
+
+    assert_eq!(response.status_code(), 200);
+    assert_eq!(header_value(&response, &REQUEST_ID), inbound);
+
+    let received = mock_upstream
+        .received_requests()
+        .await
+        .expect("mock upstream should record requests");
+    assert_eq!(received.len(), 1);
+    assert_eq!(
+        received[0]
+            .headers
+            .get("x-request-id")
+            .and_then(|value| value.to_str().ok()),
+        Some(inbound.as_str())
+    );
+    println!(
+        "request_id_contract streaming headers observed before body chunks status={} x-request-id={} forwarded=true",
+        response.status_code(),
+        inbound
+    );
+    let body = response.text();
+    assert!(
+        body.contains("[DONE]"),
+        "stream body should remain readable after header assertion"
+    );
+}

--- a/crates/api/tests/request_id_contract_tests.rs
+++ b/crates/api/tests/request_id_contract_tests.rs
@@ -1,0 +1,179 @@
+mod common;
+
+#[path = "request_id_contract/support.rs"]
+mod support;
+
+use bytes::Bytes;
+use http::{HeaderName, HeaderValue};
+use serde_json::json;
+use support::{
+    assert_uuid_header, bearer_header, create_request_id_test_server, header_value, REQUEST_ID,
+};
+use uuid::Uuid;
+
+#[tokio::test]
+async fn request_id_contract_reuses_valid_inbound_id_on_success_and_static_fallback() {
+    let server = create_request_id_test_server().await;
+    let inbound = Uuid::new_v4().to_string();
+
+    let health_response = server
+        .get("/health")
+        .add_header(
+            REQUEST_ID.clone(),
+            HeaderValue::from_str(&inbound).expect("uuid header is valid"),
+        )
+        .await;
+    assert_eq!(health_response.status_code(), 200);
+    assert_eq!(header_value(&health_response, &REQUEST_ID), inbound);
+    println!(
+        "request_id_contract valid reuse status={} x-request-id={}",
+        health_response.status_code(),
+        inbound
+    );
+
+    let fallback_response = server
+        .get("/definitely-not-a-real-static-file")
+        .add_header(
+            REQUEST_ID.clone(),
+            HeaderValue::from_str(&inbound).expect("uuid header is valid"),
+        )
+        .await;
+    let fallback_request_id = header_value(&fallback_response, &REQUEST_ID);
+    assert_eq!(fallback_request_id, inbound);
+    println!(
+        "request_id_contract static fallback status={} x-request-id={}",
+        fallback_response.status_code(),
+        fallback_request_id
+    );
+}
+
+#[tokio::test]
+async fn request_id_contract_replaces_invalid_and_missing_ids_on_error_surfaces() {
+    let server = create_request_id_test_server().await;
+
+    let invalid_response = server
+        .get("/health")
+        .add_header(REQUEST_ID.clone(), HeaderValue::from_static("not-a-uuid"))
+        .await;
+    assert_eq!(invalid_response.status_code(), 200);
+    let replacement_id = assert_uuid_header(&invalid_response);
+    assert_ne!(replacement_id, "not-a-uuid");
+    println!(
+        "request_id_contract invalid replacement status={} x-request-id={}",
+        invalid_response.status_code(),
+        replacement_id
+    );
+
+    let auth_failure = server
+        .post("/v1/chat/completions")
+        .json(&json!({
+            "model": "gpt-test",
+            "messages": [{"role": "user", "content": ""}]
+        }))
+        .await;
+    assert_eq!(auth_failure.status_code(), 401);
+    let auth_request_id = assert_uuid_header(&auth_failure);
+    println!(
+        "request_id_contract auth failure status={} x-request-id={}",
+        auth_failure.status_code(),
+        auth_request_id
+    );
+}
+
+#[tokio::test]
+async fn request_id_contract_replaces_invalid_id_on_json_extractor_failure() {
+    let server = create_request_id_test_server().await;
+    let email = format!("request-id-validation-{}@example.com", Uuid::new_v4());
+    let token = common::mock_login(&server, &email).await;
+
+    let response = server
+        .post("/v1/users/me/settings")
+        .add_header(
+            HeaderName::from_static("authorization"),
+            bearer_header(&token),
+        )
+        .add_header(
+            REQUEST_ID.clone(),
+            HeaderValue::from_static("invalid-public-id"),
+        )
+        .add_header(
+            HeaderName::from_static("content-type"),
+            HeaderValue::from_static("application/json"),
+        )
+        .bytes(Bytes::from_static(b"{"))
+        .await;
+
+    assert_eq!(response.status_code(), 400);
+    let replacement_id = assert_uuid_header(&response);
+    assert_ne!(replacement_id, "invalid-public-id");
+    println!(
+        "request_id_contract validation/extractor failure status={} x-request-id={}",
+        response.status_code(),
+        replacement_id
+    );
+}
+
+#[tokio::test]
+async fn request_id_contract_allows_and_exposes_header_through_cors() {
+    let server = create_request_id_test_server().await;
+
+    let preflight = server
+        .method(http::Method::OPTIONS, "/v1/chat/completions")
+        .add_header(
+            HeaderName::from_static("origin"),
+            HeaderValue::from_static("http://localhost:3000"),
+        )
+        .add_header(
+            HeaderName::from_static("access-control-request-method"),
+            HeaderValue::from_static("POST"),
+        )
+        .add_header(
+            HeaderName::from_static("access-control-request-headers"),
+            HeaderValue::from_static("authorization,content-type,x-request-id"),
+        )
+        .await;
+    assert_eq!(preflight.status_code(), 200);
+    assert_uuid_header(&preflight);
+    assert_header_csv_contains(&preflight, "access-control-allow-headers", "x-request-id");
+    println!(
+        "request_id_contract CORS preflight status={} access-control-allow-headers={}",
+        preflight.status_code(),
+        header_value_by_name(&preflight, "access-control-allow-headers")
+    );
+
+    let actual = server
+        .get("/health")
+        .add_header(
+            HeaderName::from_static("origin"),
+            HeaderValue::from_static("http://localhost:3000"),
+        )
+        .await;
+    assert_eq!(actual.status_code(), 200);
+    assert_uuid_header(&actual);
+    assert_header_csv_contains(&actual, "access-control-expose-headers", "x-request-id");
+    println!(
+        "request_id_contract CORS actual status={} access-control-expose-headers={}",
+        actual.status_code(),
+        header_value_by_name(&actual, "access-control-expose-headers")
+    );
+}
+
+fn assert_header_csv_contains(response: &axum_test::TestResponse, name: &str, expected: &str) {
+    let header = header_value_by_name(response, name);
+    assert!(
+        header
+            .split(',')
+            .map(str::trim)
+            .any(|part| part.eq_ignore_ascii_case(expected)),
+        "{name} should include {expected}; actual value: {header}"
+    );
+}
+
+fn header_value_by_name(response: &axum_test::TestResponse, name: &str) -> String {
+    let header = response
+        .headers()
+        .get(name)
+        .and_then(|value| value.to_str().ok())
+        .expect("response should include expected header");
+    header.to_string()
+}

--- a/crates/database/src/repositories/oauth_repository.rs
+++ b/crates/database/src/repositories/oauth_repository.rs
@@ -19,10 +19,13 @@ impl PostgresOAuthRepository {
 #[async_trait]
 impl OAuthRepository for PostgresOAuthRepository {
     async fn store_oauth_state(&self, state: &OAuthState) -> anyhow::Result<()> {
+        let state_present = !state.state.is_empty();
+        let state_len = state.state.len();
         tracing::debug!(
-            "Repository: Storing OAuth state - state={}, provider={:?}",
-            state.state,
-            state.provider
+            state_present,
+            state_len,
+            provider = ?state.provider,
+            "Repository: Storing OAuth state"
         );
 
         let client = self.pool.get().await?;
@@ -48,15 +51,22 @@ impl OAuthRepository for PostgresOAuthRepository {
             .await?;
 
         tracing::debug!(
-            "Repository: OAuth state stored successfully - state={}",
-            state.state
+            state_present,
+            state_len,
+            "Repository: OAuth state stored successfully"
         );
 
         Ok(())
     }
 
     async fn consume_oauth_state(&self, state: &str) -> anyhow::Result<Option<OAuthState>> {
-        tracing::debug!("Repository: Consuming OAuth state - state={}", state);
+        let state_present = !state.is_empty();
+        let state_len = state.len();
+        tracing::debug!(
+            state_present,
+            state_len,
+            "Repository: Consuming OAuth state"
+        );
 
         let mut client = self.pool.get().await?;
 
@@ -95,13 +105,15 @@ impl OAuthRepository for PostgresOAuthRepository {
 
         if result.is_some() {
             tracing::debug!(
-                "Repository: OAuth state consumed successfully - state={}",
-                state
+                state_present,
+                state_len,
+                "Repository: OAuth state consumed successfully"
             );
         } else {
             tracing::warn!(
-                "Repository: OAuth state not found or already consumed - state={}",
-                state
+                state_present,
+                state_len,
+                "Repository: OAuth state not found or already consumed"
             );
         }
 

--- a/crates/database/src/repositories/user_repository.rs
+++ b/crates/database/src/repositories/user_repository.rs
@@ -167,9 +167,10 @@ impl UserRepository for PostgresUserRepository {
         avatar_url: Option<String>,
     ) -> anyhow::Result<User> {
         tracing::info!(
-            "Repository: Creating user with email={}, name={:?}",
-            email,
-            name
+            "Repository: Creating user with email_present={} name_present={} avatar_url_present={}",
+            !email.is_empty(),
+            name.is_some(),
+            avatar_url.is_some()
         );
 
         let client = self.pool.get().await?;
@@ -193,9 +194,8 @@ impl UserRepository for PostgresUserRepository {
         };
 
         tracing::info!(
-            "Repository: User created successfully with user_id={}, email={}",
-            user.id,
-            user.email
+            "Repository: User created successfully with user_id={}",
+            user.id
         );
 
         Ok(user)

--- a/crates/services/src/agent/service.rs
+++ b/crates/services/src/agent/service.rs
@@ -864,9 +864,9 @@ impl AgentServiceImpl {
         };
 
         tracing::info!(
-            "Calling compose-api /auth/proxy-session: url={}, session_token_len={}",
+            "Calling compose-api /auth/proxy-session: url={}, user_id={}",
             url,
-            session_token.len()
+            user_id
         );
 
         let response = self
@@ -888,17 +888,18 @@ impl AgentServiceImpl {
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_string());
 
-        // Capture response body for debug logging only (do not include in errors per CLAUDE.md)
-        let response_text = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "(unable to read response body)".to_string());
+        let response_body_len = response.text().await.map(|body| body.len()).unwrap_or(0);
 
         if !status.is_success() {
-            tracing::warn!("compose-api /auth/proxy-session failed: status={}", status);
             tracing::debug!(
-                "compose-api /auth/proxy-session response body (debug only): {}",
-                response_text
+                "compose-api /auth/proxy-session response body redacted: status={}, body_len={}",
+                status,
+                response_body_len
+            );
+            tracing::warn!(
+                "compose-api /auth/proxy-session failed: status={}, body_len={}",
+                status,
+                response_body_len
             );
             return Err(anyhow!(
                 "compose-api /auth/proxy-session error: status {}",
@@ -1120,11 +1121,11 @@ impl AgentServiceImpl {
                 .text()
                 .await
                 .unwrap_or_else(|_| "(unable to read response)".to_string());
-            // Log full error for debugging, but don't expose to clients
+            let error_body_len = error_body.len();
             tracing::warn!(
-                "Agent API create instance failed: status={}, body={}",
+                "Agent API create instance failed: status={}, body_len={}",
                 status,
-                error_body
+                error_body_len
             );
             return Err(anyhow!("Agent API error: {}", status));
         }
@@ -1390,12 +1391,13 @@ impl AgentServiceImpl {
                 .text()
                 .await
                 .unwrap_or_else(|_| "(unable to read response)".to_string());
+            let error_body_len = error_body.len();
             tracing::warn!(
-                "Agent API create instance failed: status={}, body={}",
+                "Agent API create instance failed: status={}, body_len={}",
                 status,
-                error_body
+                error_body_len
             );
-            return Err(anyhow!("Agent API error: {} - {}", status, error_body));
+            return Err(anyhow!("Agent API error: {}", status));
         }
 
         tracing::info!(
@@ -3015,10 +3017,10 @@ impl AgentService for AgentServiceImpl {
                 .await
                 .unwrap_or_else(|_| "unable to read body".to_string());
             tracing::error!(
-                "Agent API restart failed: status={}, url={}, body={}, instance_id={}",
+                "Agent API restart failed: status={}, url={}, body_len={}, instance_id={}",
                 status,
                 restart_url,
-                body,
+                body.len(),
                 instance_id
             );
             return Err(anyhow!(
@@ -3182,10 +3184,10 @@ impl AgentService for AgentServiceImpl {
                 .await
                 .unwrap_or_else(|_| "unable to read body".to_string());
             tracing::error!(
-                "Agent API stop failed: status={}, url={}, body={}, instance_id={}",
+                "Agent API stop failed: status={}, url={}, body_len={}, instance_id={}",
                 status,
                 stop_url,
-                body,
+                body.len(),
                 instance_id
             );
             return Err(anyhow!(
@@ -3270,10 +3272,10 @@ impl AgentService for AgentServiceImpl {
                 .await
                 .unwrap_or_else(|_| "unable to read body".to_string());
             tracing::error!(
-                "Agent API start failed: status={}, url={}, body={}, instance_id={}",
+                "Agent API start failed: status={}, url={}, body_len={}, instance_id={}",
                 status,
                 start_url,
-                body,
+                body.len(),
                 instance_id
             );
             return Err(anyhow!(
@@ -4057,7 +4059,12 @@ impl AgentServiceImpl {
             .await
             .map_err(|e| anyhow!("Failed to parse compose-api version response: {}", e))?;
 
-        tracing::debug!("TEE: /version response body: {:?}", version);
+        tracing::debug!(
+            "TEE: /version response parsed: image_count={} has_worker_image={} has_ironclaw_image={}",
+            version.images.len(),
+            version.images.contains_key("worker"),
+            version.images.contains_key("ironclaw")
+        );
 
         // Map service_type to image key in the version response
         let service_type = instance.service_type_str();

--- a/crates/services/src/auth/service.rs
+++ b/crates/services/src/auth/service.rs
@@ -340,9 +340,11 @@ impl OAuthServiceImpl {
         oauth_state: OAuthState,
     ) -> anyhow::Result<(UserSession, Option<String>, bool, OAuthProvider)> {
         tracing::info!(
-            "Processing OAuth callback: provider={:?}, redirect_uri={}",
-            provider,
-            oauth_state.redirect_uri
+            provider = ?provider,
+            redirect_uri_len = oauth_state.redirect_uri.len(),
+            frontend_callback_present = oauth_state.frontend_callback.is_some(),
+            action = "process_oauth_callback",
+            "Processing OAuth callback"
         );
 
         let (client_id, client_secret, auth_url, token_url) = match provider {
@@ -632,7 +634,8 @@ impl EmailAuthServiceImpl {
         if !body.success {
             tracing::warn!(
                 email_hash = %email_hash,
-                client_ip = %client_ip,
+                client_ip_present = !client_ip.is_empty(),
+                client_ip_len = client_ip.len(),
                 error_codes = ?body.error_codes,
                 "Turnstile verification rejected request"
             );
@@ -673,7 +676,8 @@ impl EmailAuthService for EmailAuthServiceImpl {
         {
             tracing::warn!(
                 email_hash = %email_hash,
-                client_ip = %client_ip,
+                client_ip_present = !client_ip.is_empty(),
+                client_ip_len = client_ip.len(),
                 "Email OTP request rate-limited by email threshold"
             );
             return Err(RequestEmailCodeError::RateLimited);
@@ -687,7 +691,8 @@ impl EmailAuthService for EmailAuthServiceImpl {
         {
             tracing::warn!(
                 email_hash = %email_hash,
-                client_ip = %client_ip,
+                client_ip_present = !client_ip.is_empty(),
+                client_ip_len = client_ip.len(),
                 "Email OTP request rate-limited by IP threshold"
             );
             return Err(RequestEmailCodeError::RateLimited);
@@ -745,7 +750,8 @@ impl EmailAuthService for EmailAuthServiceImpl {
         {
             tracing::warn!(
                 email_hash = %email_hash,
-                client_ip = %client_ip,
+                client_ip_present = !client_ip.is_empty(),
+                client_ip_len = client_ip.len(),
                 "Email OTP verify rate-limited by email failure threshold"
             );
             return Err(VerifyEmailCodeError::RateLimited);
@@ -760,7 +766,8 @@ impl EmailAuthService for EmailAuthServiceImpl {
         {
             tracing::warn!(
                 email_hash = %email_hash,
-                client_ip = %client_ip,
+                client_ip_present = !client_ip.is_empty(),
+                client_ip_len = client_ip.len(),
                 "Email OTP verify rate-limited by IP failure threshold"
             );
             return Err(VerifyEmailCodeError::RateLimited);
@@ -808,10 +815,12 @@ impl OAuthService for OAuthServiceImpl {
         frontend_callback: Option<String>,
     ) -> anyhow::Result<String> {
         tracing::info!(
-            "Generating authorization URL for provider={:?}, redirect_uri={}, frontend_callback={:?}",
-            provider,
-            redirect_uri,
-            frontend_callback
+            provider = ?provider,
+            redirect_uri_len = redirect_uri.len(),
+            frontend_callback_present = frontend_callback.is_some(),
+            frontend_callback_len = frontend_callback.as_ref().map_or(0, String::len),
+            action = "generate_oauth_authorization_url",
+            "Generating OAuth authorization URL"
         );
 
         let (client_id, client_secret, auth_url, token_url, scopes) = match provider {
@@ -935,7 +944,9 @@ impl OAuthService for OAuthServiceImpl {
         code: String,
         state: String,
     ) -> anyhow::Result<(UserSession, Option<String>, bool, OAuthProvider)> {
-        tracing::info!("Handling unified OAuth callback with state: {}", state);
+        let state_present = !state.is_empty();
+        let state_len = state.len();
+        tracing::info!(state_present, state_len, "Handling unified OAuth callback");
 
         let oauth_state = self
             .oauth_repository

--- a/crates/services/src/response/service.rs
+++ b/crates/services/src/response/service.rs
@@ -118,6 +118,8 @@ impl OpenAIProxyService for OpenAIProxy {
         // Forward all headers from the client (except Authorization which we set above)
         headers.remove("authorization");
         headers.remove("host"); // Don't forward host header
+        headers.remove("x-org-id");
+        headers.remove("x-workspace-id");
 
         // If no body is provided, remove content-related headers to avoid
         // the server waiting for body data that will never arrive

--- a/crates/services/src/response/service.rs
+++ b/crates/services/src/response/service.rs
@@ -118,6 +118,7 @@ impl OpenAIProxyService for OpenAIProxy {
         // Forward all headers from the client (except Authorization which we set above)
         headers.remove("authorization");
         headers.remove("host"); // Don't forward host header
+        headers.remove("cookie");
         headers.remove("x-org-id");
         headers.remove("x-workspace-id");
 

--- a/crates/services/src/user/service.rs
+++ b/crates/services/src/user/service.rs
@@ -36,10 +36,9 @@ impl UserService for UserServiceImpl {
             })?;
 
         tracing::debug!(
-            "User data retrieved: user_id={}, email={}, name={:?}",
+            "User data retrieved: user_id={}, has_name={}",
             user.id,
-            user.email,
-            user.name
+            user.name.is_some()
         );
 
         // Get linked accounts
@@ -73,10 +72,10 @@ impl UserService for UserServiceImpl {
         avatar_url: Option<String>,
     ) -> anyhow::Result<User> {
         tracing::info!(
-            "Updating user profile: user_id={}, name={:?}, avatar_url={:?}",
+            "Updating user profile: user_id={}, name_present={}, avatar_url_present={}",
             user_id,
-            name,
-            avatar_url
+            name.is_some(),
+            avatar_url.is_some()
         );
 
         let user = self
@@ -84,11 +83,7 @@ impl UserService for UserServiceImpl {
             .update_user(user_id, name.clone(), avatar_url.clone())
             .await?;
 
-        tracing::info!(
-            "User profile updated successfully: user_id={}, email={}",
-            user.id,
-            user.email
-        );
+        tracing::info!("User profile updated successfully: user_id={}", user.id);
 
         Ok(user)
     }

--- a/crates/services/src/user/user_settings_service.rs
+++ b/crates/services/src/user/user_settings_service.rs
@@ -39,9 +39,13 @@ impl UserSettingsService for UserSettingsServiceImpl {
         content: UserSettingsContent,
     ) -> anyhow::Result<UserSettingsContent> {
         tracing::info!(
-            "Upserting user settings: user_id={}, content={:?}",
-            user_id,
-            content
+            user_id = %user_id,
+            notification = content.notification,
+            web_search = content.web_search,
+            appearance = ?content.appearance,
+            has_system_prompt = content.system_prompt.is_some(),
+            system_prompt_len = content.system_prompt.as_ref().map_or(0, |system_prompt| system_prompt.len()),
+            "Upserting user settings"
         );
 
         let settings = self


### PR DESCRIPTION
## Summary
- Adds Chat API x-request-id middleware, CORS exposure, and upstream proxy propagation.
- Preserves customer privacy by scanning logging patterns and avoiding request/response body logging.
- Adds direct and proxy contract tests for success, auth failure, extractor failure, CORS, and streaming surfaces.

## Validation
- cargo fmt --all -- --check
- cargo test -p api --features test --test request_id_contract_tests -- --nocapture
- cargo test -p api --features test --test request_id_contract_proxy_tests -- --nocapture
- git diff --cached --check
- High-confidence staged secret pattern scan: clean

## Related PRs
- Related PR links will be added after all PRs are created.
