### PR TITLE
chore(soc2): add CodeQL code scanning (rust + actions) (R6)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,10 +10,16 @@ permissions:
   contents: read
   security-events: write   # CodeQL uploads results to GitHub code scanning
   actions: read
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   analyze:
     name: CodeQL (${{ matrix.language }})
     runs-on: ubuntu-latest
+    # Skip on fork PRs: their GITHUB_TOKEN is read-only, so the SARIF upload would fail and
+    # leave a noisy failing check. push + schedule (and same-repo PRs) still run.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       fail-fast: false
       matrix:
@@ -23,7 +29,9 @@ jobs:
       - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
         with:
           languages: ${{ matrix.language }}
+      # autobuild only applies to compiled languages; skip it for the `actions` analysis (no-op there).
       - uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        if: matrix.language == 'rust'
       - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,29 @@
+name: CodeQL
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 9 * * 2"   # weekly Tue 09:00 UTC
+permissions:
+  contents: read
+  security-events: write   # CodeQL uploads results to GitHub code scanning
+  actions: read
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [rust, actions]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        with:
+          languages: ${{ matrix.language }}
+      - uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
SOC 2 CC.3.1.5: static analysis (CodeQL) for the Rust app + GitHub Actions workflows. Free on this public repo (no GHAS). Report-only - alerts appear in the Security tab and do not gate merges unless wired as a required check later.

Note: GitHub's *default setup* (Settings -> Code security -> CodeQL) is a lower-maintenance alternative that auto-manages the Rust build; this explicit workflow was used because it is reviewable + SHA-pinned and could be pushed directly. The Rust analysis runs `autobuild` (cargo) on the GitHub-hosted runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)