### PR TITLE
fix: preserve canceled HoS subscriptions

### DIFF
--- a/crates/api/src/routes/subscriptions.rs
+++ b/crates/api/src/routes/subscriptions.rs
@@ -677,7 +677,7 @@ pub async fn create_portal_session(
     path = "/v1/subscriptions/near/sync",
     tag = "Subscriptions",
     responses(
-        (status = 200, description = "Reconcile finished; see `skipped`, `deleted_house_of_stake_rows`, `upserted_house_of_stake_row`, and optional `skipped_reason` in the body.", body = NearStakingSyncSummary),
+        (status = 200, description = "Reconcile finished; see `skipped`, `deleted_house_of_stake_rows`, `canceled_house_of_stake_rows`, `upserted_house_of_stake_row`, and optional `skipped_reason` in the body.", body = NearStakingSyncSummary),
         (status = 401, description = "Unauthorized", body = crate::error::ApiErrorResponse),
         (status = 500, description = "Internal server error", body = crate::error::ApiErrorResponse),
         (status = 503, description = "NEAR RPC unavailable", body = crate::error::ApiErrorResponse)

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -4224,6 +4224,8 @@ async fn test_near_staking_sync_skipped_reason_when_upsert_blocked_by_active_str
         .to_string();
 
     insert_test_subscription(&server, &db, near_email, false).await;
+    insert_house_of_stake_subscription_for_existing_user(&db, near_email, "price_hos_basic", false)
+        .await;
 
     let response = server
         .post("/v1/subscriptions/near/sync")
@@ -4242,6 +4244,11 @@ async fn test_near_staking_sync_skipped_reason_when_upsert_blocked_by_active_str
         Some(0)
     );
     assert_eq!(
+        body.get("canceled_house_of_stake_rows")
+            .and_then(|x| x.as_u64()),
+        Some(1)
+    );
+    assert_eq!(
         body.get("upserted_house_of_stake_row")
             .and_then(|x| x.as_bool()),
         Some(false)
@@ -4250,6 +4257,23 @@ async fn test_near_staking_sync_skipped_reason_when_upsert_blocked_by_active_str
         body.get("skipped_reason").and_then(|x| x.as_str()),
         Some(NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS)
     );
+
+    let user = db
+        .user_repository()
+        .get_user_by_email(near_email)
+        .await
+        .unwrap()
+        .unwrap();
+    let client = db.pool().get().await.unwrap();
+    let row = client
+        .query_one(
+            "SELECT status FROM subscriptions
+             WHERE user_id = $1 AND provider = 'house-of-stake'",
+            &[&user.id],
+        )
+        .await
+        .expect("HoS row should be preserved");
+    assert_eq!(row.get::<_, String>("status"), "canceled");
 }
 
 #[tokio::test]
@@ -4321,10 +4345,15 @@ async fn test_near_staking_sync_marks_local_hos_canceled_when_chain_returns_null
             .and_then(|x| x.as_u64()),
         Some(0)
     );
+    assert_eq!(
+        body.get("canceled_house_of_stake_rows")
+            .and_then(|x| x.as_u64()),
+        Some(1)
+    );
 
     let row = client
         .query_one(
-            "SELECT COUNT(*)::bigint, MAX(status)
+            "SELECT COUNT(*)::bigint, MAX(status), MAX(updated_at)
              FROM subscriptions
              WHERE user_id = $1 AND provider = 'house-of-stake'",
             &[&user.id],
@@ -4333,6 +4362,7 @@ async fn test_near_staking_sync_marks_local_hos_canceled_when_chain_returns_null
         .unwrap();
     let cnt: i64 = row.get(0);
     let status: Option<String> = row.get(1);
+    let canceled_updated_at: Option<chrono::DateTime<Utc>> = row.get(2);
     assert_eq!(cnt, 1, "HoS row should be preserved as history");
     assert_eq!(status.as_deref(), Some("canceled"));
 
@@ -4352,6 +4382,51 @@ async fn test_near_staking_sync_marks_local_hos_canceled_when_chain_returns_null
     assert_eq!(subscriptions.len(), 1);
     assert_eq!(subscriptions[0]["provider"], "house-of-stake");
     assert_eq!(subscriptions[0]["status"], "canceled");
+
+    let preserved_updated_at = Utc.with_ymd_and_hms(2026, 1, 3, 0, 0, 0).unwrap();
+    client
+        .execute(
+            "UPDATE subscriptions SET updated_at = $1
+             WHERE user_id = $2 AND provider = 'house-of-stake'",
+            &[&preserved_updated_at, &user.id],
+        )
+        .await
+        .expect("seed stable canceled updated_at");
+
+    let response = server
+        .post("/v1/subscriptions/near/sync")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body: serde_json::Value = response.json();
+    assert_eq!(
+        body.get("canceled_house_of_stake_rows")
+            .and_then(|x| x.as_u64()),
+        Some(0),
+        "already-canceled HoS history should not be re-upserted"
+    );
+
+    let updated_at: chrono::DateTime<Utc> = client
+        .query_one(
+            "SELECT updated_at FROM subscriptions
+             WHERE user_id = $1 AND provider = 'house-of-stake'",
+            &[&user.id],
+        )
+        .await
+        .unwrap()
+        .get("updated_at");
+    assert_eq!(
+        updated_at, preserved_updated_at,
+        "repeat sync must not bump updated_at for already-canceled HoS history"
+    );
+    assert!(
+        canceled_updated_at.is_some(),
+        "first sync should have written the canceled history row"
+    );
 }
 
 #[tokio::test]
