### PR TITLE
refactor: return HoS `subscription_id` for cancel/resume wallet intents

### DIFF
--- a/crates/api/src/routes/subscriptions.rs
+++ b/crates/api/src/routes/subscriptions.rs
@@ -48,7 +48,7 @@ pub struct CancelSubscriptionResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub contract_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub product_id: Option<String>,
+    pub subscription_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -64,7 +64,7 @@ pub struct ResumeSubscriptionResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub contract_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub product_id: Option<String>,
+    pub subscription_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -314,20 +314,20 @@ pub async fn cancel_subscription(
             message: "Subscription will be canceled at period end".to_string(),
             kind: None,
             contract_id: None,
-            product_id: None,
+            subscription_id: None,
             network_id: None,
             required_deposit_yocto: None,
         },
         CancelSubscriptionOutcome::NearStakingCancel {
             contract_id,
-            product_id,
+            subscription_id,
             network_id,
             required_deposit_yocto,
         } => CancelSubscriptionResponse {
             message: "Complete cancellation in your NEAR wallet".to_string(),
             kind: Some("near_staking_cancel".to_string()),
             contract_id: Some(contract_id),
-            product_id: Some(product_id),
+            subscription_id: Some(subscription_id),
             network_id: Some(network_id),
             required_deposit_yocto: Some(required_deposit_yocto),
         },
@@ -396,20 +396,20 @@ pub async fn resume_subscription(
             message: "Subscription resumed successfully".to_string(),
             kind: None,
             contract_id: None,
-            product_id: None,
+            subscription_id: None,
             network_id: None,
             required_deposit_yocto: None,
         },
         ResumeSubscriptionOutcome::NearStakingResume {
             contract_id,
-            product_id,
+            subscription_id,
             network_id,
             required_deposit_yocto,
         } => ResumeSubscriptionResponse {
             message: "Complete resume in your NEAR wallet".to_string(),
             kind: Some("near_staking_resume".to_string()),
             contract_id: Some(contract_id),
-            product_id: Some(product_id),
+            subscription_id: Some(subscription_id),
             network_id: Some(network_id),
             required_deposit_yocto: Some(required_deposit_yocto),
         },

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -3985,8 +3985,8 @@ async fn test_cancel_subscription_house_of_stake_returns_wallet_intent_message()
         Some("near_staking_cancel")
     );
     assert_eq!(
-        body.get("product_id").and_then(|x| x.as_str()),
-        Some("nearai|prod_cat")
+        body.get("subscription_id").and_then(|x| x.as_str()),
+        Some("sub_on_chain_hos_cancel_msg")
     );
     assert_eq!(
         body.get("contract_id").and_then(|x| x.as_str()),
@@ -4078,8 +4078,8 @@ async fn test_resume_subscription_house_of_stake_returns_wallet_intent_message()
         Some("near_staking_resume")
     );
     assert_eq!(
-        body.get("product_id").and_then(|x| x.as_str()),
-        Some("nearai|prod_cat")
+        body.get("subscription_id").and_then(|x| x.as_str()),
+        Some("sub_on_chain_hos_resume_msg")
     );
     assert_eq!(
         body.get("contract_id").and_then(|x| x.as_str()),

--- a/crates/services/src/subscription/ports.rs
+++ b/crates/services/src/subscription/ports.rs
@@ -277,7 +277,7 @@ pub enum CancelSubscriptionOutcome {
     Completed,
     NearStakingCancel {
         contract_id: String,
-        product_id: String,
+        subscription_id: String,
         network_id: String,
         required_deposit_yocto: String,
     },
@@ -290,7 +290,7 @@ pub enum ResumeSubscriptionOutcome {
     Completed,
     NearStakingResume {
         contract_id: String,
-        product_id: String,
+        subscription_id: String,
         network_id: String,
         required_deposit_yocto: String,
     },

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1226,28 +1226,6 @@ impl SubscriptionServiceImpl {
             .ok_or(SubscriptionError::HouseOfStakeNotConfigured)
     }
 
-    async fn hos_product_id_for_price(
-        &self,
-        contract_id: &str,
-        price_id: &str,
-    ) -> Result<String, SubscriptionError> {
-        let price_json = view_get_price(&self.near_rpc_url, contract_id, price_id)
-            .await
-            .map_err(Self::near_rpc_err)?
-            .ok_or_else(|| {
-                SubscriptionError::InternalError("HoS price not found on-chain".into())
-            })?;
-
-        price_json
-            .product_id
-            .as_deref()
-            .filter(|s| !s.is_empty())
-            .map(str::to_string)
-            .ok_or_else(|| {
-                SubscriptionError::InternalError("HoS price missing or empty product_id".into())
-            })
-    }
-
     /// Deterministic HoS catalog `price_id`s. `get_subscription_for_price` resolves through the
     /// price's product, so first sync must probe every configured HoS product instead of assuming
     /// any one price can discover all on-chain subscriptions.
@@ -2094,12 +2072,9 @@ impl SubscriptionService for SubscriptionServiceImpl {
 
         if subscription.provider == "house-of-stake" {
             let contract_id = self.configured_staking_contract_id()?;
-            let product_id = self
-                .hos_product_id_for_price(contract_id, &subscription.price_id)
-                .await?;
             return Ok(CancelSubscriptionOutcome::NearStakingCancel {
                 contract_id: contract_id.to_string(),
-                product_id,
+                subscription_id: subscription.subscription_id,
                 network_id: self.near_network_id.clone(),
                 required_deposit_yocto: "1".to_string(),
             });
@@ -2184,12 +2159,9 @@ impl SubscriptionService for SubscriptionServiceImpl {
 
         if subscription.provider == "house-of-stake" {
             let contract_id = self.configured_staking_contract_id()?;
-            let product_id = self
-                .hos_product_id_for_price(contract_id, &subscription.price_id)
-                .await?;
             return Ok(ResumeSubscriptionOutcome::NearStakingResume {
                 contract_id: contract_id.to_string(),
-                product_id,
+                subscription_id: subscription.subscription_id,
                 network_id: self.near_network_id.clone(),
                 required_deposit_yocto: "1".to_string(),
             });


### PR DESCRIPTION
## Summary
- return `subscription_id` instead of `product_id` for HoS cancel/resume wallet intents
- remove the extra HoS price-to-product RPC lookup from cancel/resume paths
- update API response mapping and integration-test expectations

## Dependency
- Depends on contract API change: https://github.com/nearai/house-of-stake-contracts/pull/91

## Validation
- `cargo fmt --check`
- `cargo check -q -p api`

## Not Run
- `cargo test -q -p api test_cancel_subscription_house_of_stake_returns_wallet_intent_message`
- `cargo test -q -p api test_resume_subscription_house_of_stake_returns_wallet_intent_message`

The focused API integration test command was blocked by the local database setup before app code ran: `FATAL: password authentication failed for user "postgres"`.