### PR TITLE
chore(soc2): tune Dependabot - ignore major version-updates, lower PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
+    # Major version bumps are noisy and usually need manual review; ignore them for VERSION updates.
+    # Security updates are unaffected: the `version-update:` prefix scopes this to version updates only.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     # Let releases bake ~1 week so a compromised release can be flagged before it reaches the
     # lockfile. Security updates are exempt from cooldown and are never delayed.
     cooldown:
@@ -20,7 +25,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
+    # Major version bumps are noisy and usually need manual review; ignore them for VERSION updates.
+    # Security updates are unaffected: the `version-update:` prefix scopes this to version updates only.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     # Let releases bake ~1 week so a compromised release can be flagged before it reaches the
     # lockfile. Security updates are exempt from cooldown and are never delayed.
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,8 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      # Batch minor + patch bumps into one reviewable PR; majors stay individual for human review.
+      # Batch minor + patch version-updates into one reviewable PR. Major version-updates are ignored
+      # (see the `ignore` rule above), not opened individually; security updates are unaffected.
       cargo-minor-patch:
         applies-to: version-updates
         update-types:
@@ -36,7 +37,8 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      # Batch minor + patch bumps into one reviewable PR; majors stay individual for human review.
+      # Batch minor + patch version-updates into one reviewable PR. Major version-updates are ignored
+      # (see the `ignore` rule above), not opened individually; security updates are unaffected.
       actions-minor-patch:
         applies-to: version-updates
         update-types:


### PR DESCRIPTION
Reduce Dependabot version-update noise. Version-update PR creation is not a SOC 2 requirement (the relevant controls are Dependabot alerts + security-update PRs + remediation); this only trims the routine version-update PRs.

- `ignore` major (`version-update:semver-major`) version-updates - majors are the noisy ones (each opens its own PR since grouping only batches minor+patch) and usually need manual review.
- `open-pull-requests-limit` 10 -> 5.
- Unchanged: grouped minor+patch version-updates, the 7-day cooldown, Dependabot alerts, and **security-update PRs** (the `version-update:` prefix scopes the ignore to version updates; security fixes still open PRs).

After merge, Dependabot closes the now-ignored open major-bump PRs on its next run.