@@ -4440,6 +4515,11 @@ async fn test_near_staking_sync_falls_back_to_configured_prices_before_canceling
         Some(0)
     );
     assert_eq!(
+        body.get("canceled_house_of_stake_rows")
+            .and_then(|x| x.as_u64()),
+        Some(0)
+    );
+    assert_eq!(
         body.get("upserted_house_of_stake_row")
             .and_then(|x| x.as_bool()),
         Some(true)
@@ -4457,6 +4537,153 @@ async fn test_near_staking_sync_falls_back_to_configured_prices_before_canceling
     let price_id: Option<String> = row.get(1);
     assert_eq!(cnt, 1, "sync should update the existing HoS row");
     assert_eq!(price_id.as_deref(), Some("price_hos_pro"));
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn test_near_staking_sync_cancels_active_stale_hos_and_preserves_canceled_history() {
+    clear_proxy_env_for_local_wiremock();
+    let chain_sub = json!({
+        "subscription_id": "sub_chain_hos_new_history",
+        "price_id": "price_hos_basic",
+        "end_ns": "2000000000000000000",
+        "status": "Active",
+        "cancel_at_period_end": false
+    });
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(near_rpc_wiremock_hos_subscription_probe_only(chain_sub))
+        .mount(&mock)
+        .await;
+
+    let (server, db) = create_test_server_and_db(TestServerConfig {
+        near_rpc_url: Some(mock.uri().to_string()),
+        near_staking_contract_id: Some("staking.testnet".to_string()),
+        ..Default::default()
+    })
+    .await;
+
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": { "providers": { "house-of-stake": { "price_id": "price_hos_basic" } }, "agent_instances": { "max": 1 }, "monthly_credits": { "max": 1000000 } }
+        }),
+    )
+    .await;
+
+    let near_email = "hos_sync_preserve_history.testnet@near";
+    let login = json!({
+        "email": near_email,
+        "name": "HoS Preserve History",
+        "oauth_provider": "near"
+    });
+    let response = server.post("/v1/auth/mock-login").json(&login).await;
+    let token = response.json::<serde_json::Value>()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    cleanup_user_subscriptions(&db, near_email).await;
+    insert_house_of_stake_subscription_for_existing_user(&db, near_email, "price_hos_basic", false)
+        .await;
+
+    let user = db
+        .user_repository()
+        .get_user_by_email(near_email)
+        .await
+        .unwrap()
+        .unwrap();
+    let client = db.pool().get().await.unwrap();
+    let preserved_updated_at = Utc.with_ymd_and_hms(2026, 1, 4, 0, 0, 0).unwrap();
+    let period_end = Utc::now() + Duration::days(1);
+    client
+        .execute(
+            "UPDATE subscriptions
+             SET subscription_id = 'sub_local_hos_stale_active'
+             WHERE user_id = $1 AND provider = 'house-of-stake'",
+            &[&user.id],
+        )
+        .await
+        .expect("seed stale active HoS row");
+    client
+        .execute(
+            "INSERT INTO subscriptions (
+                subscription_id, user_id, provider, customer_id, price_id, status,
+                current_period_end, cancel_at_period_end, created_at, updated_at
+            ) VALUES (
+                'sub_local_hos_preserved_canceled', $1, 'house-of-stake', 'cus_test',
+                'price_hos_basic', 'canceled', $2, false, $3, $3
+            )",
+            &[&user.id, &period_end, &preserved_updated_at],
+        )
+        .await
+        .expect("seed preserved canceled HoS history");
+
+    let response = server
+        .post("/v1/subscriptions/near/sync")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body: serde_json::Value = response.json();
+    assert_eq!(
+        body.get("deleted_house_of_stake_rows")
+            .and_then(|x| x.as_u64()),
+        Some(0)
+    );
+    assert_eq!(
+        body.get("canceled_house_of_stake_rows")
+            .and_then(|x| x.as_u64()),
+        Some(1)
+    );
+    assert_eq!(
+        body.get("upserted_house_of_stake_row")
+            .and_then(|x| x.as_bool()),
+        Some(true)
+    );
+
+    let rows = client
+        .query(
+            "SELECT subscription_id, status, updated_at
+             FROM subscriptions
+             WHERE user_id = $1 AND provider = 'house-of-stake'
+             ORDER BY subscription_id",
+            &[&user.id],
+        )
+        .await
+        .expect("load HoS rows after sync");
+    assert_eq!(rows.len(), 3, "sync should preserve HoS history rows");
+
+    let statuses: Vec<(String, String)> = rows
+        .iter()
+        .map(|row| (row.get("subscription_id"), row.get("status")))
+        .collect();
+    assert!(statuses.contains(&(
+        "sub_chain_hos_new_history".to_string(),
+        "active".to_string()
+    )));
+    assert!(statuses.contains(&(
+        "sub_local_hos_stale_active".to_string(),
+        "canceled".to_string()
+    )));
+    assert!(statuses.contains(&(
+        "sub_local_hos_preserved_canceled".to_string(),
+        "canceled".to_string()
+    )));
+
+    let preserved_row = rows
+        .iter()
+        .find(|row| row.get::<_, String>("subscription_id") == "sub_local_hos_preserved_canceled")
+        .expect("preserved canceled HoS row should remain");
+    assert_eq!(
+        preserved_row.get::<_, chrono::DateTime<Utc>>("updated_at"),
+        preserved_updated_at,
+        "sync must not re-touch already-canceled HoS history"
+    );
 }
 #[tokio::test]
 #[serial(subscription_tests)]

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -48,6 +48,39 @@ fn permissive_rate_limit_config() -> RateLimitConfig {
     }
 }
 
