### PR TITLE
feat(migrate): auto grant-owner, cancelled SSE, and node placement override

### DIFF
--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -4067,6 +4067,34 @@ pub async fn admin_migrate_instance(
         ));
     }
 
+    // Best-effort: grant the owning user CrabShack access so scheduled backups include the instance
+    // and it appears in their portal. Non-fatal — migration already succeeded; on failure the admin
+    // can retry via the grant-owner endpoint.
+    match grant_crabshack_owner(
+        &app_state,
+        instance.user_id,
+        &instance_name,
+        &crabshack_manager.url,
+        &crabshack_manager.token,
+    )
+    .await
+    {
+        Ok(Some(owner_user_id)) => tracing::info!(
+            "Migrate: granted CrabShack owner: instance_id={}, owner_user_id={}",
+            id,
+            owner_user_id
+        ),
+        Ok(None) => tracing::warn!(
+            "Migrate: skipped owner grant, user has no passkey credentials: instance_id={}",
+            id
+        ),
+        Err(e) => tracing::warn!(
+            "Migrate: owner grant failed (non-fatal, retry via grant-owner): instance_id={}, error={}",
+            id,
+            e
+        ),
+    }
+
     tracing::info!(
         "Migrate: completed successfully, elapsed={:.1}s, instance_id={}, name={}",
         migrate_start.elapsed().as_secs_f64(),
@@ -4079,6 +4107,57 @@ pub async fn admin_migrate_instance(
         instance_name,
         message: "Instance migrated to CrabShack".to_string(),
     }))
+}
+
+/// Derive the owning user's CrabShack id and grant them owner access on `instance_name`.
+///
+/// CrabShack user id = hex(sha256(hex_decode(auth_secret))), mirroring orchestrator-api's
+/// userIdFromAuthSecret. Never mints credentials — a fresh secret would derive a different identity
+/// and backup key than the migrated backup was encrypted with. Idempotent on CrabShack
+/// (last-write-wins), so re-running is safe. Returns Ok(None) when the user has no passkey
+/// credentials, Ok(Some(owner_id)) on a successful grant.
+async fn grant_crabshack_owner(
+    app_state: &AppState,
+    user_id: UserId,
+    instance_name: &str,
+    crabshack_url: &str,
+    crabshack_token: &str,
+) -> anyhow::Result<Option<String>> {
+    let auth_secret = match app_state
+        .agent_repository
+        .get_user_passkey_credentials(user_id)
+        .await?
+    {
+        Some((auth_secret, _backup_passphrase)) => auth_secret,
+        None => return Ok(None),
+    };
+
+    let auth_secret_bytes = hex::decode(auth_secret.trim())
+        .map_err(|e| anyhow::anyhow!("stored auth_secret is not valid hex: {e}"))?;
+    let owner_user_id = hex::encode(Sha256::digest(&auth_secret_bytes));
+
+    let grant_url = format!(
+        "{}/instances/{}/access",
+        crabshack_url.trim_end_matches('/'),
+        encode(instance_name)
+    );
+    let resp = app_state
+        .http_client
+        .post(&grant_url)
+        .bearer_auth(crabshack_token)
+        .json(&serde_json::json!({ "user_id": owner_user_id, "role": "owner" }))
+        .timeout(std::time::Duration::from_secs(30))
+        .send()
+        .await?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!(
+            "CrabShack rejected the access grant (status {status}): {}",
+            body.chars().take(200).collect::<String>()
+        );
+    }
+    Ok(Some(owner_user_id))
 }
 
 /// Response for the grant-owner endpoint.
@@ -4169,80 +4248,34 @@ pub async fn admin_grant_instance_owner(
         ));
     }
 
