### PR TITLE
feat(migrate): add crabshack_ironclaw_image base-override for version deduction

### DIFF
--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3596,9 +3596,20 @@ pub async fn admin_migration_status(
 /// Optional request body for migrate endpoint
 #[derive(Deserialize, Default, utoipa::ToSchema)]
 pub struct MigrateInstanceRequest {
-    /// Override the Docker image for the CrabShack instance.
+    /// Override the Docker image for the CrabShack instance, verbatim.
+    /// Highest precedence: when set, version deduction and
+    /// `crabshack_ironclaw_image` are skipped and this ref is used as-is.
     /// If not provided, uses the configured default for the service type.
     pub image: Option<String>,
+    /// Override only the base image for version deduction, replacing the
+    /// config-derived `ironclaw_image` (get_image_for_service_type result).
+    /// The version is still deduced from the running instance's /version and
+    /// appended, so `docker.io/nearaidev/ironclaw-dind` yields
+    /// `docker.io/nearaidev/ironclaw-dind:<deduced-version>`. Any tag on this
+    /// value is replaced by the deduced version. Ignored when `image` is set.
+    /// Use this to migrate legacy ironclaw workers to ironclaw-dind without
+    /// touching the shared `ironclaw_image` config (e.g. reborn on staging).
+    pub crabshack_ironclaw_image: Option<String>,
     /// Skip the backup phase entirely and use this presigned URL instead.
     /// Useful when backup was obtained directly from compose-api (e.g. the
     /// SSE stream stalls through chat-api but works when called directly).
@@ -3833,6 +3844,13 @@ pub async fn admin_migrate_instance(
     // is deferred until after the "start if stopped" block so the version query
     // can reach the running container.
     let image_override = request.image.filter(|s| !s.is_empty());
+    // Base-image override for version deduction (below). Replaces the
+    // config-derived base so a legacy ironclaw worker can target ironclaw-dind
+    // without touching the shared ironclaw_image config.
+    let base_image_override = request
+        .crabshack_ironclaw_image
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
     let provided_backup_url = request.backup_url.filter(|s| !s.is_empty());
     let has_backup_url = provided_backup_url.is_some();
     if let Some(ref url) = provided_backup_url {
@@ -3940,10 +3958,12 @@ pub async fn admin_migrate_instance(
     let image = if let Some(img) = image_override {
         img
     } else if has_backup_url {
-        let default_image = services::agent::service::get_image_for_service_type(
-            service_type,
-            hosting_config.as_ref(),
-        );
+        let default_image = base_image_override.clone().unwrap_or_else(|| {
+            services::agent::service::get_image_for_service_type(
+                service_type,
+                hosting_config.as_ref(),
+            )
+        });
         let mut fallback = default_image;
         if fallback == "docker.io/nearaidev/ironclaw-dind:latest" {
             fallback = "docker.io/nearaidev/ironclaw-dind:0.29.1".to_string();
@@ -3988,10 +4008,12 @@ pub async fn admin_migrate_instance(
         }
         .await;
 
-        let default_image = services::agent::service::get_image_for_service_type(
-            service_type,
-            hosting_config.as_ref(),
-        );
+        let default_image = base_image_override.clone().unwrap_or_else(|| {
+            services::agent::service::get_image_for_service_type(
+                service_type,
+                hosting_config.as_ref(),
+            )
+        });
         if let Some(ver) = version {
             let base = default_image
                 .rsplit_once(':')

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3843,7 +3843,10 @@ pub async fn admin_migrate_instance(
     // Image override from request body (validated non-empty). Actual resolution
     // is deferred until after the "start if stopped" block so the version query
     // can reach the running container.
-    let image_override = request.image.filter(|s| !s.is_empty());
+    let image_override = request
+        .image
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
     // Base-image override for version deduction (below). Replaces the
     // config-derived base so a legacy ironclaw worker can target ironclaw-dind
     // without touching the shared ironclaw_image config.
@@ -3958,12 +3961,12 @@ pub async fn admin_migrate_instance(
     let image = if let Some(img) = image_override {
         img
     } else if has_backup_url {
-        let default_image = base_image_override.clone().unwrap_or_else(|| {
-            services::agent::service::get_image_for_service_type(
-                service_type,
-                hosting_config.as_ref(),
-            )
-        });
+        // No /version to deduce against here (instance stays stopped), so the
+        // base-image override does not apply — use the configured default.
+        let default_image = services::agent::service::get_image_for_service_type(
+            service_type,
+            hosting_config.as_ref(),
+        );
         let mut fallback = default_image;
         if fallback == "docker.io/nearaidev/ironclaw-dind:latest" {
             fallback = "docker.io/nearaidev/ironclaw-dind:0.29.1".to_string();
@@ -4008,17 +4011,20 @@ pub async fn admin_migrate_instance(
         }
         .await;
 
-        let default_image = base_image_override.clone().unwrap_or_else(|| {
+        let default_image = base_image_override.unwrap_or_else(|| {
             services::agent::service::get_image_for_service_type(
                 service_type,
                 hosting_config.as_ref(),
             )
         });
         if let Some(ver) = version {
-            let base = default_image
-                .rsplit_once(':')
-                .map(|(b, _)| b)
-                .unwrap_or(&default_image);
+            // Strip an existing tag before appending the deduced version, but
+            // only when the last ':' is a tag separator (after the last '/') —
+            // not a registry port like host:5000/img.
+            let base = match default_image.rsplit_once(':') {
+                Some((b, tag)) if !tag.contains('/') => b,
+                _ => &default_image,
+            };
             let img = format!("{}:{}", base, ver);
             tracing::info!("Migrate: resolved image={}, instance_id={}", img, id);
             img


### PR DESCRIPTION
## What

Adds an optional `crabshack_ironclaw_image` field to the `/v1/admin/agents/instances/{id}/migrate` request. It overrides **only the base image** used for version deduction, leaving the deduction itself intact.

## Why

On staging, `agent_hosting.crabshack` is configured for the in-progress ironclaw-reborn RC testing:

- `ironclaw_service_type = "ironclaw-reborn"`
- `ironclaw_image = "docker.io/sakethare/ironclaw-reborn:1.0.0-rc.8"`

So migrating a legacy `ironclaw` worker resolves the image base via `get_image_for_service_type("ironclaw", cfg)` → the reborn image, and version deduction yields `sakethare/ironclaw-reborn:<version>` — not `ironclaw-dind:<version>`. #353's `service_type` override fixes the service_type half, but the image base still came from the reborn config.

The full `image` override (also from #353) *can* force ironclaw-dind, but it's verbatim — it skips version deduction, so the caller must hardcode the version. We want the deduced per-agent version (from the running instance's `/version`) with the ironclaw-dind base, without touching the shared reborn config.

## How

Image-resolution precedence in the migrate handler is now:

1. `image` — verbatim, highest precedence, skips deduction (unchanged)
2. else base := `crabshack_ironclaw_image` ?? `get_image_for_service_type(service_type, cfg)`, then `{base without tag}:{deduced-version}`

`service_type` remains orthogonal and is still validated against the resolved image by CrabShack's import.

### Example

```json
{ "service_type": "ironclaw-dind",
  "crabshack_ironclaw_image": "docker.io/nearaidev/ironclaw-dind" }
```
→ base `docker.io/nearaidev/ironclaw-dind`, version `0.29.0` deduced from `/version` → `docker.io/nearaidev/ironclaw-dind:0.29.0`. No version hardcoded, reborn config untouched.
