### PR TITLE
chore(soc2): bump aws-lc-rs/-sys to clear 5 RustSec advisories (vuln batch 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5ce75405893cd713f9ab8e297d8e438f624dde7d706108285f7e17a25a180f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -913,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.34.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "179c3777a8b5e70e90ea426114ffc565b2c1a9f82f6c4a0c5a34aa6ef5e781b6"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
## What
Lockfile-only, semver-compatible bump on the aws-lc crypto chain: aws-lc-rs 1.15.1->1.17.0, aws-lc-sys 0.34.0->0.41.0. No Cargo.toml change, no new crates.

## Why
Clears the aws-lc RustSec cluster from cargo-deny: RUSTSEC-2026-0044/0045/0046/0047/0048 (all on aws-lc-sys; patched >=0.38/0.39, satisfied by 0.41.0). Second RustSec remediation batch (the first, #332, cleared 6). Tracked under the Vulnerability Management procedure (SSDLC section 5.14).

## Verification
`cargo check --workspace` green locally; advisory ranges cross-checked vs the RustSec advisory DB; Test Suite + cargo deny run in CI.

## Remaining (separate, tracked)
postgres-protocol DoS-class (0178/0179/0180); hickory 0119 + legacy rustls 0049; and the no-fix/unmaintained accept-with-reason set (0118 + unmaintained crates) -> deny.toml ignores + exception register.