### PR TITLE
fix: restore expired HoS sync history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,7 @@ dependencies = [
  "sha2 0.10.9",
  "stripe_client",
  "tokio",
+ "tokio-postgres",
  "tokio-stream",
  "tower",
  "tower-http",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -72,6 +72,7 @@ axum-test = "18"
 dotenvy = "0.15"
 wiremock = "0.6"
 serial_test = "3.0"
+tokio-postgres = "0.7"
 
 [features]
 default = []

--- a/crates/api/src/bin/task_worker.rs
+++ b/crates/api/src/bin/task_worker.rs
@@ -480,6 +480,10 @@ async fn main() -> anyhow::Result<()> {
     let db = database::Database::from_config(&config.database)
         .await
         .context("failed to connect database for task worker")?;
+    tracing::info!("Running migrations for task worker...");
+    db.run_migrations()
+        .await
+        .context("failed to run database migrations for task worker")?;
 
     let system_configs_service = Arc::new(
         services::system_configs::service::SystemConfigsServiceImpl::new(

--- a/crates/api/src/bin/task_worker.rs
+++ b/crates/api/src/bin/task_worker.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use axum::{routing::get, Json, Router};
 use chrono::{Duration, Utc};
+use database::repositories::subscription_repository::CLEANUP_CANCELED_INSTANCE_USERS_SQL;
 use serde::Serialize;
 use services::conversation::ports::ConversationService;
 use services::response::service::OpenAIProxy;
@@ -102,24 +103,7 @@ impl TaskExecutor for DefaultTaskExecutor {
                 .context("failed to get DB client")?;
             let rows = client
                 .query(
-                    "SELECT s.user_id
-                     FROM subscriptions s
-                     WHERE s.status = 'canceled'
-                       AND NOT EXISTS (
-                           SELECT 1
-                           FROM subscriptions active_sub
-                           WHERE active_sub.user_id = s.user_id
-                             AND active_sub.status IN ('active', 'trialing')
-                       )
-                       AND NOT (
-                           s.provider = 'house-of-stake'
-                           AND s.canceled_at IS NOT NULL
-                           AND s.canceled_at < s.created_at
-                       )
-                     GROUP BY s.user_id
-                     HAVING MAX(s.current_period_end) <= $1
-                     ORDER BY s.user_id
-                     LIMIT $2 OFFSET $3",
+                    CLEANUP_CANCELED_INSTANCE_USERS_SQL,
                     &[&cutoff, &batch_size, &offset],
                 )
                 .await

--- a/crates/api/src/bin/task_worker.rs
+++ b/crates/api/src/bin/task_worker.rs
@@ -102,16 +102,22 @@ impl TaskExecutor for DefaultTaskExecutor {
                 .context("failed to get DB client")?;
             let rows = client
                 .query(
-                    "SELECT DISTINCT s.user_id
+                    "SELECT s.user_id
                      FROM subscriptions s
                      WHERE s.status = 'canceled'
-                       AND s.current_period_end <= $1
                        AND NOT EXISTS (
                            SELECT 1
                            FROM subscriptions active_sub
                            WHERE active_sub.user_id = s.user_id
                              AND active_sub.status IN ('active', 'trialing')
                        )
+                       AND NOT (
+                           s.provider = 'house-of-stake'
+                           AND s.canceled_at IS NOT NULL
+                           AND s.canceled_at < s.created_at
+                       )
+                     GROUP BY s.user_id
+                     HAVING MAX(s.current_period_end) <= $1
                      ORDER BY s.user_id
                      LIMIT $2 OFFSET $3",
                     &[&cutoff, &batch_size, &offset],

--- a/crates/api/src/routes/subscriptions.rs
+++ b/crates/api/src/routes/subscriptions.rs
@@ -797,7 +797,7 @@ pub async fn create_portal_session(
     path = "/v1/subscriptions/near/sync",
     tag = "Subscriptions",
     responses(
-        (status = 200, description = "Reconcile finished; see `skipped`, `deleted_house_of_stake_rows`, `canceled_house_of_stake_rows`, `upserted_house_of_stake_row`, and optional `skipped_reason` in the body.", body = NearStakingSyncSummary),
+        (status = 200, description = "Reconcile finished; see `skipped`, `retryable`, `deleted_house_of_stake_rows`, `canceled_house_of_stake_rows`, `upserted_house_of_stake_row`, and optional `skipped_reason` in the body.", body = NearStakingSyncSummary),
         (status = 401, description = "Unauthorized", body = crate::error::ApiErrorResponse),
         (status = 500, description = "Internal server error", body = crate::error::ApiErrorResponse),
         (status = 503, description = "NEAR RPC unavailable", body = crate::error::ApiErrorResponse)

--- a/crates/api/src/routes/subscriptions.rs
+++ b/crates/api/src/routes/subscriptions.rs
@@ -797,7 +797,7 @@ pub async fn create_portal_session(
     path = "/v1/subscriptions/near/sync",
     tag = "Subscriptions",
     responses(
-        (status = 200, description = "Reconcile finished; see `skipped`, `retryable`, `deleted_house_of_stake_rows`, `canceled_house_of_stake_rows`, `upserted_house_of_stake_row`, and optional `skipped_reason` in the body.", body = NearStakingSyncSummary),
+        (status = 200, description = "Reconcile finished; see `skipped`, `deleted_house_of_stake_rows`, `canceled_house_of_stake_rows`, `upserted_house_of_stake_row`, and optional `skipped_reason` in the body.", body = NearStakingSyncSummary),
         (status = 401, description = "Unauthorized", body = crate::error::ApiErrorResponse),
         (status = 500, description = "Internal server error", body = crate::error::ApiErrorResponse),
         (status = 503, description = "NEAR RPC unavailable", body = crate::error::ApiErrorResponse)

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -4591,6 +4591,120 @@ async fn test_near_staking_sync_skipped_reason_when_upsert_blocked_by_active_str
 
 #[tokio::test]
 #[serial(subscription_tests)]
+async fn test_near_staking_sync_restores_expired_hos_history_when_active_stripe_exists() {
+    clear_proxy_env_for_local_wiremock();
+    let chain_sub = json!({
+        "subscription_id": "sub_legacy_expired_hos",
+        "price_id": "price_hos_basic",
+        "end_ns": "1783039174474808018",
+        "status": "Expired",
+        "cancel_at_period_end": true
+    });
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(near_rpc_wiremock_hos_subscription_probe_only(chain_sub))
+        .mount(&mock)
+        .await;
+
+    let (server, db) = create_test_server_and_db(TestServerConfig {
+        near_rpc_url: Some(mock.uri().to_string()),
+        near_staking_contract_id: Some("staking.testnet".to_string()),
+        ..Default::default()
+    })
+    .await;
+
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": { "providers": { "house-of-stake": { "price_id": "price_hos_basic" } }, "agent_instances": { "max": 1 }, "monthly_credits": { "max": 1000000 } }
+        }),
+    )
+    .await;
+
+    let near_email = "hos_sync_legacy_expired_with_stripe.testnet@near";
+    let login = json!({
+        "email": near_email,
+        "name": "HoS Legacy Expired With Stripe",
+        "oauth_provider": "near"
+    });
+    let response = server.post("/v1/auth/mock-login").json(&login).await;
+    let token = response.json::<serde_json::Value>()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    cleanup_user_subscriptions(&db, near_email).await;
+    insert_test_subscription(&server, &db, near_email, false).await;
+
+    let response = server
+        .post("/v1/subscriptions/near/sync")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body: serde_json::Value = response.json();
+    assert_eq!(body.get("skipped").and_then(|x| x.as_bool()), Some(false));
+    assert_eq!(
+        body.get("upserted_house_of_stake_row")
+            .and_then(|x| x.as_bool()),
+        Some(true)
+    );
+    assert_eq!(body.get("skipped_reason"), None);
+
+    let user = db
+        .user_repository()
+        .get_user_by_email(near_email)
+        .await
+        .unwrap()
+        .unwrap();
+    let client = db.pool().get().await.unwrap();
+    let row = client
+        .query_one(
+            "SELECT provider, price_id, status, current_period_end, cancel_at_period_end
+             FROM subscriptions
+             WHERE user_id = $1 AND subscription_id = 'sub_legacy_expired_hos'",
+            &[&user.id],
+        )
+        .await
+        .expect("expired HoS history should be restored");
+    assert_eq!(row.get::<_, String>("provider"), "house-of-stake");
+    assert_eq!(row.get::<_, String>("price_id"), "price_hos_basic");
+    assert_eq!(row.get::<_, String>("status"), "canceled");
+    assert!(row.get::<_, bool>("cancel_at_period_end"));
+    assert_eq!(
+        row.get::<_, chrono::DateTime<Utc>>("current_period_end"),
+        Utc.with_ymd_and_hms(2026, 7, 3, 0, 39, 34).unwrap() + Duration::microseconds(474_808)
+    );
+
+    let response = server
+        .get("/v1/subscriptions?include_inactive=true")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body: serde_json::Value = response.json();
+    let subscriptions = body["subscriptions"]
+        .as_array()
+        .expect("subscriptions should be an array");
+    assert!(
+        subscriptions.iter().any(|sub| {
+            sub["subscription_id"] == "sub_legacy_expired_hos"
+                && sub["provider"] == "house-of-stake"
+                && sub["status"] == "canceled"
+        }),
+        "include_inactive=true should return restored HoS history: {subscriptions:?}"
+    );
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
 async fn test_near_staking_sync_marks_local_hos_canceled_when_chain_returns_null() {
     clear_proxy_env_for_local_wiremock();
     let mock = MockServer::start().await;

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -3255,7 +3255,7 @@ async fn test_subscription_gating_full_flow() {
 
 #[tokio::test]
 #[serial(subscription_tests)]
-async fn last_cancelled_period_uses_latest_canceled_period_end() {
+async fn last_cancelled_period_uses_most_recent_non_hos_canceled_row() {
     let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 
     let user_email = "test_free_anchor_max_canceled@example.com";
@@ -3307,8 +3307,67 @@ async fn last_cancelled_period_uses_latest_canceled_period_end() {
         .unwrap();
     assert_eq!(
         got,
-        Some(later_period_end),
-        "latest canceled period end should win even when an older restored row has newer updated_at"
+        Some(restored_history_period_end),
+        "non-HoS cancellations should keep updated_at ordering, not greatest period_end"
+    );
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn last_cancelled_period_deprioritizes_restored_hos_updated_at() {
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
+
+    let user_email = "test_free_anchor_restored_hos_updated_at@example.com";
+    cleanup_user_subscriptions(&db, user_email).await;
+    let _ = mock_login(&server, user_email).await;
+    let user = db
+        .user_repository()
+        .get_user_by_email(user_email)
+        .await
+        .unwrap()
+        .expect("user should exist");
+
+    let client = db.pool().get().await.unwrap();
+    let stripe_period_end = Utc.with_ymd_and_hms(2026, 2, 1, 0, 0, 0).unwrap();
+    let hos_history_period_end = Utc.with_ymd_and_hms(2024, 5, 1, 0, 0, 0).unwrap();
+    let stripe_updated_at = Utc.with_ymd_and_hms(2026, 2, 1, 0, 0, 0).unwrap();
+    let restored_hos_updated_at = Utc.with_ymd_and_hms(2026, 7, 26, 0, 0, 0).unwrap();
+
+    client
+        .execute(
+            "INSERT INTO subscriptions (
+                subscription_id, user_id, provider, customer_id, price_id, status,
+                current_period_end, cancel_at_period_end, created_at, updated_at
+            ) VALUES ($1, $2, 'stripe', 'cus_anchor', 'price_test_basic', 'canceled', $3, false, $4, $4)",
+            &[&"sub_free_anchor_stripe", &user.id, &stripe_period_end, &stripe_updated_at],
+        )
+        .await
+        .unwrap();
+    client
+        .execute(
+            "INSERT INTO subscriptions (
+                subscription_id, user_id, provider, customer_id, price_id, status,
+                current_period_end, cancel_at_period_end, created_at, updated_at
+            ) VALUES ($1, $2, 'house-of-stake', 'cus_anchor', 'price_hos_basic', 'canceled', $3, false, $4, $4)",
+            &[
+                &"sub_free_anchor_restored_hos",
+                &user.id,
+                &hos_history_period_end,
+                &restored_hos_updated_at,
+            ],
+        )
+        .await
+        .unwrap();
+
+    let got = db
+        .subscription_repository()
+        .last_cancelled_subscription_period_end_for_user(user.id)
+        .await
+        .unwrap();
+    assert_eq!(
+        got,
+        Some(stripe_period_end),
+        "freshly restored old HoS history should not override a newer Stripe cancellation boundary"
     );
 }
 

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -5460,8 +5460,8 @@ async fn test_near_staking_sync_marks_expired_cancel_at_period_end_row_canceled(
     let status: String = row.get("status");
     let cancel_at_period_end: bool = row.get("cancel_at_period_end");
     assert!(
-        cancel_at_period_end,
-        "row should stay marked cancel_at_period_end"
+        !cancel_at_period_end,
+        "canceled HoS history should clear cancel_at_period_end"
     );
     assert_eq!(
         status, "canceled",

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -3334,6 +3334,8 @@ async fn last_cancelled_period_deprioritizes_restored_hos_updated_at() {
     let stripe_updated_at = Utc.with_ymd_and_hms(2026, 2, 1, 0, 0, 0).unwrap();
     let restored_hos_updated_at = Utc.with_ymd_and_hms(2026, 7, 26, 0, 0, 0).unwrap();
     let early_hos_restore_updated_at = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+    let restored_hos_canceled_at = hos_history_period_end;
+    let early_hos_canceled_at = early_hos_restore_updated_at;
 
     client
         .execute(
@@ -3349,13 +3351,14 @@ async fn last_cancelled_period_deprioritizes_restored_hos_updated_at() {
         .execute(
             "INSERT INTO subscriptions (
                 subscription_id, user_id, provider, customer_id, price_id, status,
-                current_period_end, cancel_at_period_end, created_at, updated_at
-            ) VALUES ($1, $2, 'house-of-stake', 'cus_anchor', 'price_hos_basic', 'canceled', $3, false, $4, $4)",
+                current_period_end, cancel_at_period_end, created_at, updated_at, canceled_at
+            ) VALUES ($1, $2, 'house-of-stake', 'cus_anchor', 'price_hos_basic', 'canceled', $3, false, $4, $4, $5)",
             &[
                 &"sub_free_anchor_ended_future_hos",
                 &user.id,
                 &ended_future_hos_period_end,
                 &early_hos_restore_updated_at,
+                &early_hos_canceled_at,
             ],
         )
         .await
@@ -3364,13 +3367,14 @@ async fn last_cancelled_period_deprioritizes_restored_hos_updated_at() {
         .execute(
             "INSERT INTO subscriptions (
                 subscription_id, user_id, provider, customer_id, price_id, status,
-                current_period_end, cancel_at_period_end, created_at, updated_at
-            ) VALUES ($1, $2, 'house-of-stake', 'cus_anchor', 'price_hos_basic', 'canceled', $3, false, $4, $4)",
+                current_period_end, cancel_at_period_end, created_at, updated_at, canceled_at
+            ) VALUES ($1, $2, 'house-of-stake', 'cus_anchor', 'price_hos_basic', 'canceled', $3, false, $4, $4, $5)",
             &[
                 &"sub_free_anchor_restored_hos",
                 &user.id,
                 &hos_history_period_end,
                 &restored_hos_updated_at,
+                &restored_hos_canceled_at,
             ],
         )
         .await
@@ -4939,7 +4943,7 @@ async fn test_near_staking_sync_normalizes_canceled_chain_history() {
     let client = db.pool().get().await.unwrap();
     let row = client
         .query_one(
-            "SELECT status, current_period_end, cancel_at_period_end
+            "SELECT status, current_period_end, cancel_at_period_end, canceled_at
              FROM subscriptions
              WHERE user_id = $1 AND subscription_id = 'sub_chain_future_canceled_hos'",
             &[&user.id],
@@ -4952,6 +4956,13 @@ async fn test_near_staking_sync_normalizes_canceled_chain_history() {
     assert_eq!(
         period_end, chain_period_end,
         "future terminal HoS period end should stay chain-authored"
+    );
+    let canceled_at = row
+        .get::<_, Option<chrono::DateTime<Utc>>>("canceled_at")
+        .expect("restored canceled HoS history should set canceled_at");
+    assert!(
+        canceled_at < chain_period_end,
+        "future terminal HoS canceled_at should reflect restore time, not the future chain boundary"
     );
 
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;
@@ -4966,7 +4977,7 @@ async fn test_near_staking_sync_normalizes_canceled_chain_history() {
     assert_eq!(response.status_code(), 200, "{}", response.text());
     let row = client
         .query_one(
-            "SELECT current_period_end
+            "SELECT current_period_end, canceled_at
              FROM subscriptions
              WHERE user_id = $1 AND subscription_id = 'sub_chain_future_canceled_hos'",
             &[&user.id],
@@ -4977,6 +4988,11 @@ async fn test_near_staking_sync_normalizes_canceled_chain_history() {
         row.get::<_, chrono::DateTime<Utc>>("current_period_end"),
         period_end,
         "re-syncing the same future terminal chain row should not move current_period_end"
+    );
+    assert_eq!(
+        row.get::<_, Option<chrono::DateTime<Utc>>>("canceled_at"),
+        Some(canceled_at),
+        "re-syncing the same terminal chain row should not move canceled_at"
     );
 }
 

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -4965,6 +4965,204 @@ async fn test_list_subscriptions_tolerates_restored_hos_history_with_off_catalog
 
 #[tokio::test]
 #[serial(subscription_tests)]
+async fn test_list_subscriptions_keeps_active_off_catalog_rows_loud() {
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
+
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": {
+                "providers": { "stripe": { "price_id": "price_test_basic" } },
+                "agent_instances": { "max": 1 },
+                "monthly_credits": { "max": 1000000 }
+            }
+        }),
+    )
+    .await;
+
+    let user_email = "test_active_off_catalog_subscription@example.com";
+    let token = mock_login(&server, user_email).await;
+    insert_test_subscription_with_provider_and_price(
+        &server,
+        &db,
+        user_email,
+        "stripe",
+        "price_retired_live",
+        false,
+    )
+    .await;
+
+    let response = server
+        .get("/v1/subscriptions")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(
+        response.status_code(),
+        500,
+        "active off-catalog rows should still fail loudly: {}",
+        response.text()
+    );
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn test_near_staking_sync_prefers_active_chain_result_over_terminal_local_price() {
+    clear_proxy_env_for_local_wiremock();
+    let terminal_basic = json!({
+        "subscription_id": "sub_terminal_basic_hos",
+        "price_id": "price_hos_basic",
+        "end_ns": "1783039174474808018",
+        "status": "Expired",
+        "cancel_at_period_end": true
+    });
+    let active_pro = json!({
+        "subscription_id": "sub_active_pro_hos",
+        "price_id": "price_hos_pro",
+        "end_ns": "2000000000000000000",
+        "status": "Active",
+        "cancel_at_period_end": false
+    });
+
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with({
+            let terminal_basic = terminal_basic.clone();
+            let active_pro = active_pro.clone();
+            move |req: &wiremock::Request| {
+                use base64::{engine::general_purpose::STANDARD, Engine};
+
+                let body: serde_json::Value =
+                    serde_json::from_slice(&req.body).unwrap_or(json!({}));
+                let empty = json!({});
+                let params = body.get("params").unwrap_or(&empty);
+                match params.get("method_name").and_then(|x| x.as_str()) {
+                    Some("get_subscription_for_price") => {
+                        let args_b64 = params
+                            .get("args_base64")
+                            .and_then(|x| x.as_str())
+                            .unwrap_or("");
+                        let decoded = STANDARD
+                            .decode(args_b64)
+                            .ok()
+                            .and_then(|bytes| {
+                                serde_json::from_slice::<serde_json::Value>(&bytes).ok()
+                            })
+                            .unwrap_or_default();
+                        let price_id = decoded
+                            .get("price_id")
+                            .and_then(|x| x.as_str())
+                            .unwrap_or("");
+                        let subscription = if price_id == "price_hos_pro" {
+                            &active_pro
+                        } else {
+                            &terminal_basic
+                        };
+                        ResponseTemplate::new(200)
+                            .set_body_json(near_rpc_call_function_body(subscription))
+                    }
+                    Some("get_price") => ResponseTemplate::new(200).set_body_json(
+                        near_rpc_call_function_body(&json!({
+                            "price_id": "price_hos_pro",
+                            "product_id": "nearai|prod_cat",
+                            "amount": "2000000000000000000000000",
+                            "status": "Active"
+                        })),
+                    ),
+                    _ => ResponseTemplate::new(500).set_body_json(json!({
+                        "error": "unexpected NEAR RPC mock"
+                    })),
+                }
+            }
+        })
+        .mount(&mock)
+        .await;
+
+    let (server, db) = create_test_server_and_db(TestServerConfig {
+        near_rpc_url: Some(mock.uri().to_string()),
+        near_staking_contract_id: Some("staking.testnet".to_string()),
+        ..Default::default()
+    })
+    .await;
+
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": { "providers": { "house-of-stake": { "price_id": "price_hos_basic" } }, "agent_instances": { "max": 1 }, "monthly_credits": { "max": 1000000 } },
+            "pro": { "providers": { "house-of-stake": { "price_id": "price_hos_pro" } }, "agent_instances": { "max": 1 }, "monthly_credits": { "max": 2000000 } }
+        }),
+    )
+    .await;
+
+    let near_email = "hos_sync_prefers_active_chain.testnet@near";
+    let login = json!({
+        "email": near_email,
+        "name": "HoS Prefers Active Chain",
+        "oauth_provider": "near"
+    });
+    let response = server.post("/v1/auth/mock-login").json(&login).await;
+    let token = response.json::<serde_json::Value>()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    cleanup_user_subscriptions(&db, near_email).await;
+
+    let user = db
+        .user_repository()
+        .get_user_by_email(near_email)
+        .await
+        .unwrap()
+        .unwrap();
+    let client = db.pool().get().await.unwrap();
+    let terminal_period_end = Utc::now() - Duration::days(30);
+    client
+        .execute(
+            "INSERT INTO subscriptions (
+                subscription_id, user_id, provider, customer_id, price_id, status,
+                current_period_end, cancel_at_period_end, created_at, updated_at, canceled_at
+            ) VALUES (
+                'sub_local_terminal_basic_hos', $1, 'house-of-stake', 'cus_test',
+                'price_hos_basic', 'canceled', $2, false, NOW(), NOW(), $2
+            )",
+            &[&user.id, &terminal_period_end],
+        )
+        .await
+        .expect("seed local terminal HoS history");
+
+    let response = server
+        .post("/v1/subscriptions/near/sync")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body: serde_json::Value = response.json();
+    assert_eq!(
+        body.get("upserted_house_of_stake_row")
+            .and_then(|x| x.as_bool()),
+        Some(true)
+    );
+
+    let row = client
+        .query_one(
+            "SELECT status, price_id FROM subscriptions
+             WHERE user_id = $1 AND subscription_id = 'sub_active_pro_hos'",
+            &[&user.id],
+        )
+        .await
+        .expect("active pro chain row should be selected and upserted");
+    assert_eq!(row.get::<_, String>("status"), "active");
+    assert_eq!(row.get::<_, String>("price_id"), "price_hos_pro");
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
 async fn test_near_staking_sync_normalizes_canceled_chain_history() {
     clear_proxy_env_for_local_wiremock();
     let chain_period_end = Utc.timestamp_opt(2_000_000_000, 0).unwrap();

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -10,6 +10,7 @@ use common::{
     insert_test_subscription_with_provider_and_price, mock_login, set_subscription_plans,
     TestServerConfig,
 };
+use database::repositories::subscription_repository::CLEANUP_CANCELED_INSTANCE_USERS_SQL;
 use hmac::Mac;
 use serde_json::json;
 use serial_test::serial;
@@ -3470,6 +3471,123 @@ async fn last_cancelled_period_uses_genuine_hos_lapse() {
         got,
         Some(hos_period_end),
         "genuine HoS lapses should still anchor free-plan usage windows"
+    );
+}
+
+async fn cleanup_candidate_user_ids(
+    client: &tokio_postgres::Client,
+    cutoff: chrono::DateTime<Utc>,
+) -> Vec<UserId> {
+    let limit = 200_i64;
+    let offset = 0_i64;
+    client
+        .query(
+            CLEANUP_CANCELED_INSTANCE_USERS_SQL,
+            &[
+                &cutoff as &(dyn tokio_postgres::types::ToSql + Sync),
+                &limit,
+                &offset,
+            ],
+        )
+        .await
+        .expect("query cleanup candidates")
+        .into_iter()
+        .map(|row| row.get::<_, UserId>("user_id"))
+        .collect()
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn cleanup_candidates_use_latest_canceled_period_for_grace() {
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
+
+    let blocked_email = "test_cleanup_latest_cancel_blocked@example.com";
+    let eligible_email = "test_cleanup_latest_cancel_eligible@example.com";
+    cleanup_user_subscriptions(&db, blocked_email).await;
+    cleanup_user_subscriptions(&db, eligible_email).await;
+    let _ = mock_login(&server, blocked_email).await;
+    let _ = mock_login(&server, eligible_email).await;
+    let blocked_user = db
+        .user_repository()
+        .get_user_by_email(blocked_email)
+        .await
+        .unwrap()
+        .expect("blocked user should exist");
+    let eligible_user = db
+        .user_repository()
+        .get_user_by_email(eligible_email)
+        .await
+        .unwrap()
+        .expect("eligible user should exist");
+
+    let client = db.pool().get().await.unwrap();
+    let cutoff = Utc.with_ymd_and_hms(2026, 7, 16, 0, 0, 0).unwrap();
+    let old_period_end = cutoff - Duration::days(30);
+    let recent_period_end = cutoff + Duration::days(1);
+    let updated_at = cutoff - Duration::days(1);
+
+    client
+        .execute(
+            "INSERT INTO subscriptions (
+                subscription_id, user_id, provider, customer_id, price_id, status,
+                current_period_end, cancel_at_period_end, created_at, updated_at, canceled_at
+            ) VALUES
+                ('sub_cleanup_blocked_old', $1, 'stripe', 'cus_cleanup', 'price_test_basic', 'canceled', $3, false, $5, $5, $5),
+                ('sub_cleanup_blocked_recent', $1, 'stripe', 'cus_cleanup', 'price_test_basic', 'canceled', $4, false, $5, $5, $5),
+                ('sub_cleanup_eligible_old', $2, 'stripe', 'cus_cleanup', 'price_test_basic', 'canceled', $3, false, $5, $5, $5)",
+            &[&blocked_user.id, &eligible_user.id, &old_period_end, &recent_period_end, &updated_at],
+        )
+        .await
+        .unwrap();
+
+    let candidates = cleanup_candidate_user_ids(&client, cutoff).await;
+    assert!(
+        !candidates.contains(&blocked_user.id),
+        "a recent canceled row should preserve cleanup grace despite older canceled rows"
+    );
+    assert!(
+        candidates.contains(&eligible_user.id),
+        "users whose latest canceled period is past the cutoff should be cleanup candidates"
+    );
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn cleanup_candidates_ignore_restored_hos_only_history() {
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
+
+    let user_email = "test_cleanup_restored_hos_only@example.com";
+    cleanup_user_subscriptions(&db, user_email).await;
+    let _ = mock_login(&server, user_email).await;
+    let user = db
+        .user_repository()
+        .get_user_by_email(user_email)
+        .await
+        .unwrap()
+        .expect("user should exist");
+
+    let client = db.pool().get().await.unwrap();
+    let cutoff = Utc.with_ymd_and_hms(2026, 7, 16, 0, 0, 0).unwrap();
+    let restored_period_end = Utc.with_ymd_and_hms(2024, 5, 1, 0, 0, 0).unwrap();
+    let restored_at = cutoff + Duration::days(1);
+    client
+        .execute(
+            "INSERT INTO subscriptions (
+                subscription_id, user_id, provider, customer_id, price_id, status,
+                current_period_end, cancel_at_period_end, created_at, updated_at, canceled_at
+            ) VALUES (
+                'sub_cleanup_restored_hos_only', $1, 'house-of-stake', 'cus_cleanup',
+                'price_hos_basic', 'canceled', $2, false, $3, $3, $2
+            )",
+            &[&user.id, &restored_period_end, &restored_at],
+        )
+        .await
+        .unwrap();
+
+    let candidates = cleanup_candidate_user_ids(&client, cutoff).await;
+    assert!(
+        !candidates.contains(&user.id),
+        "back-dated restored HoS history should not make cleanup delete agent instances"
     );
 }
 

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -3328,7 +3328,7 @@ async fn last_cancelled_period_ignores_non_canceled_statuses_and_future_periods(
         .expect("user should exist");
 
     let client = db.pool().get().await.unwrap();
-    let now = Utc::now();
+    let now = Utc::now().with_nanosecond(0).unwrap();
     let canceled_end = now - Duration::days(60);
     let other_provider_canceled_end = now - Duration::days(30);
     let active_end = now + Duration::days(30);
@@ -5098,6 +5098,44 @@ async fn test_near_staking_sync_reports_retryable_skip_for_stripe_only_when_near
             .and_then(|x| x.as_bool()),
         Some(false)
     );
+    assert_eq!(
+        body.get("skipped_reason").and_then(|x| x.as_str()),
+        Some(NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE)
+    );
+
+    let user = db
+        .user_repository()
+        .get_user_by_email(near_email)
+        .await
+        .unwrap()
+        .unwrap();
+    let client = db.pool().get().await.unwrap();
+    let inactive_hos_period_end = Utc::now() - Duration::days(1);
+    client
+        .execute(
+            "INSERT INTO subscriptions (
+                subscription_id, user_id, provider, customer_id, price_id, status,
+                current_period_end, cancel_at_period_end
+            ) VALUES (
+                'sub_inactive_hos_rpc_error_context', $1, 'house-of-stake', 'cus_test',
+                'price_hos_basic', 'canceled', $2, false
+            )",
+            &[&user.id, &inactive_hos_period_end],
+        )
+        .await
+        .expect("seed inactive HoS history");
+
+    let response = server
+        .post("/v1/subscriptions/near/sync")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body: serde_json::Value = response.json();
+    assert_eq!(body.get("skipped").and_then(|x| x.as_bool()), Some(true));
     assert_eq!(
         body.get("skipped_reason").and_then(|x| x.as_str()),
         Some(NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE)

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -5581,14 +5581,12 @@ async fn test_near_staking_sync_reports_retryable_skip_for_stripe_only_when_near
         )
         .await;
 
-    assert_eq!(response.status_code(), 200, "{}", response.text());
-    let body: serde_json::Value = response.json();
-    assert_eq!(body.get("skipped").and_then(|x| x.as_bool()), Some(false));
     assert_eq!(
-        body.get("skipped_reason").and_then(|x| x.as_str()),
-        Some(NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE)
+        response.status_code(),
+        503,
+        "inactive local HoS context should keep the existing RPC failure contract: {}",
+        response.text()
     );
-    assert_eq!(body.get("retryable").and_then(|x| x.as_bool()), Some(true));
 }
 
 #[tokio::test]
@@ -6009,6 +6007,103 @@ async fn test_near_staking_sync_cancels_active_stale_hos_and_preserves_canceled_
         "sync must not re-touch already-canceled HoS history"
     );
 }
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn test_near_staking_sync_preserves_cancel_at_period_end_for_existing_active_hos_expiry() {
+    clear_proxy_env_for_local_wiremock();
+    let past_ns = (Utc::now() - Duration::hours(1))
+        .timestamp_nanos_opt()
+        .expect("nanoseconds timestamp should be representable")
+        .to_string();
+    let chain_sub = json!({
+        "subscription_id": "sub_existing_hos_expired",
+        "price_id": "price_hos_basic",
+        "end_ns": past_ns,
+        "status": "Active",
+        "cancel_at_period_end": true
+    });
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(near_rpc_wiremock_hos_subscription_probe_only(chain_sub))
+        .mount(&mock)
+        .await;
+
+    let (server, db) = create_test_server_and_db(TestServerConfig {
+        near_rpc_url: Some(mock.uri().to_string()),
+        near_staking_contract_id: Some("staking.testnet".to_string()),
+        ..Default::default()
+    })
+    .await;
+
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": { "providers": { "house-of-stake": { "price_id": "price_hos_basic" } }, "agent_instances": { "max": 1 }, "monthly_credits": { "max": 1000000 } }
+        }),
+    )
+    .await;
+
+    let near_email = "hos_sync_existing_active_expired.testnet@near";
+    let login = json!({
+        "email": near_email,
+        "name": "Existing HoS Active Expired",
+        "oauth_provider": "near"
+    });
+    let response = server.post("/v1/auth/mock-login").json(&login).await;
+    let token = response.json::<serde_json::Value>()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    cleanup_user_subscriptions(&db, near_email).await;
+
+    let user = db
+        .user_repository()
+        .get_user_by_email(near_email)
+        .await
+        .unwrap()
+        .unwrap();
+    let client = db.pool().get().await.unwrap();
+    let local_period_end = Utc::now() + Duration::days(1);
+    client
+        .execute(
+            "INSERT INTO subscriptions (
+                subscription_id, user_id, provider, customer_id, price_id, status,
+                current_period_end, cancel_at_period_end
+            ) VALUES (
+                'sub_existing_hos_expired', $1, 'house-of-stake', 'cus_test',
+                'price_hos_basic', 'active', $2, true
+            )",
+            &[&user.id, &local_period_end],
+        )
+        .await
+        .expect("seed active HoS row");
+
+    let response = server
+        .post("/v1/subscriptions/near/sync")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+
+    let row = client
+        .query_one(
+            "SELECT status, cancel_at_period_end FROM subscriptions
+             WHERE user_id = $1 AND subscription_id = 'sub_existing_hos_expired'",
+            &[&user.id],
+        )
+        .await
+        .expect("load synced existing HoS row");
+    assert_eq!(row.get::<_, String>("status"), "canceled");
+    assert!(
+        row.get::<_, bool>("cancel_at_period_end"),
+        "existing active HoS expiry keeps chain cancel_at_period_end"
+    );
+}
+
 #[tokio::test]
 #[serial(subscription_tests)]
 async fn test_near_staking_sync_marks_expired_cancel_at_period_end_row_canceled() {

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -4617,7 +4617,14 @@ async fn test_near_staking_sync_restores_expired_hos_history_when_active_stripe_
     set_subscription_plans(
         &server,
         json!({
-            "basic": { "providers": { "house-of-stake": { "price_id": "price_hos_basic" } }, "agent_instances": { "max": 1 }, "monthly_credits": { "max": 1000000 } }
+            "basic": {
+                "providers": {
+                    "stripe": { "price_id": "price_test_basic" },
+                    "house-of-stake": { "price_id": "price_hos_basic" }
+                },
+                "agent_instances": { "max": 1 },
+                "monthly_credits": { "max": 1000000 }
+            }
         }),
     )
     .await;

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -3503,10 +3503,13 @@ async fn cleanup_candidates_use_latest_canceled_period_for_grace() {
 
     let blocked_email = "test_cleanup_latest_cancel_blocked@example.com";
     let eligible_email = "test_cleanup_latest_cancel_eligible@example.com";
+    let stale_future_email = "test_cleanup_stale_future_not_permanent@example.com";
     cleanup_user_subscriptions(&db, blocked_email).await;
     cleanup_user_subscriptions(&db, eligible_email).await;
+    cleanup_user_subscriptions(&db, stale_future_email).await;
     let _ = mock_login(&server, blocked_email).await;
     let _ = mock_login(&server, eligible_email).await;
+    let _ = mock_login(&server, stale_future_email).await;
     let blocked_user = db
         .user_repository()
         .get_user_by_email(blocked_email)
@@ -3519,12 +3522,21 @@ async fn cleanup_candidates_use_latest_canceled_period_for_grace() {
         .await
         .unwrap()
         .expect("eligible user should exist");
+    let stale_future_user = db
+        .user_repository()
+        .get_user_by_email(stale_future_email)
+        .await
+        .unwrap()
+        .expect("stale future user should exist");
 
     let client = db.pool().get().await.unwrap();
     let cutoff = Utc.with_ymd_and_hms(2026, 7, 16, 0, 0, 0).unwrap();
     let old_period_end = cutoff - Duration::days(30);
     let recent_period_end = cutoff + Duration::days(1);
-    let updated_at = cutoff - Duration::days(1);
+    let far_future_period_end = Utc.with_ymd_and_hms(2030, 1, 1, 0, 0, 0).unwrap();
+    let stale_future_canceled_at = cutoff - Duration::days(10);
+    let old_canceled_at = cutoff - Duration::days(2);
+    let recent_canceled_at = cutoff - Duration::days(1);
 
     client
         .execute(
@@ -3533,9 +3545,21 @@ async fn cleanup_candidates_use_latest_canceled_period_for_grace() {
                 current_period_end, cancel_at_period_end, created_at, updated_at, canceled_at
             ) VALUES
                 ('sub_cleanup_blocked_old', $1, 'stripe', 'cus_cleanup', 'price_test_basic', 'canceled', $3, false, $5, $5, $5),
-                ('sub_cleanup_blocked_recent', $1, 'stripe', 'cus_cleanup', 'price_test_basic', 'canceled', $4, false, $5, $5, $5),
-                ('sub_cleanup_eligible_old', $2, 'stripe', 'cus_cleanup', 'price_test_basic', 'canceled', $3, false, $5, $5, $5)",
-            &[&blocked_user.id, &eligible_user.id, &old_period_end, &recent_period_end, &updated_at],
+                ('sub_cleanup_blocked_recent', $1, 'stripe', 'cus_cleanup', 'price_test_basic', 'canceled', $4, false, $6, $6, $6),
+                ('sub_cleanup_eligible_old', $2, 'stripe', 'cus_cleanup', 'price_test_basic', 'canceled', $3, false, $5, $5, $5),
+                ('sub_cleanup_stale_future', $7, 'stripe', 'cus_cleanup', 'price_test_basic', 'canceled', $8, false, $9, $9, $9),
+                ('sub_cleanup_stale_future_later_cancel', $7, 'stripe', 'cus_cleanup', 'price_test_basic', 'canceled', $3, false, $6, $6, $6)",
+            &[
+                &blocked_user.id,
+                &eligible_user.id,
+                &old_period_end,
+                &recent_period_end,
+                &old_canceled_at,
+                &recent_canceled_at,
+                &stale_future_user.id,
+                &far_future_period_end,
+                &stale_future_canceled_at,
+            ],
         )
         .await
         .unwrap();
@@ -3548,6 +3572,10 @@ async fn cleanup_candidates_use_latest_canceled_period_for_grace() {
     assert!(
         candidates.contains(&eligible_user.id),
         "users whose latest canceled period is past the cutoff should be cleanup candidates"
+    );
+    assert!(
+        candidates.contains(&stale_future_user.id),
+        "a stale far-future canceled row should not permanently block cleanup after a later eligible cancellation"
     );
 }
 

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -4869,6 +4869,102 @@ async fn test_near_staking_sync_restores_expired_hos_history_when_active_stripe_
 
 #[tokio::test]
 #[serial(subscription_tests)]
+async fn test_list_subscriptions_tolerates_restored_hos_history_with_off_catalog_price() {
+    clear_proxy_env_for_local_wiremock();
+    let chain_sub = json!({
+        "subscription_id": "sub_legacy_off_catalog_hos",
+        "price_id": "price_hos_retired",
+        "end_ns": "1783039174474808018",
+        "status": "Expired",
+        "cancel_at_period_end": true
+    });
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(near_rpc_wiremock_hos_subscription_probe_only(chain_sub))
+        .mount(&mock)
+        .await;
+
+    let (server, db) = create_test_server_and_db(TestServerConfig {
+        near_rpc_url: Some(mock.uri().to_string()),
+        near_staking_contract_id: Some("staking.testnet".to_string()),
+        ..Default::default()
+    })
+    .await;
+
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": {
+                "providers": {
+                    "stripe": { "price_id": "price_test_basic" },
+                    "house-of-stake": { "price_id": "price_hos_basic" }
+                },
+                "agent_instances": { "max": 1 },
+                "monthly_credits": { "max": 1000000 }
+            }
+        }),
+    )
+    .await;
+
+    let near_email = "hos_sync_off_catalog_history.testnet@near";
+    let login = json!({
+        "email": near_email,
+        "name": "HoS Off Catalog History",
+        "oauth_provider": "near"
+    });
+    let response = server.post("/v1/auth/mock-login").json(&login).await;
+    let token = response.json::<serde_json::Value>()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    cleanup_user_subscriptions(&db, near_email).await;
+    insert_test_subscription(&server, &db, near_email, false).await;
+
+    let response = server
+        .post("/v1/subscriptions/near/sync")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body: serde_json::Value = response.json();
+    assert_eq!(
+        body.get("upserted_house_of_stake_row")
+            .and_then(|x| x.as_bool()),
+        Some(true)
+    );
+
+    let response = server
+        .get("/v1/subscriptions?include_inactive=true")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body: serde_json::Value = response.json();
+    let subscriptions = body["subscriptions"]
+        .as_array()
+        .expect("subscriptions should be an array");
+    assert!(
+        subscriptions.iter().any(|sub| {
+            sub["subscription_id"] == "sub_legacy_off_catalog_hos"
+                && sub["provider"] == "house-of-stake"
+                && sub["price_id"] == "price_hos_retired"
+                && sub["plan"] == "unknown"
+                && sub["status"] == "canceled"
+        }),
+        "include_inactive=true should return off-catalog restored HoS history as unknown plan: {subscriptions:?}"
+    );
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
 async fn test_near_staking_sync_normalizes_canceled_chain_history() {
     clear_proxy_env_for_local_wiremock();
     let chain_period_end = Utc.timestamp_opt(2_000_000_000, 0).unwrap();
@@ -5245,7 +5341,7 @@ async fn test_near_staking_sync_reports_retryable_skip_for_stripe_only_when_near
 
     assert_eq!(response.status_code(), 200, "{}", response.text());
     let body: serde_json::Value = response.json();
-    assert_eq!(body.get("skipped").and_then(|x| x.as_bool()), Some(true));
+    assert_eq!(body.get("skipped").and_then(|x| x.as_bool()), Some(false));
     assert_eq!(
         body.get("upserted_house_of_stake_row")
             .and_then(|x| x.as_bool()),
@@ -5289,7 +5385,7 @@ async fn test_near_staking_sync_reports_retryable_skip_for_stripe_only_when_near
 
     assert_eq!(response.status_code(), 200, "{}", response.text());
     let body: serde_json::Value = response.json();
-    assert_eq!(body.get("skipped").and_then(|x| x.as_bool()), Some(true));
+    assert_eq!(body.get("skipped").and_then(|x| x.as_bool()), Some(false));
     assert_eq!(
         body.get("skipped_reason").and_then(|x| x.as_str()),
         Some(NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE)

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -4799,6 +4799,31 @@ async fn test_near_staking_sync_normalizes_canceled_chain_history() {
         before_sync <= period_end && period_end <= after_sync,
         "future canceled HoS period end should be clamped to sync time, got {period_end}"
     );
+
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    let response = server
+        .post("/v1/subscriptions/near/sync")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let row = client
+        .query_one(
+            "SELECT current_period_end
+             FROM subscriptions
+             WHERE user_id = $1 AND subscription_id = 'sub_chain_future_canceled_hos'",
+            &[&user.id],
+        )
+        .await
+        .expect("canceled HoS history should still be present");
+    assert_eq!(
+        row.get::<_, chrono::DateTime<Utc>>("current_period_end"),
+        period_end,
+        "re-syncing the same future terminal chain row should not move current_period_end"
+    );
 }
 
 #[tokio::test]

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -3314,7 +3314,7 @@ async fn last_cancelled_period_uses_latest_canceled_period_end() {
 
 #[tokio::test]
 #[serial(subscription_tests)]
-async fn last_cancelled_period_ignores_non_canceled_statuses() {
+async fn last_cancelled_period_ignores_non_canceled_statuses_and_future_periods() {
     let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 
     let user_email = "test_free_anchor_ignore_non_canceled@example.com";
@@ -3328,10 +3328,12 @@ async fn last_cancelled_period_ignores_non_canceled_statuses() {
         .expect("user should exist");
 
     let client = db.pool().get().await.unwrap();
-    let canceled_end = Utc.with_ymd_and_hms(2026, 3, 19, 0, 0, 0).unwrap();
-    let active_end = Utc.with_ymd_and_hms(2027, 12, 31, 23, 59, 59).unwrap();
-    let incomplete_end = Utc.with_ymd_and_hms(2028, 1, 1, 0, 0, 0).unwrap();
-    let other_provider_canceled_end = Utc.with_ymd_and_hms(2030, 1, 1, 0, 0, 0).unwrap();
+    let now = Utc::now();
+    let canceled_end = now - Duration::days(60);
+    let other_provider_canceled_end = now - Duration::days(30);
+    let active_end = now + Duration::days(30);
+    let incomplete_end = now + Duration::days(60);
+    let future_canceled_end = now + Duration::days(90);
 
     client
         .execute(
@@ -3340,6 +3342,16 @@ async fn last_cancelled_period_ignores_non_canceled_statuses() {
                 current_period_end, cancel_at_period_end
             ) VALUES ($1, $2, 'stripe', 'cus_x', 'price_test_basic', 'canceled', $3, false)",
             &[&"sub_only_canceled", &user.id, &canceled_end],
+        )
+        .await
+        .unwrap();
+    client
+        .execute(
+            "INSERT INTO subscriptions (
+                subscription_id, user_id, provider, customer_id, price_id, status,
+                current_period_end, cancel_at_period_end
+            ) VALUES ($1, $2, 'stripe', 'cus_x', 'price_test_basic', 'canceled', $3, false)",
+            &[&"sub_future_canceled", &user.id, &future_canceled_end],
         )
         .await
         .unwrap();
@@ -3386,7 +3398,7 @@ async fn last_cancelled_period_ignores_non_canceled_statuses() {
     assert_eq!(
         got,
         Some(other_provider_canceled_end),
-        "latest canceled row should win regardless of provider"
+        "latest ended canceled row should win regardless of provider; future canceled rows are ignored"
     );
 }
 

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -4833,6 +4833,104 @@ async fn test_near_staking_sync_normalizes_canceled_chain_history() {
 
 #[tokio::test]
 #[serial(subscription_tests)]
+async fn test_near_staking_sync_preserves_later_past_chain_period_end() {
+    clear_proxy_env_for_local_wiremock();
+    let local_period_end = Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap();
+    let chain_period_end = Utc.with_ymd_and_hms(2026, 6, 15, 0, 0, 0).unwrap();
+    let chain_sub = json!({
+        "subscription_id": "sub_chain_later_past_canceled_hos",
+        "price_id": "price_hos_basic",
+        "end_ns": chain_period_end
+            .timestamp_nanos_opt()
+            .expect("nanoseconds timestamp should be representable")
+            .to_string(),
+        "status": "Expired",
+        "cancel_at_period_end": true
+    });
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(near_rpc_wiremock_hos_subscription_probe_only(chain_sub))
+        .mount(&mock)
+        .await;
+
+    let (server, db) = create_test_server_and_db(TestServerConfig {
+        near_rpc_url: Some(mock.uri().to_string()),
+        near_staking_contract_id: Some("staking.testnet".to_string()),
+        ..Default::default()
+    })
+    .await;
+
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": { "providers": { "house-of-stake": { "price_id": "price_hos_basic" } }, "agent_instances": { "max": 1 }, "monthly_credits": { "max": 1000000 } }
+        }),
+    )
+    .await;
+
+    let near_email = "hos_sync_preserve_later_past.testnet@near";
+    let login = json!({
+        "email": near_email,
+        "name": "HoS Preserve Later Past Period",
+        "oauth_provider": "near"
+    });
+    let response = server.post("/v1/auth/mock-login").json(&login).await;
+    let token = response.json::<serde_json::Value>()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    cleanup_user_subscriptions(&db, near_email).await;
+    let user = db
+        .user_repository()
+        .get_user_by_email(near_email)
+        .await
+        .unwrap()
+        .unwrap();
+    let client = db.pool().get().await.unwrap();
+    client
+        .execute(
+            "INSERT INTO subscriptions (
+                subscription_id, user_id, provider, customer_id, price_id, status,
+                current_period_end, cancel_at_period_end
+            ) VALUES (
+                'sub_chain_later_past_canceled_hos', $1, 'house-of-stake', 'cus_test',
+                'price_hos_basic', 'canceled', $2, false
+            )",
+            &[&user.id, &local_period_end],
+        )
+        .await
+        .expect("seed stale local HoS history");
+
+    let response = server
+        .post("/v1/subscriptions/near/sync")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let row = client
+        .query_one(
+            "SELECT current_period_end, cancel_at_period_end
+             FROM subscriptions
+             WHERE user_id = $1 AND subscription_id = 'sub_chain_later_past_canceled_hos'",
+            &[&user.id],
+        )
+        .await
+        .expect("load synced HoS history");
+    assert_eq!(
+        row.get::<_, chrono::DateTime<Utc>>("current_period_end"),
+        chain_period_end,
+        "past terminal chain period should replace stale earlier local history"
+    );
+    assert!(!row.get::<_, bool>("cancel_at_period_end"));
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
 async fn test_near_staking_sync_noops_when_active_stripe_and_chain_returns_null() {
     clear_proxy_env_for_local_wiremock();
     let mock = MockServer::start().await;

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -18,7 +18,8 @@ use services::aml::{
     AmlRiskLevel, AmlRiskService,
 };
 use services::subscription::ports::{
-    ChangePlanOutcome, NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS,
+    ChangePlanOutcome, NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE,
+    NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS,
 };
 use services::subscription::SubscriptionRepository;
 use services::system_configs::ports::RateLimitConfig;
@@ -4681,7 +4682,7 @@ async fn test_near_staking_sync_restores_expired_hos_history_when_active_stripe_
     assert_eq!(row.get::<_, String>("provider"), "house-of-stake");
     assert_eq!(row.get::<_, String>("price_id"), "price_hos_basic");
     assert_eq!(row.get::<_, String>("status"), "canceled");
-    assert!(row.get::<_, bool>("cancel_at_period_end"));
+    assert!(!row.get::<_, bool>("cancel_at_period_end"));
     assert_eq!(
         row.get::<_, chrono::DateTime<Utc>>("current_period_end"),
         Utc.with_ymd_and_hms(2026, 7, 3, 0, 39, 34).unwrap() + Duration::microseconds(474_808)
@@ -4707,6 +4708,96 @@ async fn test_near_staking_sync_restores_expired_hos_history_when_active_stripe_
                 && sub["status"] == "canceled"
         }),
         "include_inactive=true should return restored HoS history: {subscriptions:?}"
+    );
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn test_near_staking_sync_normalizes_canceled_chain_history() {
+    clear_proxy_env_for_local_wiremock();
+    let chain_sub = json!({
+        "subscription_id": "sub_chain_future_canceled_hos",
+        "price_id": "price_hos_basic",
+        "end_ns": "2000000000000000000",
+        "status": "Cancelled",
+        "cancel_at_period_end": true
+    });
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(near_rpc_wiremock_hos_subscription_probe_only(chain_sub))
+        .mount(&mock)
+        .await;
+
+    let (server, db) = create_test_server_and_db(TestServerConfig {
+        near_rpc_url: Some(mock.uri().to_string()),
+        near_staking_contract_id: Some("staking.testnet".to_string()),
+        ..Default::default()
+    })
+    .await;
+
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": { "providers": { "house-of-stake": { "price_id": "price_hos_basic" } }, "agent_instances": { "max": 1 }, "monthly_credits": { "max": 1000000 } }
+        }),
+    )
+    .await;
+
+    let near_email = "hos_sync_normalize_canceled.testnet@near";
+    let login = json!({
+        "email": near_email,
+        "name": "HoS Normalize Canceled",
+        "oauth_provider": "near"
+    });
+    let response = server.post("/v1/auth/mock-login").json(&login).await;
+    let token = response.json::<serde_json::Value>()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    cleanup_user_subscriptions(&db, near_email).await;
+    let before_sync = Utc::now() - Duration::seconds(1);
+
+    let response = server
+        .post("/v1/subscriptions/near/sync")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    let after_sync = Utc::now() + Duration::seconds(1);
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body: serde_json::Value = response.json();
+    assert_eq!(
+        body.get("upserted_house_of_stake_row")
+            .and_then(|x| x.as_bool()),
+        Some(true)
+    );
+
+    let user = db
+        .user_repository()
+        .get_user_by_email(near_email)
+        .await
+        .unwrap()
+        .unwrap();
+    let client = db.pool().get().await.unwrap();
+    let row = client
+        .query_one(
+            "SELECT status, current_period_end, cancel_at_period_end
+             FROM subscriptions
+             WHERE user_id = $1 AND subscription_id = 'sub_chain_future_canceled_hos'",
+            &[&user.id],
+        )
+        .await
+        .expect("canceled HoS history should be restored");
+    let period_end = row.get::<_, chrono::DateTime<Utc>>("current_period_end");
+    assert_eq!(row.get::<_, String>("status"), "canceled");
+    assert!(!row.get::<_, bool>("cancel_at_period_end"));
+    assert!(
+        before_sync <= period_end && period_end <= after_sync,
+        "future canceled HoS period end should be clamped to sync time, got {period_end}"
     );
 }
 
@@ -4803,7 +4894,7 @@ async fn test_near_staking_sync_noops_when_active_stripe_and_chain_returns_null(
 
 #[tokio::test]
 #[serial(subscription_tests)]
-async fn test_near_staking_sync_noops_for_stripe_only_when_near_rpc_errors() {
+async fn test_near_staking_sync_reports_retryable_skip_for_stripe_only_when_near_rpc_errors() {
     clear_proxy_env_for_local_wiremock();
     let mock = MockServer::start().await;
     Mock::given(method("POST"))
@@ -4861,13 +4952,16 @@ async fn test_near_staking_sync_noops_for_stripe_only_when_near_rpc_errors() {
 
     assert_eq!(response.status_code(), 200, "{}", response.text());
     let body: serde_json::Value = response.json();
-    assert_eq!(body.get("skipped").and_then(|x| x.as_bool()), Some(false));
+    assert_eq!(body.get("skipped").and_then(|x| x.as_bool()), Some(true));
     assert_eq!(
         body.get("upserted_house_of_stake_row")
             .and_then(|x| x.as_bool()),
         Some(false)
     );
-    assert_eq!(body.get("skipped_reason"), None);
+    assert_eq!(
+        body.get("skipped_reason").and_then(|x| x.as_str()),
+        Some(NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE)
+    );
 }
 
 #[tokio::test]

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -4712,6 +4712,166 @@ async fn test_near_staking_sync_restores_expired_hos_history_when_active_stripe_
 
 #[tokio::test]
 #[serial(subscription_tests)]
+async fn test_near_staking_sync_noops_when_active_stripe_and_chain_returns_null() {
+    clear_proxy_env_for_local_wiremock();
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(near_rpc_call_function_body(&serde_json::Value::Null)),
+        )
+        .mount(&mock)
+        .await;
+
+    let (server, db) = create_test_server_and_db(TestServerConfig {
+        near_rpc_url: Some(mock.uri().to_string()),
+        near_staking_contract_id: Some("staking.testnet".to_string()),
+        ..Default::default()
+    })
+    .await;
+
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": {
+                "providers": {
+                    "stripe": { "price_id": "price_test_basic" },
+                    "house-of-stake": { "price_id": "price_hos_basic" }
+                },
+                "agent_instances": { "max": 1 },
+                "monthly_credits": { "max": 1000000 }
+            }
+        }),
+    )
+    .await;
+
+    let near_email = "hos_sync_stripe_only_chain_null.testnet@near";
+    let login = json!({
+        "email": near_email,
+        "name": "HoS Stripe Only Chain Null",
+        "oauth_provider": "near"
+    });
+    let response = server.post("/v1/auth/mock-login").json(&login).await;
+    let token = response.json::<serde_json::Value>()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    cleanup_user_subscriptions(&db, near_email).await;
+    insert_test_subscription(&server, &db, near_email, false).await;
+
+    let response = server
+        .post("/v1/subscriptions/near/sync")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body: serde_json::Value = response.json();
+    assert_eq!(body.get("skipped").and_then(|x| x.as_bool()), Some(false));
+    assert_eq!(
+        body.get("upserted_house_of_stake_row")
+            .and_then(|x| x.as_bool()),
+        Some(false)
+    );
+    assert_eq!(body.get("skipped_reason"), None);
+
+    let user = db
+        .user_repository()
+        .get_user_by_email(near_email)
+        .await
+        .unwrap()
+        .unwrap();
+    let client = db.pool().get().await.unwrap();
+    let count: i64 = client
+        .query_one(
+            "SELECT COUNT(*)::bigint FROM subscriptions
+             WHERE user_id = $1 AND provider = 'house-of-stake'",
+            &[&user.id],
+        )
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(
+        count, 0,
+        "Stripe-only no-chain sync should not create HoS rows"
+    );
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn test_near_staking_sync_noops_for_stripe_only_when_near_rpc_errors() {
+    clear_proxy_env_for_local_wiremock();
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(json!({
+            "error": "NEAR RPC unavailable"
+        })))
+        .mount(&mock)
+        .await;
+
+    let (server, db) = create_test_server_and_db(TestServerConfig {
+        near_rpc_url: Some(mock.uri().to_string()),
+        near_staking_contract_id: Some("staking.testnet".to_string()),
+        ..Default::default()
+    })
+    .await;
+
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": {
+                "providers": {
+                    "stripe": { "price_id": "price_test_basic" },
+                    "house-of-stake": { "price_id": "price_hos_basic" }
+                },
+                "agent_instances": { "max": 1 },
+                "monthly_credits": { "max": 1000000 }
+            }
+        }),
+    )
+    .await;
+
+    let near_email = "hos_sync_stripe_only_rpc_error.testnet@near";
+    let login = json!({
+        "email": near_email,
+        "name": "HoS Stripe Only RPC Error",
+        "oauth_provider": "near"
+    });
+    let response = server.post("/v1/auth/mock-login").json(&login).await;
+    let token = response.json::<serde_json::Value>()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    cleanup_user_subscriptions(&db, near_email).await;
+    insert_test_subscription(&server, &db, near_email, false).await;
+
+    let response = server
+        .post("/v1/subscriptions/near/sync")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body: serde_json::Value = response.json();
+    assert_eq!(body.get("skipped").and_then(|x| x.as_bool()), Some(false));
+    assert_eq!(
+        body.get("upserted_house_of_stake_row")
+            .and_then(|x| x.as_bool()),
+        Some(false)
+    );
+    assert_eq!(body.get("skipped_reason"), None);
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
 async fn test_near_staking_sync_marks_local_hos_canceled_when_chain_returns_null() {
     clear_proxy_env_for_local_wiremock();
     let mock = MockServer::start().await;

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -4732,10 +4732,14 @@ async fn test_near_staking_sync_restores_expired_hos_history_when_active_stripe_
 #[serial(subscription_tests)]
 async fn test_near_staking_sync_normalizes_canceled_chain_history() {
     clear_proxy_env_for_local_wiremock();
+    let chain_period_end = Utc.timestamp_opt(2_000_000_000, 0).unwrap();
     let chain_sub = json!({
         "subscription_id": "sub_chain_future_canceled_hos",
         "price_id": "price_hos_basic",
-        "end_ns": "2000000000000000000",
+        "end_ns": chain_period_end
+            .timestamp_nanos_opt()
+            .expect("nanoseconds timestamp should be representable")
+            .to_string(),
         "status": "Cancelled",
         "cancel_at_period_end": true
     });
@@ -4774,7 +4778,6 @@ async fn test_near_staking_sync_normalizes_canceled_chain_history() {
         .to_string();
 
     cleanup_user_subscriptions(&db, near_email).await;
-    let before_sync = Utc::now() - Duration::seconds(1);
 
     let response = server
         .post("/v1/subscriptions/near/sync")
@@ -4784,7 +4787,6 @@ async fn test_near_staking_sync_normalizes_canceled_chain_history() {
         )
         .await;
 
-    let after_sync = Utc::now() + Duration::seconds(1);
     assert_eq!(response.status_code(), 200, "{}", response.text());
     let body: serde_json::Value = response.json();
     assert_eq!(
@@ -4812,9 +4814,9 @@ async fn test_near_staking_sync_normalizes_canceled_chain_history() {
     let period_end = row.get::<_, chrono::DateTime<Utc>>("current_period_end");
     assert_eq!(row.get::<_, String>("status"), "canceled");
     assert!(!row.get::<_, bool>("cancel_at_period_end"));
-    assert!(
-        before_sync <= period_end && period_end <= after_sync,
-        "future canceled HoS period end should be clamped to sync time, got {period_end}"
+    assert_eq!(
+        period_end, chain_period_end,
+        "future terminal HoS period end should stay chain-authored"
     );
 
     tokio::time::sleep(std::time::Duration::from_millis(10)).await;

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -3330,8 +3330,10 @@ async fn last_cancelled_period_deprioritizes_restored_hos_updated_at() {
     let client = db.pool().get().await.unwrap();
     let stripe_period_end = Utc.with_ymd_and_hms(2026, 2, 1, 0, 0, 0).unwrap();
     let hos_history_period_end = Utc.with_ymd_and_hms(2024, 5, 1, 0, 0, 0).unwrap();
+    let ended_future_hos_period_end = Utc.with_ymd_and_hms(2026, 7, 1, 0, 0, 0).unwrap();
     let stripe_updated_at = Utc.with_ymd_and_hms(2026, 2, 1, 0, 0, 0).unwrap();
     let restored_hos_updated_at = Utc.with_ymd_and_hms(2026, 7, 26, 0, 0, 0).unwrap();
+    let early_hos_restore_updated_at = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
 
     client
         .execute(
@@ -3340,6 +3342,21 @@ async fn last_cancelled_period_deprioritizes_restored_hos_updated_at() {
                 current_period_end, cancel_at_period_end, created_at, updated_at
             ) VALUES ($1, $2, 'stripe', 'cus_anchor', 'price_test_basic', 'canceled', $3, false, $4, $4)",
             &[&"sub_free_anchor_stripe", &user.id, &stripe_period_end, &stripe_updated_at],
+        )
+        .await
+        .unwrap();
+    client
+        .execute(
+            "INSERT INTO subscriptions (
+                subscription_id, user_id, provider, customer_id, price_id, status,
+                current_period_end, cancel_at_period_end, created_at, updated_at
+            ) VALUES ($1, $2, 'house-of-stake', 'cus_anchor', 'price_hos_basic', 'canceled', $3, false, $4, $4)",
+            &[
+                &"sub_free_anchor_ended_future_hos",
+                &user.id,
+                &ended_future_hos_period_end,
+                &early_hos_restore_updated_at,
+            ],
         )
         .await
         .unwrap();
@@ -5163,6 +5180,7 @@ async fn test_near_staking_sync_reports_retryable_skip_for_stripe_only_when_near
         body.get("skipped_reason").and_then(|x| x.as_str()),
         Some(NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE)
     );
+    assert_eq!(body.get("retryable").and_then(|x| x.as_bool()), Some(true));
 
     let user = db
         .user_repository()
@@ -5201,6 +5219,7 @@ async fn test_near_staking_sync_reports_retryable_skip_for_stripe_only_when_near
         body.get("skipped_reason").and_then(|x| x.as_str()),
         Some(NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE)
     );
+    assert_eq!(body.get("retryable").and_then(|x| x.as_bool()), Some(true));
 }
 
 #[tokio::test]

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -3390,7 +3390,7 @@ async fn last_cancelled_period_deprioritizes_restored_hos_updated_at() {
 
 #[tokio::test]
 #[serial(subscription_tests)]
-async fn last_cancelled_period_ignores_non_canceled_statuses_and_future_periods() {
+async fn last_cancelled_period_ignores_non_canceled_statuses_and_future_hos_periods() {
     let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 
     let user_email = "test_free_anchor_ignore_non_canceled@example.com";
@@ -3409,7 +3409,7 @@ async fn last_cancelled_period_ignores_non_canceled_statuses_and_future_periods(
     let other_provider_canceled_end = now - Duration::days(30);
     let active_end = now + Duration::days(30);
     let incomplete_end = now + Duration::days(60);
-    let future_canceled_end = now + Duration::days(90);
+    let future_hos_canceled_end = now + Duration::days(90);
 
     client
         .execute(
@@ -3426,8 +3426,12 @@ async fn last_cancelled_period_ignores_non_canceled_statuses_and_future_periods(
             "INSERT INTO subscriptions (
                 subscription_id, user_id, provider, customer_id, price_id, status,
                 current_period_end, cancel_at_period_end
-            ) VALUES ($1, $2, 'stripe', 'cus_x', 'price_test_basic', 'canceled', $3, false)",
-            &[&"sub_future_canceled", &user.id, &future_canceled_end],
+            ) VALUES ($1, $2, 'house-of-stake', 'cus_x', 'price_hos_basic', 'canceled', $3, false)",
+            &[
+                &"sub_future_hos_canceled",
+                &user.id,
+                &future_hos_canceled_end,
+            ],
         )
         .await
         .unwrap();
@@ -3474,7 +3478,62 @@ async fn last_cancelled_period_ignores_non_canceled_statuses_and_future_periods(
     assert_eq!(
         got,
         Some(other_provider_canceled_end),
-        "latest ended canceled row should win regardless of provider; future canceled rows are ignored"
+        "latest ended canceled row should win regardless of provider; future HoS terminal rows are ignored"
+    );
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn last_cancelled_period_preserves_future_non_hos_updated_at_ordering() {
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
+
+    let user_email = "test_free_anchor_future_non_hos@example.com";
+    cleanup_user_subscriptions(&db, user_email).await;
+    let _ = mock_login(&server, user_email).await;
+    let user = db
+        .user_repository()
+        .get_user_by_email(user_email)
+        .await
+        .unwrap()
+        .expect("user should exist");
+
+    let client = db.pool().get().await.unwrap();
+    let now = Utc::now().with_nanosecond(0).unwrap();
+    let ended_period = now - Duration::days(30);
+    let future_period = now + Duration::days(30);
+    let older_updated_at = now - Duration::days(2);
+    let newer_updated_at = now - Duration::days(1);
+
+    client
+        .execute(
+            "INSERT INTO subscriptions (
+                subscription_id, user_id, provider, customer_id, price_id, status,
+                current_period_end, cancel_at_period_end, created_at, updated_at
+            ) VALUES ($1, $2, 'stripe', 'cus_anchor', 'price_test_basic', 'canceled', $3, false, $4, $4)",
+            &[&"sub_ended_non_hos_anchor", &user.id, &ended_period, &older_updated_at],
+        )
+        .await
+        .unwrap();
+    client
+        .execute(
+            "INSERT INTO subscriptions (
+                subscription_id, user_id, provider, customer_id, price_id, status,
+                current_period_end, cancel_at_period_end, created_at, updated_at
+            ) VALUES ($1, $2, 'stripe', 'cus_anchor', 'price_test_basic', 'canceled', $3, false, $4, $4)",
+            &[&"sub_future_non_hos_anchor", &user.id, &future_period, &newer_updated_at],
+        )
+        .await
+        .unwrap();
+
+    let got = db
+        .subscription_repository()
+        .last_cancelled_subscription_period_end_for_user(user.id)
+        .await
+        .unwrap();
+    assert_eq!(
+        got,
+        Some(future_period),
+        "future non-HoS cancellations should keep legacy updated_at ordering"
     );
 }
 

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -3394,6 +3394,46 @@ async fn last_cancelled_period_deprioritizes_restored_hos_updated_at() {
 
 #[tokio::test]
 #[serial(subscription_tests)]
+async fn last_cancelled_period_ignores_hos_only_history() {
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
+
+    let user_email = "test_free_anchor_hos_only_history@example.com";
+    cleanup_user_subscriptions(&db, user_email).await;
+    let _ = mock_login(&server, user_email).await;
+    let user = db
+        .user_repository()
+        .get_user_by_email(user_email)
+        .await
+        .unwrap()
+        .expect("user should exist");
+
+    let client = db.pool().get().await.unwrap();
+    let hos_period_end = Utc.with_ymd_and_hms(2024, 5, 1, 0, 0, 0).unwrap();
+    let hos_updated_at = Utc.with_ymd_and_hms(2026, 7, 26, 0, 0, 0).unwrap();
+    client
+        .execute(
+            "INSERT INTO subscriptions (
+                subscription_id, user_id, provider, customer_id, price_id, status,
+                current_period_end, cancel_at_period_end, created_at, updated_at, canceled_at
+            ) VALUES ($1, $2, 'house-of-stake', 'cus_anchor', 'price_hos_basic', 'canceled', $3, false, $4, $4, $3)",
+            &[&"sub_free_anchor_hos_only", &user.id, &hos_period_end, &hos_updated_at],
+        )
+        .await
+        .unwrap();
+
+    let got = db
+        .subscription_repository()
+        .last_cancelled_subscription_period_end_for_user(user.id)
+        .await
+        .unwrap();
+    assert_eq!(
+        got, None,
+        "HoS inactive history should not move free-plan usage windows"
+    );
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
 async fn last_cancelled_period_ignores_non_canceled_statuses_and_future_hos_periods() {
     let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -18,8 +18,7 @@ use services::aml::{
     AmlRiskLevel, AmlRiskService,
 };
 use services::subscription::ports::{
-    ChangePlanOutcome, NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE,
-    NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS,
+    ChangePlanOutcome, NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS,
 };
 use services::subscription::SubscriptionRepository;
 use services::system_configs::ports::RateLimitConfig;
@@ -3434,6 +3433,48 @@ async fn last_cancelled_period_ignores_hos_only_history() {
 
 #[tokio::test]
 #[serial(subscription_tests)]
+async fn last_cancelled_period_uses_genuine_hos_lapse() {
+    let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
+
+    let user_email = "test_free_anchor_genuine_hos_lapse@example.com";
+    cleanup_user_subscriptions(&db, user_email).await;
+    let _ = mock_login(&server, user_email).await;
+    let user = db
+        .user_repository()
+        .get_user_by_email(user_email)
+        .await
+        .unwrap()
+        .expect("user should exist");
+
+    let client = db.pool().get().await.unwrap();
+    let created_at = Utc.with_ymd_and_hms(2026, 7, 1, 0, 0, 0).unwrap();
+    let hos_period_end = Utc.with_ymd_and_hms(2026, 7, 20, 0, 0, 0).unwrap();
+    let canceled_at = Utc.with_ymd_and_hms(2026, 7, 26, 0, 0, 0).unwrap();
+    client
+        .execute(
+            "INSERT INTO subscriptions (
+                subscription_id, user_id, provider, customer_id, price_id, status,
+                current_period_end, cancel_at_period_end, created_at, updated_at, canceled_at
+            ) VALUES ($1, $2, 'house-of-stake', 'cus_anchor', 'price_hos_basic', 'canceled', $3, false, $4, $5, $5)",
+            &[&"sub_free_anchor_genuine_hos_lapse", &user.id, &hos_period_end, &created_at, &canceled_at],
+        )
+        .await
+        .unwrap();
+
+    let got = db
+        .subscription_repository()
+        .last_cancelled_subscription_period_end_for_user(user.id)
+        .await
+        .unwrap();
+    assert_eq!(
+        got,
+        Some(hos_period_end),
+        "genuine HoS lapses should still anchor free-plan usage windows"
+    );
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
 async fn last_cancelled_period_ignores_non_canceled_statuses_and_future_hos_periods() {
     let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 
@@ -5521,7 +5562,7 @@ async fn test_near_staking_sync_noops_when_active_stripe_and_chain_returns_null(
 
 #[tokio::test]
 #[serial(subscription_tests)]
-async fn test_near_staking_sync_reports_retryable_skip_for_stripe_only_when_near_rpc_errors() {
+async fn test_near_staking_sync_returns_503_for_stripe_only_when_near_rpc_errors() {
     clear_proxy_env_for_local_wiremock();
     let mock = MockServer::start().await;
     Mock::given(method("POST"))
@@ -5577,19 +5618,12 @@ async fn test_near_staking_sync_reports_retryable_skip_for_stripe_only_when_near
         )
         .await;
 
-    assert_eq!(response.status_code(), 200, "{}", response.text());
-    let body: serde_json::Value = response.json();
-    assert_eq!(body.get("skipped").and_then(|x| x.as_bool()), Some(false));
     assert_eq!(
-        body.get("upserted_house_of_stake_row")
-            .and_then(|x| x.as_bool()),
-        Some(false)
+        response.status_code(),
+        503,
+        "RPC failure should stay visible to existing clients: {}",
+        response.text()
     );
-    assert_eq!(
-        body.get("skipped_reason").and_then(|x| x.as_str()),
-        Some(NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE)
-    );
-    assert_eq!(body.get("retryable").and_then(|x| x.as_bool()), Some(true));
 
     let user = db
         .user_repository()

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -3255,7 +3255,7 @@ async fn test_subscription_gating_full_flow() {
 
 #[tokio::test]
 #[serial(subscription_tests)]
-async fn last_cancelled_period_uses_most_recent_canceled_row() {
+async fn last_cancelled_period_uses_latest_canceled_period_end() {
     let (server, db) = create_test_server_and_db(TestServerConfig::default()).await;
 
     let user_email = "test_free_anchor_max_canceled@example.com";
@@ -3269,10 +3269,10 @@ async fn last_cancelled_period_uses_most_recent_canceled_row() {
         .expect("user should exist");
 
     let client = db.pool().get().await.unwrap();
-    let older_row_period_end = Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap();
-    let newer_row_period_end = Utc.with_ymd_and_hms(2026, 3, 19, 8, 0, 0).unwrap();
-    let older_updated_at = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
-    let newer_updated_at = Utc.with_ymd_and_hms(2026, 1, 2, 0, 0, 0).unwrap();
+    let later_period_end = Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap();
+    let restored_history_period_end = Utc.with_ymd_and_hms(2026, 3, 19, 8, 0, 0).unwrap();
+    let original_updated_at = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+    let restored_history_updated_at = Utc.with_ymd_and_hms(2026, 1, 2, 0, 0, 0).unwrap();
 
     client
         .execute(
@@ -3280,7 +3280,7 @@ async fn last_cancelled_period_uses_most_recent_canceled_row() {
                 subscription_id, user_id, provider, customer_id, price_id, status,
                 current_period_end, cancel_at_period_end, created_at, updated_at
             ) VALUES ($1, $2, 'stripe', 'cus_anchor', 'price_test_basic', 'canceled', $3, false, $4, $4)",
-            &[&"sub_free_anchor_old", &user.id, &older_row_period_end, &older_updated_at],
+            &[&"sub_free_anchor_latest_period", &user.id, &later_period_end, &original_updated_at],
         )
         .await
         .unwrap();
@@ -3290,7 +3290,12 @@ async fn last_cancelled_period_uses_most_recent_canceled_row() {
                 subscription_id, user_id, provider, customer_id, price_id, status,
                 current_period_end, cancel_at_period_end, created_at, updated_at
             ) VALUES ($1, $2, 'stripe', 'cus_anchor', 'price_test_basic', 'canceled', $3, false, $4, $4)",
-            &[&"sub_free_anchor_new", &user.id, &newer_row_period_end, &newer_updated_at],
+            &[
+                &"sub_free_anchor_restored_history",
+                &user.id,
+                &restored_history_period_end,
+                &restored_history_updated_at,
+            ],
         )
         .await
         .unwrap();
@@ -3302,8 +3307,8 @@ async fn last_cancelled_period_uses_most_recent_canceled_row() {
         .unwrap();
     assert_eq!(
         got,
-        Some(newer_row_period_end),
-        "latest canceled row (by updated_at) should win, not greatest period_end"
+        Some(later_period_end),
+        "latest canceled period end should win even when an older restored row has newer updated_at"
     );
 }
 

--- a/crates/database/src/migrations/sql/V36__add_subscription_canceled_at.sql
+++ b/crates/database/src/migrations/sql/V36__add_subscription_canceled_at.sql
@@ -2,5 +2,8 @@ ALTER TABLE subscriptions
     ADD COLUMN canceled_at TIMESTAMPTZ;
 
 UPDATE subscriptions
-SET canceled_at = updated_at
+SET canceled_at = CASE
+    WHEN provider = 'house-of-stake' THEN LEAST(updated_at, current_period_end)
+    ELSE updated_at
+END
 WHERE status = 'canceled' AND canceled_at IS NULL;

--- a/crates/database/src/migrations/sql/V36__add_subscription_canceled_at.sql
+++ b/crates/database/src/migrations/sql/V36__add_subscription_canceled_at.sql
@@ -1,0 +1,10 @@
+ALTER TABLE subscriptions
+    ADD COLUMN canceled_at TIMESTAMPTZ;
+
+UPDATE subscriptions
+SET canceled_at = updated_at
+WHERE status = 'canceled' AND canceled_at IS NULL;
+
+CREATE INDEX idx_subscriptions_user_canceled_at
+    ON subscriptions(user_id, canceled_at DESC)
+    WHERE status = 'canceled';

--- a/crates/database/src/migrations/sql/V36__add_subscription_canceled_at.sql
+++ b/crates/database/src/migrations/sql/V36__add_subscription_canceled_at.sql
@@ -5,6 +5,6 @@ UPDATE subscriptions
 SET canceled_at = updated_at
 WHERE status = 'canceled' AND canceled_at IS NULL;
 
-CREATE INDEX idx_subscriptions_user_canceled_at
-    ON subscriptions(user_id, canceled_at DESC)
+CREATE INDEX idx_subscriptions_user_canceled_anchor
+    ON subscriptions(user_id, (COALESCE(canceled_at, updated_at)) DESC)
     WHERE status = 'canceled';

--- a/crates/database/src/migrations/sql/V36__add_subscription_canceled_at.sql
+++ b/crates/database/src/migrations/sql/V36__add_subscription_canceled_at.sql
@@ -4,7 +4,3 @@ ALTER TABLE subscriptions
 UPDATE subscriptions
 SET canceled_at = updated_at
 WHERE status = 'canceled' AND canceled_at IS NULL;
-
-CREATE INDEX idx_subscriptions_user_canceled_anchor
-    ON subscriptions(user_id, (COALESCE(canceled_at, updated_at)) DESC)
-    WHERE status = 'canceled';

--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -258,13 +258,13 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
         user_id: UserId,
     ) -> anyhow::Result<Option<chrono::DateTime<chrono::Utc>>> {
         let client = self.pool.get().await?;
-        // Use the latest canceled period boundary, not the most recently updated row.
+        // Use the latest ended canceled period boundary, not the most recently updated row.
         // Restored historical rows get a fresh `updated_at`, but should not override a newer
         // cancellation period when anchoring free-plan monthly windows.
         let row = client
             .query_opt(
                 "SELECT current_period_end FROM subscriptions \
-                 WHERE user_id = $1 AND status = 'canceled' \
+                 WHERE user_id = $1 AND status = 'canceled' AND current_period_end <= NOW() \
                  ORDER BY current_period_end DESC, updated_at DESC, created_at DESC, subscription_id DESC \
                  LIMIT 1",
                 &[&user_id],

--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -275,16 +275,15 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
         user_id: UserId,
     ) -> anyhow::Result<Option<chrono::DateTime<chrono::Utc>>> {
         let client = self.pool.get().await?;
-        // Preserve historical canceled ordering while keeping restored HoS history from winning
-        // solely because sync refreshed `updated_at` or carried a future terminal chain boundary.
-        // A future terminal HoS row becomes eligible only after that paid period boundary passes.
+        // Preserve historical non-HoS canceled ordering while keeping restored HoS history from
+        // moving free-plan usage windows. HoS rows are restored for inactive-history display only.
         // Non-HoS rows keep their legacy ordering semantics; changing Stripe future-period anchors
         // would be a separate billing-policy migration.
         let row = client
             .query_opt(
                 "SELECT current_period_end FROM subscriptions \
                  WHERE user_id = $1 AND status = 'canceled' \
-                   AND (provider != 'house-of-stake' OR current_period_end <= NOW()) \
+                   AND provider != 'house-of-stake' \
                  ORDER BY COALESCE(canceled_at, updated_at) DESC, created_at DESC, subscription_id DESC \
                  LIMIT 1",
                 &[&user_id],

--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -36,6 +36,25 @@ const SUBSCRIPTION_COLUMNS: &str =
        pending_downgrade_expected_period_end, pending_downgrade_status,
        pending_downgrade_updated_at";
 
+pub const CLEANUP_CANCELED_INSTANCE_USERS_SQL: &str = "SELECT s.user_id
+     FROM subscriptions s
+     WHERE s.status = 'canceled'
+       AND NOT EXISTS (
+           SELECT 1
+           FROM subscriptions active_sub
+           WHERE active_sub.user_id = s.user_id
+             AND active_sub.status IN ('active', 'trialing')
+       )
+       AND NOT (
+           s.provider = 'house-of-stake'
+           AND s.canceled_at IS NOT NULL
+           AND s.canceled_at < s.created_at
+       )
+     GROUP BY s.user_id
+     HAVING MAX(s.current_period_end) <= $1
+     ORDER BY s.user_id
+     LIMIT $2 OFFSET $3";
+
 pub struct PostgresSubscriptionRepository {
     pool: DbPool,
 }

--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -259,11 +259,13 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
     ) -> anyhow::Result<Option<chrono::DateTime<chrono::Utc>>> {
         let client = self.pool.get().await?;
         // Preserve the historical updated_at ordering for non-HoS cancellations, but do not let a
-        // freshly-restored HoS history row win solely because sync refreshed its updated_at.
+        // freshly-restored HoS history row win solely because sync refreshed its updated_at or
+        // carries a future terminal chain boundary.
         let row = client
             .query_opt(
                 "SELECT current_period_end FROM subscriptions \
-                 WHERE user_id = $1 AND status = 'canceled' AND current_period_end <= NOW() \
+                 WHERE user_id = $1 AND status = 'canceled' \
+                   AND (provider != 'house-of-stake' OR current_period_end <= NOW()) \
                  ORDER BY \
                     CASE \
                         WHEN provider = 'house-of-stake' THEN LEAST(updated_at, current_period_end) \

--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -481,7 +481,7 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
                      pending_downgrade_expected_period_end = $12,
                      pending_downgrade_status = $13,
                      pending_downgrade_updated_at = $14,
-                     canceled_at = CASE WHEN $6 = 'canceled' THEN NOW() ELSE NULL END,
+                     canceled_at = CASE WHEN $6::text = 'canceled' THEN NOW() ELSE NULL END,
                      updated_at = NOW()
                  WHERE subscription_id = $1
                  RETURNING subscription_id, user_id, provider, customer_id, price_id, status,

--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -128,7 +128,13 @@ impl PostgresSubscriptionRepository {
                     pending_downgrade_expected_period_end, pending_downgrade_status,
                     pending_downgrade_updated_at, canceled_at
                  )
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+                 VALUES (
+                    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
+                    CASE
+                        WHEN $6::VARCHAR = 'canceled' THEN COALESCE($14, NOW())
+                        ELSE NULL
+                    END
+                 )
                  ON CONFLICT (subscription_id)
                  DO UPDATE SET
                     user_id = EXCLUDED.user_id,
@@ -272,6 +278,8 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
         // Preserve historical canceled ordering while keeping restored HoS history from winning
         // solely because sync refreshed `updated_at` or carried a future terminal chain boundary.
         // A future terminal HoS row becomes eligible only after that paid period boundary passes.
+        // Non-HoS rows keep their legacy ordering semantics; changing Stripe future-period anchors
+        // would be a separate billing-policy migration.
         let row = client
             .query_opt(
                 "SELECT current_period_end FROM subscriptions \

--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -258,14 +258,15 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
         user_id: UserId,
     ) -> anyhow::Result<Option<chrono::DateTime<chrono::Utc>>> {
         let client = self.pool.get().await?;
-        // Use the latest ended canceled period boundary, not the most recently updated row.
-        // Restored historical rows get a fresh `updated_at`, but should not override a newer
-        // cancellation period when anchoring free-plan monthly windows.
+        // Preserve the historical updated_at ordering for non-HoS cancellations, but do not let a
+        // freshly-restored HoS history row win solely because sync refreshed its updated_at.
         let row = client
             .query_opt(
                 "SELECT current_period_end FROM subscriptions \
                  WHERE user_id = $1 AND status = 'canceled' AND current_period_end <= NOW() \
-                 ORDER BY current_period_end DESC, updated_at DESC, created_at DESC, subscription_id DESC \
+                 ORDER BY \
+                    CASE WHEN provider = 'house-of-stake' THEN current_period_end ELSE updated_at END DESC, \
+                    created_at DESC, subscription_id DESC \
                  LIMIT 1",
                 &[&user_id],
             )

--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -36,23 +36,26 @@ const SUBSCRIPTION_COLUMNS: &str =
        pending_downgrade_expected_period_end, pending_downgrade_status,
        pending_downgrade_updated_at";
 
-pub const CLEANUP_CANCELED_INSTANCE_USERS_SQL: &str = "SELECT s.user_id
-     FROM subscriptions s
-     WHERE s.status = 'canceled'
-       AND NOT EXISTS (
-           SELECT 1
-           FROM subscriptions active_sub
-           WHERE active_sub.user_id = s.user_id
-             AND active_sub.status IN ('active', 'trialing')
-       )
-       AND NOT (
-           s.provider = 'house-of-stake'
-           AND s.canceled_at IS NOT NULL
-           AND s.canceled_at < s.created_at
-       )
-     GROUP BY s.user_id
-     HAVING MAX(s.current_period_end) <= $1
-     ORDER BY s.user_id
+pub const CLEANUP_CANCELED_INSTANCE_USERS_SQL: &str = "SELECT latest.user_id
+     FROM (
+         SELECT DISTINCT ON (s.user_id) s.user_id, s.current_period_end
+         FROM subscriptions s
+         WHERE s.status = 'canceled'
+           AND NOT EXISTS (
+               SELECT 1
+               FROM subscriptions active_sub
+               WHERE active_sub.user_id = s.user_id
+                 AND active_sub.status IN ('active', 'trialing')
+           )
+           AND NOT (
+               s.provider = 'house-of-stake'
+               AND s.canceled_at IS NOT NULL
+               AND s.canceled_at <= s.current_period_end
+           )
+         ORDER BY s.user_id, COALESCE(s.canceled_at, s.updated_at) DESC, s.created_at DESC, s.subscription_id DESC
+     ) latest
+     WHERE latest.current_period_end <= $1
+     ORDER BY latest.user_id
      LIMIT $2 OFFSET $3";
 
 pub struct PostgresSubscriptionRepository {
@@ -294,9 +297,9 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
         user_id: UserId,
     ) -> anyhow::Result<Option<chrono::DateTime<chrono::Utc>>> {
         let client = self.pool.get().await?;
-        // Preserve historical non-HoS canceled ordering while keeping restored back-dated HoS
-        // history from moving free-plan usage windows. Genuine HoS lapses still anchor after the
-        // paid period ends.
+        // Preserve historical non-HoS canceled ordering while keeping restored/backfilled HoS
+        // history from moving free-plan usage windows. Genuine HoS lapses still anchor after
+        // cancellation because their `canceled_at` is later than the paid period end.
         // Non-HoS rows keep their legacy ordering semantics; changing Stripe future-period anchors
         // would be a separate billing-policy migration.
         let row = client
@@ -305,7 +308,7 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
                  WHERE user_id = $1 AND status = 'canceled' \
                    AND (provider != 'house-of-stake' OR ( \
                        current_period_end <= NOW() \
-                       AND NOT (canceled_at IS NOT NULL AND canceled_at < created_at) \
+                       AND NOT (canceled_at IS NOT NULL AND canceled_at <= current_period_end) \
                    )) \
                  ORDER BY COALESCE(canceled_at, updated_at) DESC, created_at DESC, subscription_id DESC \
                  LIMIT 1",

--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -265,7 +265,10 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
                 "SELECT current_period_end FROM subscriptions \
                  WHERE user_id = $1 AND status = 'canceled' AND current_period_end <= NOW() \
                  ORDER BY \
-                    CASE WHEN provider = 'house-of-stake' THEN current_period_end ELSE updated_at END DESC, \
+                    CASE \
+                        WHEN provider = 'house-of-stake' THEN LEAST(updated_at, current_period_end) \
+                        ELSE updated_at \
+                    END DESC, \
                     created_at DESC, subscription_id DESC \
                  LIMIT 1",
                 &[&user_id],

--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -17,6 +17,7 @@ fn row_to_subscription(row: &tokio_postgres::Row) -> Subscription {
         cancel_at_period_end: row.get("cancel_at_period_end"),
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
+        canceled_at: row.get("canceled_at"),
         pending_downgrade_target_price_id: row.get("pending_downgrade_target_price_id"),
         pending_downgrade_from_price_id: row.get("pending_downgrade_from_price_id"),
         pending_downgrade_expected_period_end: row.get("pending_downgrade_expected_period_end"),
@@ -30,6 +31,7 @@ fn row_to_subscription(row: &tokio_postgres::Row) -> Subscription {
 const SUBSCRIPTION_COLUMNS: &str =
     "subscription_id, user_id, provider, customer_id, price_id, status,
        current_period_end, cancel_at_period_end, created_at, updated_at,
+       canceled_at,
        pending_downgrade_target_price_id, pending_downgrade_from_price_id,
        pending_downgrade_expected_period_end, pending_downgrade_status,
        pending_downgrade_updated_at";
@@ -124,9 +126,9 @@ impl PostgresSubscriptionRepository {
                     status, current_period_end, cancel_at_period_end,
                     pending_downgrade_target_price_id, pending_downgrade_from_price_id,
                     pending_downgrade_expected_period_end, pending_downgrade_status,
-                    pending_downgrade_updated_at
+                    pending_downgrade_updated_at, canceled_at
                  )
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
                  ON CONFLICT (subscription_id)
                  DO UPDATE SET
                     user_id = EXCLUDED.user_id,
@@ -136,10 +138,18 @@ impl PostgresSubscriptionRepository {
                     status = EXCLUDED.status,
                     current_period_end = EXCLUDED.current_period_end,
                     cancel_at_period_end = EXCLUDED.cancel_at_period_end,
+                    canceled_at = CASE
+                        WHEN EXCLUDED.status = 'canceled' AND subscriptions.status = 'canceled'
+                            THEN COALESCE(subscriptions.canceled_at, EXCLUDED.canceled_at, NOW())
+                        WHEN EXCLUDED.status = 'canceled'
+                            THEN COALESCE(EXCLUDED.canceled_at, NOW())
+                        ELSE NULL
+                    END,
                     {}
                     updated_at = NOW()
                  RETURNING subscription_id, user_id, provider, customer_id, price_id, status,
                            current_period_end, cancel_at_period_end, created_at, updated_at,
+                           canceled_at,
                            pending_downgrade_target_price_id, pending_downgrade_from_price_id,
                            pending_downgrade_expected_period_end, pending_downgrade_status,
                            pending_downgrade_updated_at",
@@ -163,6 +173,7 @@ impl PostgresSubscriptionRepository {
                     &subscription.pending_downgrade_expected_period_end,
                     &pending_downgrade_status,
                     &pending_downgrade_updated_at,
+                    &subscription.canceled_at,
                 ],
             )
             .await
@@ -258,20 +269,14 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
         user_id: UserId,
     ) -> anyhow::Result<Option<chrono::DateTime<chrono::Utc>>> {
         let client = self.pool.get().await?;
-        // Preserve the historical updated_at ordering for non-HoS cancellations, but do not let a
-        // freshly-restored HoS history row win solely because sync refreshed its updated_at or
-        // carries a future terminal chain boundary.
+        // Preserve historical canceled ordering while keeping restored HoS history from winning
+        // solely because sync refreshed `updated_at` or carried a future terminal chain boundary.
         let row = client
             .query_opt(
                 "SELECT current_period_end FROM subscriptions \
                  WHERE user_id = $1 AND status = 'canceled' \
                    AND (provider != 'house-of-stake' OR current_period_end <= NOW()) \
-                 ORDER BY \
-                    CASE \
-                        WHEN provider = 'house-of-stake' THEN LEAST(updated_at, current_period_end) \
-                        ELSE updated_at \
-                    END DESC, \
-                    created_at DESC, subscription_id DESC \
+                 ORDER BY COALESCE(canceled_at, updated_at) DESC, created_at DESC, subscription_id DESC \
                  LIMIT 1",
                 &[&user_id],
             )
@@ -476,10 +481,12 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
                      pending_downgrade_expected_period_end = $12,
                      pending_downgrade_status = $13,
                      pending_downgrade_updated_at = $14,
+                     canceled_at = CASE WHEN $6 = 'canceled' THEN NOW() ELSE NULL END,
                      updated_at = NOW()
                  WHERE subscription_id = $1
                  RETURNING subscription_id, user_id, provider, customer_id, price_id, status,
                            current_period_end, cancel_at_period_end, created_at, updated_at,
+                           canceled_at,
                            pending_downgrade_target_price_id, pending_downgrade_from_price_id,
                            pending_downgrade_expected_period_end, pending_downgrade_status,
                            pending_downgrade_updated_at",

--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -258,13 +258,14 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
         user_id: UserId,
     ) -> anyhow::Result<Option<chrono::DateTime<chrono::Utc>>> {
         let client = self.pool.get().await?;
-        // Use the most recently canceled row (by updated_at), not MAX(period_end),
-        // so stale rows with far-future period ends do not override the latest cancellation boundary.
+        // Use the latest canceled period boundary, not the most recently updated row.
+        // Restored historical rows get a fresh `updated_at`, but should not override a newer
+        // cancellation period when anchoring free-plan monthly windows.
         let row = client
             .query_opt(
                 "SELECT current_period_end FROM subscriptions \
                  WHERE user_id = $1 AND status = 'canceled' \
-                 ORDER BY updated_at DESC, created_at DESC, subscription_id DESC \
+                 ORDER BY current_period_end DESC, updated_at DESC, created_at DESC, subscription_id DESC \
                  LIMIT 1",
                 &[&user_id],
             )

--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -271,6 +271,7 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
         let client = self.pool.get().await?;
         // Preserve historical canceled ordering while keeping restored HoS history from winning
         // solely because sync refreshed `updated_at` or carried a future terminal chain boundary.
+        // A future terminal HoS row becomes eligible only after that paid period boundary passes.
         let row = client
             .query_opt(
                 "SELECT current_period_end FROM subscriptions \

--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -385,7 +385,9 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
     ) -> anyhow::Result<()> {
         let n = txn
             .execute(
-                "UPDATE subscriptions SET status = 'canceled', updated_at = NOW() WHERE user_id = $1 AND status IN ('active', 'trialing')",
+                "UPDATE subscriptions
+                 SET status = 'canceled', canceled_at = COALESCE(canceled_at, NOW()), updated_at = NOW()
+                 WHERE user_id = $1 AND status IN ('active', 'trialing')",
                 &[&user_id],
             )
             .await?;
@@ -481,7 +483,10 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
                      pending_downgrade_expected_period_end = $12,
                      pending_downgrade_status = $13,
                      pending_downgrade_updated_at = $14,
-                     canceled_at = CASE WHEN $6::text = 'canceled' THEN NOW() ELSE NULL END,
+                     canceled_at = CASE
+                         WHEN $6::text = 'canceled' THEN COALESCE(canceled_at, NOW())
+                         ELSE NULL
+                     END,
                      updated_at = NOW()
                  WHERE subscription_id = $1
                  RETURNING subscription_id, user_id, provider, customer_id, price_id, status,

--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -474,7 +474,7 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
                      provider = $3,
                      customer_id = $4,
                      price_id = $5,
-                     status = $6,
+                     status = $6::VARCHAR,
                      current_period_end = $7,
                      cancel_at_period_end = $8,
                      created_at = $9,
@@ -484,7 +484,7 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
                      pending_downgrade_status = $13,
                      pending_downgrade_updated_at = $14,
                      canceled_at = CASE
-                         WHEN $6::text = 'canceled' THEN COALESCE(canceled_at, NOW())
+                         WHEN $6::VARCHAR = 'canceled' THEN COALESCE(canceled_at, NOW())
                          ELSE NULL
                      END,
                      updated_at = NOW()

--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -275,15 +275,19 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
         user_id: UserId,
     ) -> anyhow::Result<Option<chrono::DateTime<chrono::Utc>>> {
         let client = self.pool.get().await?;
-        // Preserve historical non-HoS canceled ordering while keeping restored HoS history from
-        // moving free-plan usage windows. HoS rows are restored for inactive-history display only.
+        // Preserve historical non-HoS canceled ordering while keeping restored back-dated HoS
+        // history from moving free-plan usage windows. Genuine HoS lapses still anchor after the
+        // paid period ends.
         // Non-HoS rows keep their legacy ordering semantics; changing Stripe future-period anchors
         // would be a separate billing-policy migration.
         let row = client
             .query_opt(
                 "SELECT current_period_end FROM subscriptions \
                  WHERE user_id = $1 AND status = 'canceled' \
-                   AND provider != 'house-of-stake' \
+                   AND (provider != 'house-of-stake' OR ( \
+                       current_period_end <= NOW() \
+                       AND NOT (canceled_at IS NOT NULL AND canceled_at < created_at) \
+                   )) \
                  ORDER BY COALESCE(canceled_at, updated_at) DESC, created_at DESC, subscription_id DESC \
                  LIMIT 1",
                 &[&user_id],

--- a/crates/services/src/subscription/near_staking.rs
+++ b/crates/services/src/subscription/near_staking.rs
@@ -390,6 +390,7 @@ pub fn subscription_row_from_chain(
         cancel_at_period_end,
         created_at: Utc::now(),
         updated_at: Utc::now(),
+        canceled_at: None,
         pending_downgrade_target_price_id: pd_target,
         pending_downgrade_from_price_id: pd_from,
         pending_downgrade_expected_period_end: pd_end,

--- a/crates/services/src/subscription/near_staking.rs
+++ b/crates/services/src/subscription/near_staking.rs
@@ -12,7 +12,7 @@ use tokio::time::timeout;
 /// Upper bound for NEAR JSON-RPC view calls so API handlers do not block indefinitely.
 const NEAR_VIEW_RPC_TIMEOUT: Duration = Duration::from_secs(15);
 
-const NEAR_VIEW_RPC_TIMEOUT_MSG: &str = "NEAR RPC view call timed out";
+pub(crate) const NEAR_VIEW_RPC_TIMEOUT_MSG: &str = "NEAR RPC view call timed out";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct YoctoNear(u128);

--- a/crates/services/src/subscription/ports.rs
+++ b/crates/services/src/subscription/ports.rs
@@ -339,9 +339,6 @@ pub struct NearStakingSyncSummary {
     pub canceled_house_of_stake_rows: u32,
     /// True when a local row was upserted from chain JSON.
     pub upserted_house_of_stake_row: bool,
-    /// True when a future no-op reason is retryable.
-    #[serde(default)]
-    pub retryable: bool,
     /// When reconcile did not upsert or delete, optionally explains a no-op. Omitted from JSON when `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub skipped_reason: Option<String>,

--- a/crates/services/src/subscription/ports.rs
+++ b/crates/services/src/subscription/ports.rs
@@ -60,7 +60,8 @@ pub struct Subscription {
     pub cancel_at_period_end: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
-    /// Timestamp when this row first entered `canceled`; used for free-plan anchor ordering.
+    /// Stable terminal timestamp for canceled rows; normally when the row first entered `canceled`,
+    /// or the chain-authored expiry time for restored HoS history.
     pub canceled_at: Option<DateTime<Utc>>,
     /// Target price_id for a deferred downgrade intent.
     pub pending_downgrade_target_price_id: Option<String>,
@@ -324,11 +325,6 @@ pub enum ResumeSubscriptionOutcome {
 pub const NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS: &str =
     "upsert_blocked_active_non_house_of_stake_subscription";
 
-/// Machine-readable [`NearStakingSyncSummary::skipped_reason`] when reconcile could not probe
-/// NEAR RPC for a Stripe-primary user with no local HoS context. This is reported as a retryable
-/// sync no-op instead of a 503 to preserve the historical no-op behavior for Stripe users.
-pub const NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE: &str = "near_rpc_unavailable";
-
 /// Summary from `POST /v1/subscriptions/near/sync` / internal HoS reconcile.
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -343,12 +339,10 @@ pub struct NearStakingSyncSummary {
     pub canceled_house_of_stake_rows: u32,
     /// True when a local row was upserted from chain JSON.
     pub upserted_house_of_stake_row: bool,
-    /// True when the no-op is retryable, such as transient NEAR RPC unavailability. Retryable no-ops
-    /// can have `skipped=false` so older clients do not treat the response as terminal.
+    /// True when a future no-op reason is retryable.
     #[serde(default)]
     pub retryable: bool,
-    /// When reconcile did not upsert or delete, optionally explains a no-op (e.g. blocked upsert
-    /// or retryable RPC unavailability). Omitted from JSON when `None`.
+    /// When reconcile did not upsert or delete, optionally explains a no-op. Omitted from JSON when `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub skipped_reason: Option<String>,
 }

--- a/crates/services/src/subscription/ports.rs
+++ b/crates/services/src/subscription/ports.rs
@@ -337,6 +337,9 @@ pub struct NearStakingSyncSummary {
     pub canceled_house_of_stake_rows: u32,
     /// True when a local row was upserted from chain JSON.
     pub upserted_house_of_stake_row: bool,
+    /// True when the no-op is retryable, such as transient NEAR RPC unavailability.
+    #[serde(default)]
+    pub retryable: bool,
     /// When reconcile did not upsert or delete, optionally explains a no-op (e.g. blocked upsert
     /// or retryable RPC unavailability). Omitted from JSON when `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/services/src/subscription/ports.rs
+++ b/crates/services/src/subscription/ports.rs
@@ -92,6 +92,10 @@ pub struct SubscriptionReplacement {
     pub pending_downgrade_updated_at: Option<DateTime<Utc>>,
 }
 
+/// Sentinel plan name used only for inactive subscription history whose original
+/// catalog entry is no longer configured.
+pub const UNKNOWN_SUBSCRIPTION_PLAN_NAME: &str = "unknown";
+
 /// API response model with plan name resolved from `price_id` (HoS clients use `price_id` + `provider` for wallet flows).
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -100,7 +104,8 @@ pub struct SubscriptionWithPlan {
     pub user_id: String,
     pub provider: String,
     pub price_id: String,
-    pub plan: String, // Resolved from price_id
+    /// Resolved from `price_id`; `unknown` is returned only for inactive off-catalog history rows.
+    pub plan: String,
     pub status: String,
     pub current_period_end: DateTime<Utc>,
     pub cancel_at_period_end: bool,

--- a/crates/services/src/subscription/ports.rs
+++ b/crates/services/src/subscription/ports.rs
@@ -60,6 +60,8 @@ pub struct Subscription {
     pub cancel_at_period_end: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// Timestamp when this row first entered `canceled`; used for free-plan anchor ordering.
+    pub canceled_at: Option<DateTime<Utc>>,
     /// Target price_id for a deferred downgrade intent.
     pub pending_downgrade_target_price_id: Option<String>,
     /// Snapshot of current price_id when the downgrade intent was created.
@@ -741,7 +743,8 @@ pub trait SubscriptionRepository: Send + Sync {
     ) -> anyhow::Result<Option<Subscription>>;
 
     /// `current_period_end` of the most recently canceled subscription row for this user
-    /// (ordered by `updated_at`; canceled status is stored as the string `canceled`). Used to align free-plan billing months with the boundary
+    /// (ordered by `canceled_at`, falling back to `updated_at` for legacy rows; canceled status is
+    /// stored as the string `canceled`). Used to align free-plan billing months with the boundary
     /// where the latest cancellation period ended; if none exist, callers fall back to a calendar month.
     async fn last_cancelled_subscription_period_end_for_user(
         &self,

--- a/crates/services/src/subscription/ports.rs
+++ b/crates/services/src/subscription/ports.rs
@@ -317,11 +317,18 @@ pub enum ResumeSubscriptionOutcome {
 pub const NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS: &str =
     "upsert_blocked_active_non_house_of_stake_subscription";
 
+/// Machine-readable [`NearStakingSyncSummary::skipped_reason`] when reconcile could not probe
+/// NEAR RPC for a Stripe-primary user with no local HoS context. This is reported as a skipped
+/// retryable sync instead of a 503 to preserve the historical no-op behavior for Stripe users.
+pub const NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE: &str = "near_rpc_unavailable";
+
 /// Summary from `POST /v1/subscriptions/near/sync` / internal HoS reconcile.
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NearStakingSyncSummary {
-    /// True when reconcile exited early (no HoS contract configured, user has no linked NEAR account, or no HoS anchor price in catalog). No RPC or DB mutation was attempted.
+    /// True when reconcile did not mutate DB because it exited before useful chain data was
+    /// available (no HoS contract configured, user has no linked NEAR account, no HoS anchor price
+    /// in catalog, or retryable RPC unavailability for a Stripe-primary user with no local HoS context).
     pub skipped: bool,
     /// Local `house-of-stake` rows removed during reconcile. Preserved history rows are not counted here.
     pub deleted_house_of_stake_rows: u32,
@@ -330,8 +337,8 @@ pub struct NearStakingSyncSummary {
     pub canceled_house_of_stake_rows: u32,
     /// True when a local row was upserted from chain JSON.
     pub upserted_house_of_stake_row: bool,
-    /// When reconcile ran but did not upsert or delete, optionally explains a no-op (e.g. blocked
-    /// upsert). Omitted from JSON when `None`. Distinct from [`Self::skipped`] (early exit before RPC).
+    /// When reconcile did not upsert or delete, optionally explains a no-op (e.g. blocked upsert
+    /// or retryable RPC unavailability). Omitted from JSON when `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub skipped_reason: Option<String>,
 }

--- a/crates/services/src/subscription/ports.rs
+++ b/crates/services/src/subscription/ports.rs
@@ -320,17 +320,16 @@ pub const NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS: &str =
     "upsert_blocked_active_non_house_of_stake_subscription";
 
 /// Machine-readable [`NearStakingSyncSummary::skipped_reason`] when reconcile could not probe
-/// NEAR RPC for a Stripe-primary user with no local HoS context. This is reported as a skipped
-/// retryable sync instead of a 503 to preserve the historical no-op behavior for Stripe users.
+/// NEAR RPC for a Stripe-primary user with no local HoS context. This is reported as a retryable
+/// sync no-op instead of a 503 to preserve the historical no-op behavior for Stripe users.
 pub const NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE: &str = "near_rpc_unavailable";
 
 /// Summary from `POST /v1/subscriptions/near/sync` / internal HoS reconcile.
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NearStakingSyncSummary {
-    /// True when reconcile did not mutate DB because it exited before useful chain data was
-    /// available (no HoS contract configured, user has no linked NEAR account, no HoS anchor price
-    /// in catalog, or retryable RPC unavailability for a Stripe-primary user with no local HoS context).
+    /// True when reconcile did not mutate DB because it exited before attempting RPC or DB work
+    /// (no HoS contract configured, user has no linked NEAR account, or no HoS anchor price in catalog).
     pub skipped: bool,
     /// Local `house-of-stake` rows removed during reconcile. Preserved history rows are not counted here.
     pub deleted_house_of_stake_rows: u32,
@@ -339,7 +338,8 @@ pub struct NearStakingSyncSummary {
     pub canceled_house_of_stake_rows: u32,
     /// True when a local row was upserted from chain JSON.
     pub upserted_house_of_stake_row: bool,
-    /// True when the no-op is retryable, such as transient NEAR RPC unavailability.
+    /// True when the no-op is retryable, such as transient NEAR RPC unavailability. Retryable no-ops
+    /// can have `skipped=false` so older clients do not treat the response as terminal.
     #[serde(default)]
     pub retryable: bool,
     /// When reconcile did not upsert or delete, optionally explains a no-op (e.g. blocked upsert

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1502,6 +1502,7 @@ impl SubscriptionServiceImpl {
         let has_active_non_hos = subs
             .iter()
             .any(|s| Self::is_active_or_trialing(&s.status) && s.provider != "house-of-stake");
+        let has_local_hos = subs.iter().any(|s| s.provider == "house-of-stake");
         let configs = self
             .system_configs_service
             .get_configs()
@@ -1571,6 +1572,14 @@ impl SubscriptionServiceImpl {
         }
         if raw.is_none() {
             if let Some(err) = first_err {
+                if has_active_non_hos && !has_local_hos {
+                    tracing::warn!(
+                        user_id = %user_id.0,
+                        error = %err,
+                        "NEAR RPC unavailable during HoS sync; no local HoS context, reporting no-op"
+                    );
+                    return Ok(Self::hos_reconcile_summary(false, 0, 0, false, None));
+                }
                 return Err(Self::near_rpc_err(err));
             }
         }
@@ -1584,18 +1593,7 @@ impl SubscriptionServiceImpl {
                 .cloned()
                 .collect();
             if local_hos_subscriptions.is_empty() {
-                let skipped_reason = if has_active_non_hos {
-                    Some(NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS)
-                } else {
-                    None
-                };
-                return Ok(Self::hos_reconcile_summary(
-                    false,
-                    0,
-                    0,
-                    false,
-                    skipped_reason,
-                ));
+                return Ok(Self::hos_reconcile_summary(false, 0, 0, false, None));
             }
             let now = Utc::now();
             let canceled = local_hos_subscriptions.len() as u32;

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -12,6 +12,7 @@ use super::ports::{
     StripeCustomerRepository, StripeSubscriptionSnapshot, StripeUpdateSubscriptionParams,
     Subscription, SubscriptionError, SubscriptionPlan, SubscriptionReplacement,
     SubscriptionRepository, SubscriptionService, SubscriptionWithPlan, DEFAULT_MONTHLY_TOKEN_LIMIT,
+    NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE,
     NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS,
 };
 use crate::agent::ports::AgentRepository;
@@ -1576,9 +1577,15 @@ impl SubscriptionServiceImpl {
                     tracing::warn!(
                         user_id = %user_id.0,
                         error = %err,
-                        "NEAR RPC unavailable during HoS sync; no local HoS context, reporting no-op"
+                        "NEAR RPC unavailable during HoS sync; no local HoS context, reporting retryable skipped sync"
                     );
-                    return Ok(Self::hos_reconcile_summary(false, 0, 0, false, None));
+                    return Ok(Self::hos_reconcile_summary(
+                        true,
+                        0,
+                        0,
+                        false,
+                        Some(NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE),
+                    ));
                 }
                 return Err(Self::near_rpc_err(err));
             }
@@ -1623,8 +1630,11 @@ impl SubscriptionServiceImpl {
         }
 
         let chain_subscription = raw.as_ref().expect("checked is_some");
-        let row = subscription_row_from_chain(user_id, &near_account, chain_subscription)
+        let mut row = subscription_row_from_chain(user_id, &near_account, chain_subscription)
             .map_err(SubscriptionError::InternalError)?;
+        if row.status == SUBSCRIPTION_STATUS_CANCELED {
+            row = Self::canceled_house_of_stake_history_row(row, Utc::now());
+        }
 
         // Do not insert/update an active HoS row while a non-HoS subscription is active/trialing locally:
         // `get_active_subscription` picks newest `created_at`, so a fresh HoS upsert could wrongly

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1576,8 +1576,14 @@ impl SubscriptionServiceImpl {
         if raw.is_none() {
             if let Some(err) = first_err {
                 if has_active_non_hos && !has_active_local_hos {
+                    let error_category = if err.contains("timed out") {
+                        "timeout"
+                    } else {
+                        "rpc_error"
+                    };
                     tracing::warn!(
                         user_id = %user_id.0,
+                        error_category = error_category,
                         "NEAR RPC unavailable during HoS sync; no active local HoS context, reporting retryable skipped sync"
                     );
                     return Ok(Self::hos_reconcile_summary(
@@ -1634,19 +1640,8 @@ impl SubscriptionServiceImpl {
         let mut row = subscription_row_from_chain(user_id, &near_account, chain_subscription)
             .map_err(SubscriptionError::InternalError)?;
         if row.status == SUBSCRIPTION_STATUS_CANCELED {
-            let now = Utc::now();
-            let clamp_at = if row.current_period_end > now {
-                subs.iter()
-                    .find(|sub| {
-                        sub.provider == "house-of-stake"
-                            && sub.subscription_id == row.subscription_id
-                    })
-                    .map(|sub| sub.current_period_end.min(now))
-                    .unwrap_or(now)
-            } else {
-                row.current_period_end
-            };
-            row = Self::canceled_house_of_stake_history_row(row, clamp_at);
+            let chain_period_end = row.current_period_end;
+            row = Self::canceled_house_of_stake_history_row(row, chain_period_end);
         }
 
         // Do not insert/update an active HoS row while a non-HoS subscription is active/trialing locally:

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1502,22 +1502,6 @@ impl SubscriptionServiceImpl {
         let has_active_non_hos = subs
             .iter()
             .any(|s| Self::is_active_or_trialing(&s.status) && s.provider != "house-of-stake");
-        let hos_subscription_ids: Vec<String> = subs
-            .iter()
-            .filter(|s| s.provider == "house-of-stake")
-            .map(|s| s.subscription_id.clone())
-            .collect();
-
-        if has_active_non_hos && hos_subscription_ids.is_empty() {
-            return Ok(Self::hos_reconcile_summary(
-                false,
-                0,
-                0,
-                false,
-                Some(NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS),
-            ));
-        }
-
         let configs = self
             .system_configs_service
             .get_configs()
@@ -1600,7 +1584,18 @@ impl SubscriptionServiceImpl {
                 .cloned()
                 .collect();
             if local_hos_subscriptions.is_empty() {
-                return Ok(Self::hos_reconcile_summary(false, 0, 0, false, None));
+                let skipped_reason = if has_active_non_hos {
+                    Some(NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS)
+                } else {
+                    None
+                };
+                return Ok(Self::hos_reconcile_summary(
+                    false,
+                    0,
+                    0,
+                    false,
+                    skipped_reason,
+                ));
             }
             let now = Utc::now();
             let canceled = local_hos_subscriptions.len() as u32;
@@ -1633,10 +1628,13 @@ impl SubscriptionServiceImpl {
         let row = subscription_row_from_chain(user_id, &near_account, chain_subscription)
             .map_err(SubscriptionError::InternalError)?;
 
-        // Do not insert/update a HoS row while a non-HoS subscription is active/trialing locally:
+        // Do not insert/update an active HoS row while a non-HoS subscription is active/trialing locally:
         // `get_active_subscription` picks newest `created_at`, so a fresh HoS upsert could wrongly
         // become the "active" row for Stripe-primary users who also staked on-chain separately.
-        if has_active_non_hos {
+        //
+        // Canceled/expired chain rows are historical records. They are safe to restore because
+        // active entitlement queries ignore them, and `include_inactive=true` needs them.
+        if has_active_non_hos && Self::is_active_or_trialing(&row.status) {
             let active_hos_subscriptions: Vec<Subscription> = subs
                 .iter()
                 .filter(|s| {

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -164,10 +164,12 @@ impl SubscriptionServiceImpl {
         sub.pending_downgrade_expected_period_end = None;
         sub.pending_downgrade_status = None;
         sub.pending_downgrade_updated_at = None;
+        sub.canceled_at = Some(now);
         sub
     }
 
     fn canceled_house_of_stake_chain_history_row(mut sub: Subscription) -> Subscription {
+        let now = Utc::now();
         sub.status = SUBSCRIPTION_STATUS_CANCELED.to_string();
         sub.cancel_at_period_end = false;
         sub.pending_downgrade_target_price_id = None;
@@ -175,6 +177,11 @@ impl SubscriptionServiceImpl {
         sub.pending_downgrade_expected_period_end = None;
         sub.pending_downgrade_status = None;
         sub.pending_downgrade_updated_at = None;
+        sub.canceled_at = Some(if sub.current_period_end <= now {
+            sub.current_period_end
+        } else {
+            now
+        });
         sub
     }
 
@@ -884,6 +891,7 @@ impl SubscriptionServiceImpl {
         user_id: UserId,
         provider: &str,
     ) -> Result<Subscription, SubscriptionError> {
+        let now = chrono::Utc::now();
         Ok(Subscription {
             subscription_id: stripe_sub.id.clone(),
             user_id,
@@ -893,8 +901,9 @@ impl SubscriptionServiceImpl {
             status: stripe_sub.status.clone(),
             current_period_end: stripe_sub.current_period_end,
             cancel_at_period_end: stripe_sub.cancel_at_period_end,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
+            created_at: now,
+            updated_at: now,
+            canceled_at: (stripe_sub.status == SUBSCRIPTION_STATUS_CANCELED).then_some(now),
             pending_downgrade_target_price_id: None,
             pending_downgrade_from_price_id: None,
             pending_downgrade_expected_period_end: None,
@@ -3668,6 +3677,7 @@ impl SubscriptionService for SubscriptionServiceImpl {
             cancel_at_period_end: false,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
+            canceled_at: None,
             pending_downgrade_target_price_id: None,
             pending_downgrade_from_price_id: None,
             pending_downgrade_expected_period_end: None,
@@ -4386,6 +4396,7 @@ mod tests {
             cancel_at_period_end: false,
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            canceled_at: None,
             pending_downgrade_target_price_id: None,
             pending_downgrade_from_price_id: None,
             pending_downgrade_expected_period_end: None,

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1588,8 +1588,15 @@ impl SubscriptionServiceImpl {
         for (_, result) in &probe_results {
             match result {
                 Ok(Some(v)) => {
-                    raw = Some(v.clone());
-                    break;
+                    let row = subscription_row_from_chain(user_id, &near_account, v)
+                        .map_err(SubscriptionError::InternalError)?;
+                    if Self::is_active_or_trialing(&row.status) {
+                        raw = Some(v.clone());
+                        break;
+                    }
+                    if raw.is_none() {
+                        raw = Some(v.clone());
+                    }
                 }
                 Ok(None) => {}
                 Err(e) if first_err.is_none() => first_err = Some(e.clone()),
@@ -2784,17 +2791,28 @@ impl SubscriptionService for SubscriptionServiceImpl {
         // Map to API response model with plan names resolved
         let mut result: Vec<SubscriptionWithPlan> = Vec::new();
         for sub in subscriptions {
-            let plan =
-                resolve_plan_name_from_config(&sub.provider, &sub.price_id, &subscription_plans)
-                    .unwrap_or_else(|| {
-                        tracing::warn!(
-                            user_id = %user_id.0,
-                            provider = %sub.provider,
-                            price_id = %sub.price_id,
-                            "Subscription row has no matching catalog plan; reporting unknown plan"
-                        );
-                        "unknown".to_string()
-                    });
+            let plan = match resolve_plan_name_from_config(
+                &sub.provider,
+                &sub.price_id,
+                &subscription_plans,
+            ) {
+                Some(plan) => plan,
+                None if !Self::is_active_or_trialing(&sub.status) => {
+                    tracing::warn!(
+                        user_id = %user_id.0,
+                        provider = %sub.provider,
+                        price_id = %sub.price_id,
+                        "Subscription row has no matching catalog plan; reporting unknown plan"
+                    );
+                    "unknown".to_string()
+                }
+                None => {
+                    return Err(SubscriptionError::InternalError(format!(
+                        "Cannot resolve plan for price_id={}, provider={}",
+                        sub.price_id, sub.provider
+                    )));
+                }
+            };
             let pending_downgrade_plan =
                 sub.pending_downgrade_target_price_id
                     .as_deref()

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1650,6 +1650,21 @@ impl SubscriptionServiceImpl {
                 return Err(Self::near_rpc_err(err));
             }
             if let Some(err) = first_parse_err {
+                if has_active_non_hos && !has_any_local_hos {
+                    tracing::warn!(
+                        user_id = %user_id.0,
+                        error_category = "parse_error",
+                        "NEAR RPC returned unparseable HoS sync data; no local HoS context, reporting retryable sync no-op"
+                    );
+                    return Ok(Self::hos_reconcile_summary(
+                        false,
+                        0,
+                        0,
+                        false,
+                        true,
+                        Some(NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE),
+                    ));
+                }
                 return Err(SubscriptionError::InternalError(err));
             }
         }

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1576,7 +1576,6 @@ impl SubscriptionServiceImpl {
                 if has_active_non_hos && !has_local_hos {
                     tracing::warn!(
                         user_id = %user_id.0,
-                        error = %err,
                         "NEAR RPC unavailable during HoS sync; no local HoS context, reporting retryable skipped sync"
                     );
                     return Ok(Self::hos_reconcile_summary(
@@ -1634,11 +1633,14 @@ impl SubscriptionServiceImpl {
             .map_err(SubscriptionError::InternalError)?;
         if row.status == SUBSCRIPTION_STATUS_CANCELED {
             let now = Utc::now();
-            let clamp_at = subs
-                .iter()
-                .find(|sub| sub.subscription_id == row.subscription_id)
-                .map(|sub| sub.current_period_end.min(now))
-                .unwrap_or(now);
+            let clamp_at = if row.current_period_end > now {
+                subs.iter()
+                    .find(|sub| sub.subscription_id == row.subscription_id)
+                    .map(|sub| sub.current_period_end.min(now))
+                    .unwrap_or(now)
+            } else {
+                row.current_period_end
+            };
             row = Self::canceled_house_of_stake_history_row(row, clamp_at);
         }
 

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -2,6 +2,7 @@ use super::near_staking::{
     lock_amount_yocto, subscription_row_from_chain, view_get_lock, view_get_price,
     view_get_purchase, view_get_subscription_for_price, view_storage_balance_bounds,
     view_storage_balance_of, NearStakingStorageBalance, NearStakingStorageBalanceBounds,
+    NEAR_VIEW_RPC_TIMEOUT_MSG,
 };
 use super::ports::{
     BillingCycleAnchor, BillingPeriod, CancelSubscriptionOutcome, ChangePlanOutcome,
@@ -140,6 +141,7 @@ impl SubscriptionServiceImpl {
             deleted_house_of_stake_rows: deleted,
             canceled_house_of_stake_rows: canceled,
             upserted_house_of_stake_row: upserted,
+            retryable: false,
             skipped_reason: skipped_reason.map(String::from),
         }
     }
@@ -156,6 +158,17 @@ impl SubscriptionServiceImpl {
         if sub.current_period_end > now {
             sub.current_period_end = now;
         }
+        sub.cancel_at_period_end = false;
+        sub.pending_downgrade_target_price_id = None;
+        sub.pending_downgrade_from_price_id = None;
+        sub.pending_downgrade_expected_period_end = None;
+        sub.pending_downgrade_status = None;
+        sub.pending_downgrade_updated_at = None;
+        sub
+    }
+
+    fn canceled_house_of_stake_chain_history_row(mut sub: Subscription) -> Subscription {
+        sub.status = SUBSCRIPTION_STATUS_CANCELED.to_string();
         sub.cancel_at_period_end = false;
         sub.pending_downgrade_target_price_id = None;
         sub.pending_downgrade_from_price_id = None;
@@ -1576,7 +1589,7 @@ impl SubscriptionServiceImpl {
         if raw.is_none() {
             if let Some(err) = first_err {
                 if has_active_non_hos && !has_active_local_hos {
-                    let error_category = if err.contains("timed out") {
+                    let error_category = if err == NEAR_VIEW_RPC_TIMEOUT_MSG {
                         "timeout"
                     } else {
                         "rpc_error"
@@ -1586,13 +1599,15 @@ impl SubscriptionServiceImpl {
                         error_category = error_category,
                         "NEAR RPC unavailable during HoS sync; no active local HoS context, reporting retryable skipped sync"
                     );
-                    return Ok(Self::hos_reconcile_summary(
+                    let mut summary = Self::hos_reconcile_summary(
                         true,
                         0,
                         0,
                         false,
                         Some(NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE),
-                    ));
+                    );
+                    summary.retryable = true;
+                    return Ok(summary);
                 }
                 return Err(Self::near_rpc_err(err));
             }
@@ -1640,8 +1655,7 @@ impl SubscriptionServiceImpl {
         let mut row = subscription_row_from_chain(user_id, &near_account, chain_subscription)
             .map_err(SubscriptionError::InternalError)?;
         if row.status == SUBSCRIPTION_STATUS_CANCELED {
-            let chain_period_end = row.current_period_end;
-            row = Self::canceled_house_of_stake_history_row(row, chain_period_end);
+            row = Self::canceled_house_of_stake_chain_history_row(row);
         }
 
         // Do not insert/update an active HoS row while a non-HoS subscription is active/trialing locally:

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -14,7 +14,7 @@ use super::ports::{
     Subscription, SubscriptionError, SubscriptionPlan, SubscriptionReplacement,
     SubscriptionRepository, SubscriptionService, SubscriptionWithPlan, DEFAULT_MONTHLY_TOKEN_LIMIT,
     NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE,
-    NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS,
+    NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS, UNKNOWN_SUBSCRIPTION_PLAN_NAME,
 };
 use crate::agent::ports::AgentRepository;
 use crate::agent::ports::AgentService;
@@ -1526,9 +1526,7 @@ impl SubscriptionServiceImpl {
         let has_active_non_hos = subs
             .iter()
             .any(|s| Self::is_active_or_trialing(&s.status) && s.provider != "house-of-stake");
-        let has_active_local_hos = subs
-            .iter()
-            .any(|s| s.provider == "house-of-stake" && Self::is_active_or_trialing(&s.status));
+        let has_any_local_hos = subs.iter().any(|s| s.provider == "house-of-stake");
         let configs = self
             .system_configs_service
             .get_configs()
@@ -1611,9 +1609,25 @@ impl SubscriptionServiceImpl {
                 Err(_) => {}
             }
         }
+        if selected_chain_row.is_some() {
+            if first_err.is_some() {
+                tracing::warn!(
+                    user_id = %user_id.0,
+                    error_category = "rpc_or_decode_error",
+                    "Skipping failed HoS chain subscription candidate during sync"
+                );
+            }
+            if first_parse_err.is_some() {
+                tracing::warn!(
+                    user_id = %user_id.0,
+                    error_category = "parse_error",
+                    "Skipping unparseable HoS chain subscription candidate during sync"
+                );
+            }
+        }
         if selected_chain_row.is_none() {
             if let Some(err) = first_err {
-                if has_active_non_hos && !has_active_local_hos {
+                if has_active_non_hos && !has_any_local_hos {
                     let error_category = if err == NEAR_VIEW_RPC_TIMEOUT_MSG {
                         "timeout"
                     } else {
@@ -1622,7 +1636,7 @@ impl SubscriptionServiceImpl {
                     tracing::warn!(
                         user_id = %user_id.0,
                         error_category = error_category,
-                        "NEAR RPC unavailable during HoS sync; no active local HoS context, reporting retryable sync no-op"
+                        "NEAR RPC unavailable during HoS sync; no local HoS context, reporting retryable sync no-op"
                     );
                     return Ok(Self::hos_reconcile_summary(
                         false,
@@ -1681,9 +1695,14 @@ impl SubscriptionServiceImpl {
         }
 
         let mut row = selected_chain_row.expect("checked is_some");
-        if row.status == SUBSCRIPTION_STATUS_CANCELED {
-            // Chain terminal rows are history, whether restored for Stripe-primary users or refreshed
-            // for HoS-primary users. Keep their shape consistent with local canceled HoS history.
+        let matching_local_hos = subs
+            .iter()
+            .find(|s| s.provider == "house-of-stake" && s.subscription_id == row.subscription_id);
+        let should_normalize_terminal_chain_history = row.status == SUBSCRIPTION_STATUS_CANCELED
+            && !matches!(matching_local_hos, Some(s) if Self::is_active_or_trialing(&s.status));
+        if should_normalize_terminal_chain_history {
+            // Restored or already-inactive chain terminal rows are history. Keep their shape
+            // consistent with local canceled HoS history without changing the active-HoS expiry path.
             row = Self::canceled_house_of_stake_chain_history_row(row);
         }
 
@@ -2809,13 +2828,13 @@ impl SubscriptionService for SubscriptionServiceImpl {
             ) {
                 Some(plan) => plan,
                 None if !Self::is_active_or_trialing(&sub.status) => {
-                    tracing::warn!(
+                    tracing::debug!(
                         user_id = %user_id.0,
                         provider = %sub.provider,
                         price_id = %sub.price_id,
                         "Subscription row has no matching catalog plan; reporting unknown plan"
                     );
-                    "unknown".to_string()
+                    UNKNOWN_SUBSCRIPTION_PLAN_NAME.to_string()
                 }
                 None => {
                     return Err(SubscriptionError::InternalError(format!(

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -2,7 +2,6 @@ use super::near_staking::{
     lock_amount_yocto, subscription_row_from_chain, view_get_lock, view_get_price,
     view_get_purchase, view_get_subscription_for_price, view_storage_balance_bounds,
     view_storage_balance_of, NearStakingStorageBalance, NearStakingStorageBalanceBounds,
-    NEAR_VIEW_RPC_TIMEOUT_MSG,
 };
 use super::ports::{
     BillingCycleAnchor, BillingPeriod, CancelSubscriptionOutcome, ChangePlanOutcome,
@@ -13,7 +12,6 @@ use super::ports::{
     StripeCustomerRepository, StripeSubscriptionSnapshot, StripeUpdateSubscriptionParams,
     Subscription, SubscriptionError, SubscriptionPlan, SubscriptionReplacement,
     SubscriptionRepository, SubscriptionService, SubscriptionWithPlan, DEFAULT_MONTHLY_TOKEN_LIMIT,
-    NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE,
     NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS, UNKNOWN_SUBSCRIPTION_PLAN_NAME,
 };
 use crate::agent::ports::AgentRepository;
@@ -1526,7 +1524,6 @@ impl SubscriptionServiceImpl {
         let has_active_non_hos = subs
             .iter()
             .any(|s| Self::is_active_or_trialing(&s.status) && s.provider != "house-of-stake");
-        let has_any_local_hos = subs.iter().any(|s| s.provider == "house-of-stake");
         let configs = self
             .system_configs_service
             .get_configs()
@@ -1627,45 +1624,10 @@ impl SubscriptionServiceImpl {
         }
         if selected_chain_row.is_none() {
             if let Some(err) = first_err {
-                if has_active_non_hos && !has_any_local_hos {
-                    let error_category = if err == NEAR_VIEW_RPC_TIMEOUT_MSG {
-                        "timeout"
-                    } else {
-                        "rpc_error"
-                    };
-                    tracing::warn!(
-                        user_id = %user_id.0,
-                        error_category = error_category,
-                        "NEAR RPC unavailable during HoS sync; no local HoS context, reporting retryable sync no-op"
-                    );
-                    return Ok(Self::hos_reconcile_summary(
-                        false,
-                        0,
-                        0,
-                        false,
-                        true,
-                        Some(NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE),
-                    ));
-                }
                 return Err(Self::near_rpc_err(err));
             }
             if let Some(err) = first_parse_err {
-                if has_active_non_hos && !has_any_local_hos {
-                    tracing::warn!(
-                        user_id = %user_id.0,
-                        error_category = "parse_error",
-                        "NEAR RPC returned unparseable HoS sync data; no local HoS context, reporting retryable sync no-op"
-                    );
-                    return Ok(Self::hos_reconcile_summary(
-                        false,
-                        0,
-                        0,
-                        false,
-                        true,
-                        Some(NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE),
-                    ));
-                }
-                return Err(SubscriptionError::InternalError(err));
+                return Err(Self::near_rpc_err(err));
             }
         }
 

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -132,7 +132,6 @@ impl SubscriptionServiceImpl {
         deleted: u32,
         canceled: u32,
         upserted: bool,
-        retryable: bool,
         skipped_reason: Option<&'static str>,
     ) -> NearStakingSyncSummary {
         NearStakingSyncSummary {
@@ -140,7 +139,6 @@ impl SubscriptionServiceImpl {
             deleted_house_of_stake_rows: deleted,
             canceled_house_of_stake_rows: canceled,
             upserted_house_of_stake_row: upserted,
-            retryable,
             skipped_reason: skipped_reason.map(String::from),
         }
     }
@@ -1511,13 +1509,13 @@ impl SubscriptionServiceImpl {
             .map(str::trim)
             .filter(|s| !s.is_empty())
         else {
-            return Ok(Self::hos_reconcile_summary(true, 0, 0, false, false, None));
+            return Ok(Self::hos_reconcile_summary(true, 0, 0, false, None));
         };
 
         let near_account = match self.get_near_account_id(user_id).await {
             Ok(a) => a,
             Err(_) => {
-                return Ok(Self::hos_reconcile_summary(true, 0, 0, false, false, None));
+                return Ok(Self::hos_reconcile_summary(true, 0, 0, false, None));
             }
         };
 
@@ -1534,7 +1532,7 @@ impl SubscriptionServiceImpl {
             .unwrap_or_default();
         let configured_hos_price_ids = Self::hos_price_ids(&subscription_plans);
         if configured_hos_price_ids.is_empty() {
-            return Ok(Self::hos_reconcile_summary(true, 0, 0, false, false, None));
+            return Ok(Self::hos_reconcile_summary(true, 0, 0, false, None));
         }
 
         // Prefer the user's stored HoS `price_id`, then fall back to every configured HoS price.
@@ -1627,7 +1625,7 @@ impl SubscriptionServiceImpl {
                 return Err(Self::near_rpc_err(err));
             }
             if let Some(err) = first_parse_err {
-                return Err(Self::near_rpc_err(err));
+                return Err(SubscriptionError::InternalError(err));
             }
         }
 
@@ -1640,7 +1638,7 @@ impl SubscriptionServiceImpl {
                 .cloned()
                 .collect();
             if local_hos_subscriptions.is_empty() {
-                return Ok(Self::hos_reconcile_summary(false, 0, 0, false, false, None));
+                return Ok(Self::hos_reconcile_summary(false, 0, 0, false, None));
             }
             let now = Utc::now();
             let canceled = local_hos_subscriptions.len() as u32;
@@ -1666,9 +1664,7 @@ impl SubscriptionServiceImpl {
                 .await
                 .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
             self.invalidate_credit_limit_cache(user_id).await;
-            return Ok(Self::hos_reconcile_summary(
-                false, 0, canceled, false, false, None,
-            ));
+            return Ok(Self::hos_reconcile_summary(false, 0, canceled, false, None));
         }
 
         let mut row = selected_chain_row.expect("checked is_some");
@@ -1734,7 +1730,6 @@ impl SubscriptionServiceImpl {
                 0,
                 canceled,
                 false,
-                false,
                 Some(NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS),
             ));
         }
@@ -1781,9 +1776,7 @@ impl SubscriptionServiceImpl {
             .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
 
         self.invalidate_credit_limit_cache(user_id).await;
-        Ok(Self::hos_reconcile_summary(
-            false, 0, canceled, true, false, None,
-        ))
+        Ok(Self::hos_reconcile_summary(false, 0, canceled, true, None))
     }
 }
 

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1503,7 +1503,9 @@ impl SubscriptionServiceImpl {
         let has_active_non_hos = subs
             .iter()
             .any(|s| Self::is_active_or_trialing(&s.status) && s.provider != "house-of-stake");
-        let has_local_hos = subs.iter().any(|s| s.provider == "house-of-stake");
+        let has_active_local_hos = subs
+            .iter()
+            .any(|s| s.provider == "house-of-stake" && Self::is_active_or_trialing(&s.status));
         let configs = self
             .system_configs_service
             .get_configs()
@@ -1573,10 +1575,10 @@ impl SubscriptionServiceImpl {
         }
         if raw.is_none() {
             if let Some(err) = first_err {
-                if has_active_non_hos && !has_local_hos {
+                if has_active_non_hos && !has_active_local_hos {
                     tracing::warn!(
                         user_id = %user_id.0,
-                        "NEAR RPC unavailable during HoS sync; no local HoS context, reporting retryable skipped sync"
+                        "NEAR RPC unavailable during HoS sync; no active local HoS context, reporting retryable skipped sync"
                     );
                     return Ok(Self::hos_reconcile_summary(
                         true,

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1635,7 +1635,10 @@ impl SubscriptionServiceImpl {
             let now = Utc::now();
             let clamp_at = if row.current_period_end > now {
                 subs.iter()
-                    .find(|sub| sub.subscription_id == row.subscription_id)
+                    .find(|sub| {
+                        sub.provider == "house-of-stake"
+                            && sub.subscription_id == row.subscription_id
+                    })
                     .map(|sub| sub.current_period_end.min(now))
                     .unwrap_or(now)
             } else {

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -134,6 +134,7 @@ impl SubscriptionServiceImpl {
         deleted: u32,
         canceled: u32,
         upserted: bool,
+        retryable: bool,
         skipped_reason: Option<&'static str>,
     ) -> NearStakingSyncSummary {
         NearStakingSyncSummary {
@@ -141,7 +142,7 @@ impl SubscriptionServiceImpl {
             deleted_house_of_stake_rows: deleted,
             canceled_house_of_stake_rows: canceled,
             upserted_house_of_stake_row: upserted,
-            retryable: false,
+            retryable,
             skipped_reason: skipped_reason.map(String::from),
         }
     }
@@ -1512,13 +1513,13 @@ impl SubscriptionServiceImpl {
             .map(str::trim)
             .filter(|s| !s.is_empty())
         else {
-            return Ok(Self::hos_reconcile_summary(true, 0, 0, false, None));
+            return Ok(Self::hos_reconcile_summary(true, 0, 0, false, false, None));
         };
 
         let near_account = match self.get_near_account_id(user_id).await {
             Ok(a) => a,
             Err(_) => {
-                return Ok(Self::hos_reconcile_summary(true, 0, 0, false, None));
+                return Ok(Self::hos_reconcile_summary(true, 0, 0, false, false, None));
             }
         };
 
@@ -1538,7 +1539,7 @@ impl SubscriptionServiceImpl {
             .unwrap_or_default();
         let configured_hos_price_ids = Self::hos_price_ids(&subscription_plans);
         if configured_hos_price_ids.is_empty() {
-            return Ok(Self::hos_reconcile_summary(true, 0, 0, false, None));
+            return Ok(Self::hos_reconcile_summary(true, 0, 0, false, false, None));
         }
 
         // Prefer the user's stored HoS `price_id`, then fall back to every configured HoS price.
@@ -1606,17 +1607,16 @@ impl SubscriptionServiceImpl {
                     tracing::warn!(
                         user_id = %user_id.0,
                         error_category = error_category,
-                        "NEAR RPC unavailable during HoS sync; no active local HoS context, reporting retryable skipped sync"
+                        "NEAR RPC unavailable during HoS sync; no active local HoS context, reporting retryable sync no-op"
                     );
-                    let mut summary = Self::hos_reconcile_summary(
-                        true,
+                    return Ok(Self::hos_reconcile_summary(
+                        false,
                         0,
                         0,
                         false,
+                        true,
                         Some(NEAR_STAKING_SYNC_SKIPPED_REASON_RPC_UNAVAILABLE),
-                    );
-                    summary.retryable = true;
-                    return Ok(summary);
+                    ));
                 }
                 return Err(Self::near_rpc_err(err));
             }
@@ -1631,7 +1631,7 @@ impl SubscriptionServiceImpl {
                 .cloned()
                 .collect();
             if local_hos_subscriptions.is_empty() {
-                return Ok(Self::hos_reconcile_summary(false, 0, 0, false, None));
+                return Ok(Self::hos_reconcile_summary(false, 0, 0, false, false, None));
             }
             let now = Utc::now();
             let canceled = local_hos_subscriptions.len() as u32;
@@ -1657,7 +1657,9 @@ impl SubscriptionServiceImpl {
                 .await
                 .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
             self.invalidate_credit_limit_cache(user_id).await;
-            return Ok(Self::hos_reconcile_summary(false, 0, canceled, false, None));
+            return Ok(Self::hos_reconcile_summary(
+                false, 0, canceled, false, false, None,
+            ));
         }
 
         let chain_subscription = raw.as_ref().expect("checked is_some");
@@ -1718,6 +1720,7 @@ impl SubscriptionServiceImpl {
                 0,
                 canceled,
                 false,
+                false,
                 Some(NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS),
             ));
         }
@@ -1764,7 +1767,9 @@ impl SubscriptionServiceImpl {
             .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
 
         self.invalidate_credit_limit_cache(user_id).await;
-        Ok(Self::hos_reconcile_summary(false, 0, canceled, true, None))
+        Ok(Self::hos_reconcile_summary(
+            false, 0, canceled, true, false, None,
+        ))
     }
 }
 
@@ -2781,12 +2786,15 @@ impl SubscriptionService for SubscriptionServiceImpl {
         for sub in subscriptions {
             let plan =
                 resolve_plan_name_from_config(&sub.provider, &sub.price_id, &subscription_plans)
-                    .ok_or_else(|| {
-                        SubscriptionError::InternalError(format!(
-                            "Cannot resolve plan for price_id={}, provider={}",
-                            sub.price_id, sub.provider
-                        ))
-                    })?;
+                    .unwrap_or_else(|| {
+                        tracing::warn!(
+                            user_id = %user_id.0,
+                            provider = %sub.provider,
+                            price_id = %sub.price_id,
+                            "Subscription row has no matching catalog plan; reporting unknown plan"
+                        );
+                        "unknown".to_string()
+                    });
             let pending_downgrade_plan =
                 sub.pending_downgrade_target_price_id
                     .as_deref()

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1633,7 +1633,13 @@ impl SubscriptionServiceImpl {
         let mut row = subscription_row_from_chain(user_id, &near_account, chain_subscription)
             .map_err(SubscriptionError::InternalError)?;
         if row.status == SUBSCRIPTION_STATUS_CANCELED {
-            row = Self::canceled_house_of_stake_history_row(row, Utc::now());
+            let now = Utc::now();
+            let clamp_at = subs
+                .iter()
+                .find(|sub| sub.subscription_id == row.subscription_id)
+                .map(|sub| sub.current_period_end.min(now))
+                .unwrap_or(now);
+            row = Self::canceled_house_of_stake_history_row(row, clamp_at);
         }
 
         // Do not insert/update an active HoS row while a non-HoS subscription is active/trialing locally:

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1583,19 +1583,27 @@ impl SubscriptionServiceImpl {
         }))
         .await;
 
-        let mut raw = None;
+        let mut selected_chain_row = None;
         let mut first_err = None;
+        let mut first_parse_err = None;
         for (_, result) in &probe_results {
             match result {
                 Ok(Some(v)) => {
-                    let row = subscription_row_from_chain(user_id, &near_account, v)
-                        .map_err(SubscriptionError::InternalError)?;
+                    let row = match subscription_row_from_chain(user_id, &near_account, v) {
+                        Ok(row) => row,
+                        Err(err) => {
+                            if first_parse_err.is_none() {
+                                first_parse_err = Some(err);
+                            }
+                            continue;
+                        }
+                    };
                     if Self::is_active_or_trialing(&row.status) {
-                        raw = Some(v.clone());
+                        selected_chain_row = Some(row);
                         break;
                     }
-                    if raw.is_none() {
-                        raw = Some(v.clone());
+                    if selected_chain_row.is_none() {
+                        selected_chain_row = Some(row);
                     }
                 }
                 Ok(None) => {}
@@ -1603,7 +1611,7 @@ impl SubscriptionServiceImpl {
                 Err(_) => {}
             }
         }
-        if raw.is_none() {
+        if selected_chain_row.is_none() {
             if let Some(err) = first_err {
                 if has_active_non_hos && !has_active_local_hos {
                     let error_category = if err == NEAR_VIEW_RPC_TIMEOUT_MSG {
@@ -1627,9 +1635,12 @@ impl SubscriptionServiceImpl {
                 }
                 return Err(Self::near_rpc_err(err));
             }
+            if let Some(err) = first_parse_err {
+                return Err(SubscriptionError::InternalError(err));
+            }
         }
 
-        if raw.is_none() {
+        if selected_chain_row.is_none() {
             let mut local_hos_subscriptions: Vec<Subscription> = subs
                 .iter()
                 .filter(|s| {
@@ -1669,10 +1680,10 @@ impl SubscriptionServiceImpl {
             ));
         }
 
-        let chain_subscription = raw.as_ref().expect("checked is_some");
-        let mut row = subscription_row_from_chain(user_id, &near_account, chain_subscription)
-            .map_err(SubscriptionError::InternalError)?;
+        let mut row = selected_chain_row.expect("checked is_some");
         if row.status == SUBSCRIPTION_STATUS_CANCELED {
+            // Chain terminal rows are history, whether restored for Stripe-primary users or refreshed
+            // for HoS-primary users. Keep their shape consistent with local canceled HoS history.
             row = Self::canceled_house_of_stake_chain_history_row(row);
         }
 


### PR DESCRIPTION
## Summary

Allow `POST /v1/subscriptions/near/sync` to restore inactive House-of-Stake subscription history returned by the staking contract, even when the user also has an active non-HoS subscription.

## Root Cause

The HoS sync path skipped all chain upserts whenever an active/trialing non-HoS subscription existed. That guard is needed for active HoS rows because `get_active_subscription` can otherwise pick the newly upserted HoS row over Stripe, but it was too broad for canceled/expired chain rows. Those rows are historical data and are ignored by active entitlement queries.

## Changes

- Remove the pre-RPC early return for active non-HoS users so sync can inspect the staking contract for inactive HoS history.
- Keep blocking active/trialing HoS chain rows when active non-HoS billing exists.
- Prefer active chain probe results over terminal results, using terminal chain rows only as fallback history.
- Permit canceled/expired HoS chain rows to upsert as inactive history.
- Normalize restored or already-inactive canceled HoS rows with a chain-history normalizer that clears inactive flags while preserving the chain-authored `current_period_end`; existing active HoS expiry keeps the chain `cancel_at_period_end` behavior.
- Add `subscriptions.canceled_at`; backfill non-HoS canceled rows from `updated_at` and HoS canceled rows from `LEAST(updated_at, current_period_end)` so restored/backfilled HoS history is distinguishable from genuine HoS lapses.
- Preserve `canceled_at` on repeat canceled upserts/replacements, populate it when active/trialing rows are deactivated, and default it on first insert of canceled rows.
- Exclude restored/backfilled HoS history from free-plan anchoring while preserving genuine HoS lapse anchors after the paid period ends.
- Exclude restored/backfilled HoS history from canceled-user agent-instance cleanup. Cleanup now selects each user by the latest eligible canceled row using stable cancellation ordering, so old restored history cannot bypass the grace window and stale far-future canceled rows do not permanently block cleanup.
- Run database migrations from `task_worker` startup as well as API startup, so worker SQL can safely depend on current schema during rolling deploys.
- Preserve historical `updated_at` fallback and future-row behavior for legacy/non-HoS free-plan anchors.
- Make subscription listing tolerant of off-catalog inactive legacy rows by returning `plan="unknown"` instead of failing the entire inactive list, while keeping active off-catalog rows loud.
- Keep NEAR RPC/decode/parse probe failures as non-2xx failures so existing clients continue to retry or surface sync failure.
- Leave `skipped_reason` empty when the chain simply has no HoS subscription to restore.
- Add regression coverage for restoring expired HoS history, listing off-catalog restored HoS history, keeping active off-catalog rows loud, preferring active chain probe results, normalizing canceled chain history, preserving later past chain expiry, idempotent terminal-row sync including stable `canceled_at`, non-HoS free-plan anchor ordering, restored HoS history exclusion from free-plan anchors, genuine HoS lapse anchoring, legacy future non-HoS anchor behavior, restored-HoS anchor de-ranking, chain-null no-op, RPC failure 503 behavior, existing active HoS expiry compatibility, and cleanup grace protection including stale far-future rows.

## Observable API Notes

- Stripe-primary users with no local HoS rows may now trigger bounded HoS price probes on explicit `/v1/subscriptions/near/sync`; probes are concurrent and bounded by the existing NEAR view timeout.
- If multiple configured HoS prices return chain subscriptions, sync now prefers an active/trialing chain result over terminal history.
- If the chain returns no HoS subscription, the endpoint returns a no-op summary without the blocked-upsert reason.
- NEAR RPC/decode/parse failures remain non-2xx failures; the route documents 503 for NEAR RPC sync failure and 500 for internal parse/validation failures.
- Restored terminal HoS rows return `cancel_at_period_end=false` because they are inactive history, not pending cancellations; existing active HoS expiry keeps the chain value.
- Restored/backfilled HoS terminal `current_period_end` values are stored as chain history but are not used as free-plan anchors or cleanup grace anchors.
- Future non-HoS canceled rows keep the previous repository behavior and can still be returned as the latest cancellation anchor by `updated_at` fallback/backfilled `canceled_at`; downstream free-plan period logic already handles future anchors by using the calendar-month window.
- Off-catalog inactive legacy subscription rows are listed with `plan="unknown"` so `include_inactive=true` remains usable even when an old chain `price_id` is no longer in `subscription_plans`.
- Current `private-assistant` billing code already fetches `/v1/subscriptions?include_inactive=true`, and it does not branch on the old blocked-upsert `skipped_reason`; restored inactive rows are displayable without a frontend change after `/near/sync` has restored them. A frontend auto-sync would only be needed if we want legacy testers to self-heal on page load instead of running sync operationally.

## Validation

- `cargo fmt --check`
- `cargo check -p api --features test`
- `cargo test -p services near_staking`
- `cargo clippy -p api --features test -- -D warnings`
- `cargo test -p api --features test --test subscriptions_tests cleanup_candidates --no-run`
- `git diff --check`
- DB-backed API integration tests are covered by CI; local execution is blocked by Postgres auth in this workspace.