-    // Look up the owning user's passkey credentials. The auth_secret is the root of the CrabShack
-    // user identity. Never mint new credentials here: fresh creds would derive a different identity
-    // and backup key than the migrated backup was encrypted with.
-    let auth_secret = match app_state
-        .agent_repository
-        .get_user_passkey_credentials(instance.user_id)
-        .await
-        .map_err(|e| {
-            tracing::error!(
-                "grant-owner: failed to get passkey credentials: user_id={}, error={}",
-                instance.user_id,
-                e
-            );
-            ApiError::internal_server_error("Failed to get user credentials")
-        })? {
-        Some((auth_secret, _backup_passphrase)) => auth_secret,
-        None => {
+    // Derive the owner id and grant access. Shared with the migrate handler, which performs the
+    // same grant automatically after a successful import.
+    let owner_user_id = match grant_crabshack_owner(
+        &app_state,
+        instance.user_id,
+        &instance.name,
+        &crabshack_manager.url,
+        &crabshack_manager.token,
+    )
+    .await
+    {
+        Ok(Some(owner_user_id)) => owner_user_id,
+        Ok(None) => {
             return Err(ApiError::bad_request(
                 "User has no passkey credentials — cannot derive CrabShack owner id",
             ));
         }
-    };
-
-    // CrabShack user id = hex(sha256(hex_decode(auth_secret))).
-    // Mirrors CrabShack's userIdFromAuthSecret (orchestrator-api/src/auth/user-queries.ts).
-    let auth_secret_bytes = hex::decode(auth_secret.trim()).map_err(|e| {
-        tracing::error!(
-            "grant-owner: stored auth_secret is not valid hex: instance_id={}, error={}",
-            id,
-            e
-        );
-        ApiError::internal_server_error("Stored auth_secret is not valid hex")
-    })?;
-    let owner_user_id = hex::encode(Sha256::digest(&auth_secret_bytes));
-
-    // Grant owner access on CrabShack (admin endpoint). Idempotent: last-write-wins.
-    let grant_url = format!(
-        "{}/instances/{}/access",
-        crabshack_manager.url.trim_end_matches('/'),
-        encode(&instance.name)
-    );
-    let resp = app_state
-        .http_client
-        .post(&grant_url)
-        .bearer_auth(&crabshack_manager.token)
-        .json(&serde_json::json!({ "user_id": owner_user_id, "role": "owner" }))
-        .timeout(std::time::Duration::from_secs(30))
-        .send()
-        .await
-        .map_err(|e| {
+        Err(e) => {
             tracing::error!(
-                "grant-owner: CrabShack access call failed: instance_id={}, error={}",
+                "grant-owner: failed to grant CrabShack owner: instance_id={}, error={}",
                 id,
                 e
             );
-            ApiError::internal_server_error("Failed to call CrabShack access endpoint")
-        })?;
-    let status = resp.status();
-    if !status.is_success() {
-        // Read the body for diagnosis and surface CrabShack's status to the caller, so a
-        // misconfigured-admin-token 401 or a CrabShack 5xx is distinguishable from a generic
-        // failure. (CrabShack's grant is idempotent and does not check instance existence, so it
-        // never returns 404/409 here — only 4xx for a malformed request or auth/transport errors.)
-        let body = resp.text().await.unwrap_or_default();
-        tracing::error!(
-            "grant-owner: CrabShack access grant failed: instance_id={}, status={}, body={}",
-            id,
-            status,
-            body.chars().take(300).collect::<String>()
-        );
-        return Err(ApiError::internal_server_error(format!(
-            "CrabShack rejected the access grant (status {status})"
-        )));
-    }
+            return Err(ApiError::internal_server_error(
+                "Failed to grant CrabShack owner access",
+            ));
+        }
+    };
 
     tracing::info!(
         "grant-owner: granted CrabShack owner: instance_id={}, owner_user_id={}",
@@ -4445,6 +4478,16 @@ async fn parse_sse_for_import_result(
                             .and_then(|v| v.as_str())
                             .unwrap_or("unknown error");
                         anyhow::bail!("CrabShack import failed: {}", msg);
+                    }
+                    // CrabShack emits event:"cancelled" when a force-delete aborts the deploy
+                    // mid-import; surface it clearly instead of the generic stream-ended error.
+                    if stage == "cancelled" || event_type == "cancelled" {
+                        let msg = event
+                            .get("message")
+                            .or_else(|| event.get("data").and_then(|d| d.get("message")))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("import was cancelled");
+                        anyhow::bail!("CrabShack import cancelled: {}", msg);
                     }
                     if stage == "complete" || stage == "done" || event_type == "import_complete" {
                         tracing::info!(

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3346,6 +3346,14 @@ pub struct MigrateInstanceRequest {
     /// user's stored passphrase + instance name. The legacy instance will NOT
     /// be started — stop it before taking the external backup to avoid data loss.
     pub backup_url: Option<String>,
+    /// Override node placement policy, passed through to CrabShack's import.
+    /// Defaults to {"version":1,"tee":"ANY_TEE"} (require a TEE node) when absent.
+    /// Accepts the orchestrator's node_policy shape, e.g.
+    /// {"version":1,"tee":"NO_TEE"|"ANY"|"ANY_TEE"}.
+    pub node_policy: Option<serde_json::Value>,
+    /// Pin the migrated instance to a specific CrabShack node id. When set,
+    /// CrabShack places it on that node and cross-checks it against node_policy.
+    pub node_id: Option<String>,
 }
 
 /// Response for migrate endpoint
@@ -3933,8 +3941,13 @@ pub async fn admin_migrate_instance(
 
     // Deploy ordering: node_policy requires CrabShack PR #327 to be deployed first.
     // Without it, CrabShack ignores the field (pre-#327 import silently drops unknown fields).
+    // node_id pinning needs the import-side node_id support (crabshack-terraform follow-up).
+    let node_policy = request
+        .node_policy
+        .unwrap_or_else(|| serde_json::json!({ "version": 1, "tee": "ANY_TEE" }));
+    let node_id = request.node_id;
     let import_url = format!("{}/instances/import", crabshack_manager.url);
-    let import_body = serde_json::json!({
+    let mut import_body = serde_json::json!({
         "name": instance.name,
         "token": instance_token,
         "backup_url": backup_presigned_url,
@@ -3948,8 +3961,11 @@ pub async fn admin_migrate_instance(
         "cpus": cpus,
         "storage_size": storage_size,
         "extra_env": extra_env,
-        "node_policy": { "version": 1, "tee": "ANY_TEE" },
+        "node_policy": node_policy,
     });
+    if let Some(node_id) = node_id {
+        import_body["node_id"] = serde_json::Value::String(node_id);
+    }
 
     let import_resp = app_state
         .http_client


### PR DESCRIPTION
## What

Quality improvements to the `/migrate` path (from staging TEE-migration prep). None is required for migration to function — the endpoint already works — but they remove manual steps, clarify one error, and make TEE placement controllable.

1. **Auto grant-owner on successful migrate.** Migration lands instances ownerless, so scheduled backups skip them and they don't appear in the owner's portal until a separate `grant-owner` call. This grants owner access automatically at the end of a successful migrate — best-effort (logs a warning on failure; the standalone `grant-owner` endpoint stays as the retry path). Removes a manual per-instance step for the ~15-agent staging run.
2. **Handle the `cancelled` import SSE event.** CrabShack emits `event:"cancelled"` when a force-delete aborts the deploy mid-import (`orchestrator-api/src/instance/instance-lifecycle-status.ts`). Previously this fell through to the generic "stream ended without completion event"; now it surfaces a clear "import cancelled" message.
3. **`node_policy` / `node_id` placement override.** Migrate hardcoded the import's `node_policy` to `ANY_TEE`. `MigrateInstanceRequest` now exposes optional `node_policy` and `node_id` (both default to the existing `ANY_TEE`), so a caller can pin a migrated instance to a specific CrabShack node or override TEE placement for a controlled cutover. `node_id` is honored once the orchestrator import gains `node_id` support ([nearai/ai-infra-agent-hosting](https://github.com/nearai/ai-infra-agent-hosting) — companion PR); older orchestrators silently ignore it, same as the `node_policy` #327 deploy-ordering.

Both grant paths are factored into a shared `grant_crabshack_owner` helper; `admin_grant_instance_owner` is refactored onto it with its 400-for-missing-credentials / 500-otherwise behavior preserved.

## Test
- `cargo check -p api --features test` — clean.
- Draft: not yet exercised against a live migrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
