### PR TITLE
fix(chat-api): add HTTP client timeouts (#298) and 404 on missing instance usage (#255)

### DIFF
--- a/crates/api/src/routes/agents.rs
+++ b/crates/api/src/routes/agents.rs
@@ -852,12 +852,18 @@ pub async fn get_instance_usage(
         )
         .await
         .map_err(|e| {
-            tracing::error!(
-                "Failed to get usage: instance_id={}, error={}",
-                instance_uuid,
-                e
-            );
-            ApiError::internal_server_error("Failed to get usage")
+            // The service returns `anyhow!("Instance not found")` when the instance
+            // has been deleted; surface that as 404 rather than a generic 500.
+            if e.to_string().to_lowercase().contains("not found") {
+                ApiError::not_found("Instance not found")
+            } else {
+                tracing::error!(
+                    "Failed to get usage: instance_id={}, error={}",
+                    instance_uuid,
+                    e
+                );
+                ApiError::internal_server_error("Failed to get usage")
+            }
         })?;
 
     Ok(Json(PaginatedResponse {

--- a/crates/services/src/agent/proxy.rs
+++ b/crates/services/src/agent/proxy.rs
@@ -42,9 +42,13 @@ pub struct AgentProxy {
 
 impl AgentProxy {
     pub fn new() -> Self {
-        // Create HTTP client with timeout to prevent indefinite hanging on unresponsive instances
+        // Bound connection setup and stalled reads without a total request timeout.
+        // A total `.timeout()` truncates legitimate long-lived streamed responses at
+        // 30s; the read timeout resets after each successful read, so it only fires
+        // when an unresponsive instance actually stalls.
         let http_client = Client::builder()
-            .timeout(std::time::Duration::from_secs(30))
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .read_timeout(std::time::Duration::from_secs(60))
             .build()
             .unwrap_or_else(|_| Client::new());
 

--- a/crates/services/src/response/service.rs
+++ b/crates/services/src/response/service.rs
@@ -15,10 +15,19 @@ pub struct OpenAIProxy {
 
 impl OpenAIProxy {
     pub fn new(vpc_service: Arc<dyn VpcCredentialsService>) -> Self {
+        // Bound connection setup and stalled reads without a total request timeout.
+        // A total `.timeout()` would truncate legitimate long-lived SSE streams; the
+        // read timeout resets after each successful read, so it only fires on a hung
+        // upstream, not on a slow-but-progressing stream.
+        let http_client = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .read_timeout(std::time::Duration::from_secs(60))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
         Self {
             vpc_service,
             base_url: "https://api.openai.com/v1".to_string(),
-            http_client: reqwest::Client::new(),
+            http_client,
         }
     }
 


### PR DESCRIPTION
Fixes #298
Fixes #255

### #298 — proxy HTTP clients lack proper timeouts
Both proxy clients are corrected to use a `connect_timeout` (10s) plus a stream-safe `read_timeout` (60s) instead of a total request timeout:
- `OpenAIProxy` (`crates/services/src/response/service.rs`) previously used `reqwest::Client::new()` with **no** timeout, so a hung upstream could stall a request indefinitely.
- `AgentProxy` (`crates/services/src/agent/proxy.rs`) previously used a **30s total** `.timeout()`, which caps the entire response including streamed bodies and truncates legitimate long SSE streams.

A total `.timeout()` is intentionally avoided. `read_timeout` resets after each successful read, so it only fires on a genuinely stalled connection, not on a slow-but-progressing stream. reqwest is 0.12, so `.read_timeout()` is available.

### #255 — internal error from agent usage endpoint when instance is deleted
`get_instance_usage` mapped **all** service errors to HTTP 500, so calling `/agents/instances/<id>/usage` after the instance was deleted returned 500 instead of 404. The service returns `anyhow!("Instance not found")` for a missing instance; that case is now mapped to 404, while other failures remain 500.

### Validation
- `cargo check --workspace` passes clean.
- `cargo test -p services` passes (231 tests), including the `OpenAIProxy` construction tests.
- All `api` test targets compile with `--features test`. The DB-backed usage integration tests could not be executed in this environment (no PostgreSQL available).