+async fn insert_house_of_stake_subscription_for_existing_user(
+    db: &database::Database,
+    user_email: &str,
+    price_id: &str,
+    cancel_at_period_end: bool,
+) {
+    let user = db
+        .user_repository()
+        .get_user_by_email(user_email)
+        .await
+        .unwrap()
+        .unwrap();
+    let client = db.pool().get().await.unwrap();
+    let period_end = Utc::now() + Duration::days(1);
+    let sub_id = format!("sub_test_{}", Uuid::new_v4());
+    client
+        .execute(
+            "INSERT INTO subscriptions (
+                subscription_id, user_id, provider, customer_id, price_id, status,
+                current_period_end, cancel_at_period_end
+            ) VALUES ($1, $2, 'house-of-stake', 'cus_test', $3, 'active', $4, $5)",
+            &[
+                &sub_id,
+                &user.id,
+                &price_id,
+                &period_end,
+                &cancel_at_period_end,
+            ],
+        )
+        .await
+        .unwrap();
+}
+
 #[tokio::test]
 #[serial(subscription_tests)]
 async fn test_list_subscriptions_requires_auth() {
@@ -3929,15 +3962,9 @@ async fn test_cancel_subscription_house_of_stake_returns_wallet_intent_message()
         .unwrap()
         .to_string();
 
-    insert_test_subscription_with_provider_and_price(
-        &server,
-        &db,
-        near_email,
-        "house-of-stake",
-        "price_hos_basic",
-        false,
-    )
-    .await;
+    cleanup_user_subscriptions(&db, near_email).await;
+    insert_house_of_stake_subscription_for_existing_user(&db, near_email, "price_hos_basic", false)
+        .await;
 
     let response = server
         .post("/v1/subscriptions/cancel")
@@ -4227,7 +4254,7 @@ async fn test_near_staking_sync_skipped_reason_when_upsert_blocked_by_active_str
 
 #[tokio::test]
 #[serial(subscription_tests)]
-async fn test_near_staking_sync_deletes_local_hos_when_chain_returns_null() {
+async fn test_near_staking_sync_marks_local_hos_canceled_when_chain_returns_null() {
     clear_proxy_env_for_local_wiremock();
     let mock = MockServer::start().await;
     Mock::given(method("POST"))
@@ -4254,10 +4281,10 @@ async fn test_near_staking_sync_deletes_local_hos_when_chain_returns_null() {
     )
     .await;
 
-    let near_email = "hos_sync_delete.testnet@near";
+    let near_email = "hos_sync_cancel.testnet@near";
     let login = json!({
         "email": near_email,
-        "name": "HoS Sync Delete",
+        "name": "HoS Sync Cancel",
         "oauth_provider": "near"
     });
     let response = server.post("/v1/auth/mock-login").json(&login).await;
@@ -4266,15 +4293,17 @@ async fn test_near_staking_sync_deletes_local_hos_when_chain_returns_null() {
         .unwrap()
         .to_string();
 
-    insert_test_subscription_with_provider_and_price(
-        &server,
-        &db,
-        near_email,
-        "house-of-stake",
-        "price_hos_basic",
-        false,
-    )
-    .await;
+    cleanup_user_subscriptions(&db, near_email).await;
+    insert_house_of_stake_subscription_for_existing_user(&db, near_email, "price_hos_basic", false)
+        .await;
+
+    let user = db
+        .user_repository()
+        .get_user_by_email(near_email)
+        .await
+        .unwrap()
+        .unwrap();
+    let client = db.pool().get().await.unwrap();
 
     let response = server
         .post("/v1/subscriptions/near/sync")
@@ -4290,33 +4319,44 @@ async fn test_near_staking_sync_deletes_local_hos_when_chain_returns_null() {
     assert_eq!(
         body.get("deleted_house_of_stake_rows")
             .and_then(|x| x.as_u64()),
-        Some(1)
+        Some(0)
     );
 
-    let user = db
-        .user_repository()
-        .get_user_by_email(near_email)
-        .await
-        .unwrap()
-        .unwrap();
-    let client = db.pool().get().await.unwrap();
-    let cnt: i64 = client
+    let row = client
         .query_one(
-            "SELECT COUNT(*)::bigint FROM subscriptions WHERE user_id = $1 AND provider = 'house-of-stake'",
+            "SELECT COUNT(*)::bigint, MAX(status)
+             FROM subscriptions
+             WHERE user_id = $1 AND provider = 'house-of-stake'",
             &[&user.id],
         )
         .await
-        .unwrap()
-        .get(0);
-    assert_eq!(
-        cnt, 0,
-        "HoS rows should be removed after chain reports null"
-    );
+        .unwrap();
+    let cnt: i64 = row.get(0);
+    let status: Option<String> = row.get(1);
+    assert_eq!(cnt, 1, "HoS row should be preserved as history");
+    assert_eq!(status.as_deref(), Some("canceled"));
+
+    let response = server
+        .get("/v1/subscriptions?include_inactive=true")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body: serde_json::Value = response.json();
+    let subscriptions = body["subscriptions"]
+        .as_array()
+        .expect("subscriptions should be an array");
+    assert_eq!(subscriptions.len(), 1);
+    assert_eq!(subscriptions[0]["provider"], "house-of-stake");
+    assert_eq!(subscriptions[0]["status"], "canceled");
 }
 
 #[tokio::test]
 #[serial(subscription_tests)]
-async fn test_near_staking_sync_falls_back_to_configured_prices_before_delete() {
+async fn test_near_staking_sync_falls_back_to_configured_prices_before_canceling_local_row() {
     clear_proxy_env_for_local_wiremock();
     let chain_sub = json!({
         "subscription_id": "sub_chain_hos_fallback",
@@ -4363,15 +4403,9 @@ async fn test_near_staking_sync_falls_back_to_configured_prices_before_delete() 
         .unwrap()
         .to_string();
 
-    insert_test_subscription_with_provider_and_price(
-        &server,
-        &db,
-        near_email,
-        "house-of-stake",
-        "price_hos_basic",
-        false,
-    )
-    .await;
+    cleanup_user_subscriptions(&db, near_email).await;
+    insert_house_of_stake_subscription_for_existing_user(&db, near_email, "price_hos_basic", false)
+        .await;
 
     let user = db
         .user_repository()

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -4392,6 +4392,15 @@ async fn test_near_staking_sync_marks_local_hos_canceled_when_chain_returns_null
         )
         .await
         .expect("seed stable canceled updated_at");
+    let updated_at_before_repeat_sync: chrono::DateTime<Utc> = client
+        .query_one(
+            "SELECT updated_at FROM subscriptions
+             WHERE user_id = $1 AND provider = 'house-of-stake'",
+            &[&user.id],
+        )
+        .await
+        .unwrap()
+        .get("updated_at");
 
     let response = server
         .post("/v1/subscriptions/near/sync")
@@ -4420,7 +4429,7 @@ async fn test_near_staking_sync_marks_local_hos_canceled_when_chain_returns_null
         .unwrap()
         .get("updated_at");
     assert_eq!(
-        updated_at, preserved_updated_at,
+        updated_at, updated_at_before_repeat_sync,
         "repeat sync must not bump updated_at for already-canceled HoS history"
     );
     assert!(

--- a/crates/services/src/subscription/ports.rs
+++ b/crates/services/src/subscription/ports.rs
@@ -308,8 +308,11 @@ pub const NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS: &str =
 pub struct NearStakingSyncSummary {
     /// True when reconcile exited early (no HoS contract configured, user has no linked NEAR account, or no HoS anchor price in catalog). No RPC or DB mutation was attempted.
     pub skipped: bool,
-    /// Local `house-of-stake` rows removed after chain reported no subscription for the probed price.
+    /// Local `house-of-stake` rows removed during reconcile. Preserved history rows are not counted here.
     pub deleted_house_of_stake_rows: u32,
+    /// Local active/trialing `house-of-stake` rows transitioned to `canceled` during reconcile.
+    #[serde(default)]
+    pub canceled_house_of_stake_rows: u32,
     /// True when a local row was upserted from chain JSON.
     pub upserted_house_of_stake_row: bool,
     /// When reconcile ran but did not upsert or delete, optionally explains a no-op (e.g. blocked

--- a/crates/services/src/subscription/ports.rs
+++ b/crates/services/src/subscription/ports.rs
@@ -1118,7 +1118,7 @@ pub trait SubscriptionService: Send + Sync {
         user_id: UserId,
     ) -> Result<ResumeSubscriptionOutcome, SubscriptionError>;
 
-    /// Re-fetch staking subscription from RPC and upsert/delete the local `house-of-stake` row.
+    /// Re-fetch staking subscription from RPC and upsert or cancel the local `house-of-stake` row.
     async fn sync_near_staking_subscription(
         &self,
         user_id: UserId,

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -610,13 +610,13 @@ impl SubscriptionServiceImpl {
         }
 
         let now = Utc::now();
-        let expired_hos_ids: Vec<String> = active_subscriptions
+        let mut expired_hos_subscriptions: Vec<Subscription> = active_subscriptions
             .iter()
             .filter(|s| s.provider == "house-of-stake" && s.current_period_end <= now)
-            .map(|s| s.subscription_id.clone())
+            .cloned()
             .collect();
 
-        if !expired_hos_ids.is_empty() {
+        if !expired_hos_subscriptions.is_empty() {
             let mut db_client = self
                 .db_pool
                 .get()
@@ -626,9 +626,18 @@ impl SubscriptionServiceImpl {
                 .transaction()
                 .await
                 .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
-            for subscription_id in &expired_hos_ids {
+
+            for sub in &mut expired_hos_subscriptions {
+                sub.status = "canceled".to_string();
+                sub.cancel_at_period_end = false;
+                sub.pending_downgrade_target_price_id = None;
+                sub.pending_downgrade_from_price_id = None;
+                sub.pending_downgrade_expected_period_end = None;
+                sub.pending_downgrade_status = None;
+                sub.pending_downgrade_updated_at = None;
+
                 self.subscription_repo
-                    .delete_subscription_txn(&txn, subscription_id)
+                    .upsert_subscription_authoritative(&txn, sub.clone())
                     .await
                     .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
             }
@@ -638,8 +647,8 @@ impl SubscriptionServiceImpl {
             self.invalidate_credit_limit_cache(user_id).await;
             tracing::warn!(
                 user_id = %user_id.0,
-                deleted_house_of_stake_rows = expired_hos_ids.len(),
-                "expired stale local HoS subscriptions before entitlement check"
+                canceled_house_of_stake_rows = expired_hos_subscriptions.len(),
+                "marked expired local HoS subscriptions canceled before entitlement check"
             );
         }
 
@@ -1424,10 +1433,15 @@ impl SubscriptionServiceImpl {
         }
 
         if raw.is_none() {
-            if hos_subscription_ids.is_empty() {
+            let mut local_hos_subscriptions: Vec<Subscription> = subs
+                .iter()
+                .filter(|s| s.provider == "house-of-stake")
+                .cloned()
+                .collect();
+            if local_hos_subscriptions.is_empty() {
                 return Ok(Self::hos_reconcile_summary(false, 0, false, None));
             }
-            let deleted = hos_subscription_ids.len() as u32;
+            let now = Utc::now();
             let mut db_client = self
                 .db_pool
                 .get()
@@ -1437,9 +1451,21 @@ impl SubscriptionServiceImpl {
                 .transaction()
                 .await
                 .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
-            for sid in &hos_subscription_ids {
+
+            for sub in &mut local_hos_subscriptions {
+                sub.status = "canceled".to_string();
+                if sub.current_period_end > now {
+                    sub.current_period_end = now;
+                }
+                sub.cancel_at_period_end = false;
+                sub.pending_downgrade_target_price_id = None;
+                sub.pending_downgrade_from_price_id = None;
+                sub.pending_downgrade_expected_period_end = None;
+                sub.pending_downgrade_status = None;
+                sub.pending_downgrade_updated_at = None;
+
                 self.subscription_repo
-                    .delete_subscription_txn(&txn, sid)
+                    .upsert_subscription_authoritative(&txn, sub.clone())
                     .await
                     .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
             }
@@ -1447,7 +1473,7 @@ impl SubscriptionServiceImpl {
                 .await
                 .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
             self.invalidate_credit_limit_cache(user_id).await;
-            return Ok(Self::hos_reconcile_summary(false, deleted, false, None));
+            return Ok(Self::hos_reconcile_summary(false, 0, false, None));
         }
 
         let chain_subscription = raw.as_ref().expect("checked is_some");

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -88,6 +88,9 @@ const TOKENS_TO_CREDITS_PER_M: u64 = 1_000_000;
 const NANO_USD_PER_1_5_USD: u64 = 1_500_000_000;
 const DOWNGRADE_CHECK_WINDOW_HOURS: i64 = 24;
 const TX_LOCK_TIMEOUT_MS: i64 = 1500;
+const SUBSCRIPTION_STATUS_ACTIVE: &str = "active";
+const SUBSCRIPTION_STATUS_TRIALING: &str = "trialing";
+const SUBSCRIPTION_STATUS_CANCELED: &str = "canceled";
 
 pub struct SubscriptionServiceImpl {
     db_pool: deadpool_postgres::Pool,
@@ -136,14 +139,14 @@ impl SubscriptionServiceImpl {
     }
 
     fn is_active_or_trialing(status: &str) -> bool {
-        status == "active" || status == "trialing"
+        status == SUBSCRIPTION_STATUS_ACTIVE || status == SUBSCRIPTION_STATUS_TRIALING
     }
 
     fn canceled_house_of_stake_history_row(
         mut sub: Subscription,
         now: DateTime<Utc>,
     ) -> Subscription {
-        sub.status = "canceled".to_string();
+        sub.status = SUBSCRIPTION_STATUS_CANCELED.to_string();
         if sub.current_period_end > now {
             sub.current_period_end = now;
         }
@@ -633,7 +636,7 @@ impl SubscriptionServiceImpl {
         }
 
         let now = Utc::now();
-        let mut expired_hos_subscriptions: Vec<Subscription> = active_subscriptions
+        let expired_hos_subscriptions: Vec<Subscription> = active_subscriptions
             .iter()
             .filter(|s| s.provider == "house-of-stake" && s.current_period_end <= now)
             .cloned()
@@ -650,17 +653,12 @@ impl SubscriptionServiceImpl {
                 .await
                 .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
 
-            for sub in &mut expired_hos_subscriptions {
-                sub.status = "canceled".to_string();
-                sub.cancel_at_period_end = false;
-                sub.pending_downgrade_target_price_id = None;
-                sub.pending_downgrade_from_price_id = None;
-                sub.pending_downgrade_expected_period_end = None;
-                sub.pending_downgrade_status = None;
-                sub.pending_downgrade_updated_at = None;
-
+            for sub in &expired_hos_subscriptions {
                 self.subscription_repo
-                    .upsert_subscription_authoritative(&txn, sub.clone())
+                    .upsert_subscription_authoritative(
+                        &txn,
+                        Self::canceled_house_of_stake_history_row(sub.clone(), now),
+                    )
                     .await
                     .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
             }
@@ -1291,9 +1289,9 @@ impl SubscriptionServiceImpl {
                 return;
             }
         };
-        let has_hos = subs.iter().any(|s| {
-            s.provider == "house-of-stake" && (s.status == "active" || s.status == "trialing")
-        });
+        let has_hos = subs
+            .iter()
+            .any(|s| s.provider == "house-of-stake" && Self::is_active_or_trialing(&s.status));
         if !has_hos {
             return;
         }
@@ -1364,9 +1362,9 @@ impl SubscriptionServiceImpl {
             }
         };
 
-        let has_active_non_hos = subs.iter().any(|s| {
-            (s.status == "active" || s.status == "trialing") && s.provider != "house-of-stake"
-        });
+        let has_active_non_hos = subs
+            .iter()
+            .any(|s| Self::is_active_or_trialing(&s.status) && s.provider != "house-of-stake");
         let hos_subscription_ids: Vec<String> = subs
             .iter()
             .filter(|s| s.provider == "house-of-stake")
@@ -1402,7 +1400,7 @@ impl SubscriptionServiceImpl {
         let local_probe_price_id = subs
             .iter()
             .filter(|s| s.provider == "house-of-stake")
-            .find(|s| s.status == "active" || s.status == "trialing")
+            .find(|s| Self::is_active_or_trialing(&s.status))
             .or_else(|| subs.iter().find(|s| s.provider == "house-of-stake"))
             .map(|s| s.price_id.as_str())
             .filter(|p| !p.is_empty());
@@ -2952,7 +2950,9 @@ impl SubscriptionService for SubscriptionServiceImpl {
                 .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
 
             // Detect first transition to canceled: trigger async instance kill
-            if old_status.as_deref() != Some("canceled") && new_sub.status == "canceled" {
+            if old_status.as_deref() != Some(SUBSCRIPTION_STATUS_CANCELED)
+                && new_sub.status == SUBSCRIPTION_STATUS_CANCELED
+            {
                 user_id_to_kill_instances = Some(user_id);
                 // Subscription is canceled — clear any stale pending downgrade intent
                 self.subscription_repo

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -24,7 +24,7 @@ use crate::user::ports::UserRepository;
 use crate::user_usage::ports::UserUsageRepository;
 use crate::UserId;
 use async_trait::async_trait;
-use chrono::{Datelike, Duration, NaiveTime, Utc};
+use chrono::{DateTime, Datelike, Duration, NaiveTime, Utc};
 use futures::future::join_all;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -122,15 +122,38 @@ impl SubscriptionServiceImpl {
     fn hos_reconcile_summary(
         skipped: bool,
         deleted: u32,
+        canceled: u32,
         upserted: bool,
         skipped_reason: Option<&'static str>,
     ) -> NearStakingSyncSummary {
         NearStakingSyncSummary {
             skipped,
             deleted_house_of_stake_rows: deleted,
+            canceled_house_of_stake_rows: canceled,
             upserted_house_of_stake_row: upserted,
             skipped_reason: skipped_reason.map(String::from),
         }
+    }
+
+    fn is_active_or_trialing(status: &str) -> bool {
+        status == "active" || status == "trialing"
+    }
+
+    fn canceled_house_of_stake_history_row(
+        mut sub: Subscription,
+        now: DateTime<Utc>,
+    ) -> Subscription {
+        sub.status = "canceled".to_string();
+        if sub.current_period_end > now {
+            sub.current_period_end = now;
+        }
+        sub.cancel_at_period_end = false;
+        sub.pending_downgrade_target_price_id = None;
+        sub.pending_downgrade_from_price_id = None;
+        sub.pending_downgrade_expected_period_end = None;
+        sub.pending_downgrade_status = None;
+        sub.pending_downgrade_updated_at = None;
+        sub
     }
 
     pub fn new(config: SubscriptionServiceConfig) -> Self {
@@ -1331,13 +1354,13 @@ impl SubscriptionServiceImpl {
             .map(str::trim)
             .filter(|s| !s.is_empty())
         else {
-            return Ok(Self::hos_reconcile_summary(true, 0, false, None));
+            return Ok(Self::hos_reconcile_summary(true, 0, 0, false, None));
         };
 
         let near_account = match self.get_near_account_id(user_id).await {
             Ok(a) => a,
             Err(_) => {
-                return Ok(Self::hos_reconcile_summary(true, 0, false, None));
+                return Ok(Self::hos_reconcile_summary(true, 0, 0, false, None));
             }
         };
 
@@ -1354,6 +1377,7 @@ impl SubscriptionServiceImpl {
             return Ok(Self::hos_reconcile_summary(
                 false,
                 0,
+                0,
                 false,
                 Some(NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS),
             ));
@@ -1369,7 +1393,7 @@ impl SubscriptionServiceImpl {
             .unwrap_or_default();
         let configured_hos_price_ids = Self::hos_price_ids(&subscription_plans);
         if configured_hos_price_ids.is_empty() {
-            return Ok(Self::hos_reconcile_summary(true, 0, false, None));
+            return Ok(Self::hos_reconcile_summary(true, 0, 0, false, None));
         }
 
         // Prefer the user's stored HoS `price_id`, then fall back to every configured HoS price.
@@ -1435,13 +1459,16 @@ impl SubscriptionServiceImpl {
         if raw.is_none() {
             let mut local_hos_subscriptions: Vec<Subscription> = subs
                 .iter()
-                .filter(|s| s.provider == "house-of-stake")
+                .filter(|s| {
+                    s.provider == "house-of-stake" && Self::is_active_or_trialing(&s.status)
+                })
                 .cloned()
                 .collect();
             if local_hos_subscriptions.is_empty() {
-                return Ok(Self::hos_reconcile_summary(false, 0, false, None));
+                return Ok(Self::hos_reconcile_summary(false, 0, 0, false, None));
             }
             let now = Utc::now();
+            let canceled = local_hos_subscriptions.len() as u32;
             let mut db_client = self
                 .db_pool
                 .get()
@@ -1453,19 +1480,10 @@ impl SubscriptionServiceImpl {
                 .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
 
             for sub in &mut local_hos_subscriptions {
-                sub.status = "canceled".to_string();
-                if sub.current_period_end > now {
-                    sub.current_period_end = now;
-                }
-                sub.cancel_at_period_end = false;
-                sub.pending_downgrade_target_price_id = None;
-                sub.pending_downgrade_from_price_id = None;
-                sub.pending_downgrade_expected_period_end = None;
-                sub.pending_downgrade_status = None;
-                sub.pending_downgrade_updated_at = None;
+                let canceled_sub = Self::canceled_house_of_stake_history_row(sub.clone(), now);
 
                 self.subscription_repo
-                    .upsert_subscription_authoritative(&txn, sub.clone())
+                    .upsert_subscription_authoritative(&txn, canceled_sub)
                     .await
                     .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
             }
@@ -1473,7 +1491,7 @@ impl SubscriptionServiceImpl {
                 .await
                 .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
             self.invalidate_credit_limit_cache(user_id).await;
-            return Ok(Self::hos_reconcile_summary(false, 0, false, None));
+            return Ok(Self::hos_reconcile_summary(false, 0, canceled, false, None));
         }
 
         let chain_subscription = raw.as_ref().expect("checked is_some");
@@ -1484,8 +1502,16 @@ impl SubscriptionServiceImpl {
         // `get_active_subscription` picks newest `created_at`, so a fresh HoS upsert could wrongly
         // become the "active" row for Stripe-primary users who also staked on-chain separately.
         if has_active_non_hos {
-            let deleted = hos_subscription_ids.len() as u32;
-            if !hos_subscription_ids.is_empty() {
+            let active_hos_subscriptions: Vec<Subscription> = subs
+                .iter()
+                .filter(|s| {
+                    s.provider == "house-of-stake" && Self::is_active_or_trialing(&s.status)
+                })
+                .cloned()
+                .collect();
+            let canceled = active_hos_subscriptions.len() as u32;
+            if !active_hos_subscriptions.is_empty() {
+                let now = Utc::now();
                 let mut db_client = self
                     .db_pool
                     .get()
@@ -1495,9 +1521,12 @@ impl SubscriptionServiceImpl {
                     .transaction()
                     .await
                     .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
-                for sid in &hos_subscription_ids {
+                for sub in active_hos_subscriptions {
                     self.subscription_repo
-                        .delete_subscription_txn(&txn, sid)
+                        .upsert_subscription_authoritative(
+                            &txn,
+                            Self::canceled_house_of_stake_history_row(sub, now),
+                        )
                         .await
                         .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
                 }
@@ -1509,12 +1538,13 @@ impl SubscriptionServiceImpl {
 
             tracing::warn!(
                 user_id = %user_id.0,
-                deleted_house_of_stake_rows = deleted,
+                canceled_house_of_stake_rows = canceled,
                 "Skipping HoS reconcile upsert: user has an active or trialing non-house-of-stake subscription row"
             );
             return Ok(Self::hos_reconcile_summary(
                 false,
-                deleted,
+                0,
+                canceled,
                 false,
                 Some(NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS),
             ));
@@ -1536,15 +1566,23 @@ impl SubscriptionServiceImpl {
             .await
             .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
 
-        let stale_subscription_ids: Vec<String> = hos_subscription_ids
+        let stale_hos_subscriptions: Vec<Subscription> = subs
             .iter()
-            .filter(|sid| sid.as_str() != chain_subscription_id.as_str())
+            .filter(|s| {
+                s.provider == "house-of-stake"
+                    && s.subscription_id.as_str() != chain_subscription_id.as_str()
+                    && Self::is_active_or_trialing(&s.status)
+            })
             .cloned()
             .collect();
-        let deleted = stale_subscription_ids.len() as u32;
-        for sid in &stale_subscription_ids {
+        let canceled = stale_hos_subscriptions.len() as u32;
+        let now = Utc::now();
+        for sub in stale_hos_subscriptions {
             self.subscription_repo
-                .delete_subscription_txn(&txn, sid)
+                .upsert_subscription_authoritative(
+                    &txn,
+                    Self::canceled_house_of_stake_history_row(sub, now),
+                )
                 .await
                 .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
         }
@@ -1554,7 +1592,7 @@ impl SubscriptionServiceImpl {
             .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
 
         self.invalidate_credit_limit_cache(user_id).await;
-        Ok(Self::hos_reconcile_summary(false, deleted, true, None))
+        Ok(Self::hos_reconcile_summary(false, 0, canceled, true, None))
     }
 }
 


### PR DESCRIPTION
## Summary

Preserve House of Stake subscription history when the on-chain subscription is no longer active.

Fixes nearai/house-of-stake-contracts#44.

## Root Cause

`GET /v1/subscriptions?include_inactive=true` is DB-only, but HoS sync deleted local `house-of-stake` rows when the contract probe returned `null`. After an effective cancellation, there was no local row left for `include_inactive=true` to return, unlike Stripe canceled subscriptions.

## Changes

- Mark expired HoS rows as `canceled` during entitlement checks instead of deleting them.
- Mark existing local HoS rows as `canceled` when chain sync returns no subscription instead of deleting them.
- Clear pending downgrade fields when preserving the canceled HoS row.
- Update HoS subscription tests to assert the preserved inactive row is returned by `include_inactive=true`.

## Validation

- `cargo test -p api --features test --test subscriptions_tests test_near_staking_sync_marks_local_hos_canceled_when_chain_returns_null`
- `cargo test -p api --features test --test subscriptions_tests test_near_staking_sync_falls_back_to_configured_prices_before_canceling_local_row`
- `cargo test -p api --features test --test subscriptions_tests test_near_staking_sync_marks_expired_cancel_at_period_end_row_canceled`
- `cargo test -p api --features test --test subscriptions_tests test_cancel_subscription_house_of_stake_returns_wallet_intent_message`