### PR TITLE
fix: restore expired HoS subscriptions from chain

### DIFF
--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -3862,6 +3862,42 @@ fn near_rpc_wiremock_hos_subscription_by_price(
     }
 }
 
+fn near_rpc_wiremock_hos_subscriptions_by_price(
+    subscriptions_by_price: Vec<(&'static str, serde_json::Value)>,
+) -> impl wiremock::Respond {
+    move |req: &wiremock::Request| {
+        use base64::{engine::general_purpose::STANDARD, Engine};
+
+        let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap_or(json!({}));
+        let empty = json!({});
+        let params = body.get("params").unwrap_or(&empty);
+        match params.get("method_name").and_then(|x| x.as_str()) {
+            Some("get_subscription_for_price") => {
+                let args_b64 = params
+                    .get("args_base64")
+                    .and_then(|x| x.as_str())
+                    .unwrap_or("");
+                let decoded = STANDARD
+                    .decode(args_b64)
+                    .ok()
+                    .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+                    .unwrap_or_default();
+                let price_id = decoded
+                    .get("price_id")
+                    .and_then(|x| x.as_str())
+                    .unwrap_or("");
+                let result = subscriptions_by_price
+                    .iter()
+                    .find(|(configured_price_id, _)| *configured_price_id == price_id)
+                    .map(|(_, subscription)| subscription.clone())
+                    .unwrap_or(serde_json::Value::Null);
+                ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(&result))
+            }
+            _ => ResponseTemplate::new(500).set_body_json(json!({ "error": "unmocked NEAR RPC" })),
+        }
+    }
+}
+
 #[test]
 fn test_change_plan_outcome_serde_uses_kind_discriminant() {
     let o = ChangePlanOutcome::NearStakingChangePlan {
@@ -4989,6 +5025,106 @@ async fn test_near_staking_sync_falls_back_to_configured_prices_before_canceling
     let price_id: Option<String> = row.get(1);
     assert_eq!(cnt, 1, "sync should update the existing HoS row");
     assert_eq!(price_id.as_deref(), Some("price_hos_pro"));
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn test_near_staking_sync_prefers_active_chain_subscription_over_expired() {
+    clear_proxy_env_for_local_wiremock();
+    let past_ns = (Utc::now() - Duration::hours(1))
+        .timestamp_nanos_opt()
+        .expect("timestamp nanos")
+        .to_string();
+    let expired_basic = json!({
+        "subscription_id": "sub_chain_hos_expired_basic",
+        "price_id": "price_hos_basic",
+        "end_ns": past_ns,
+        "status": "Expired",
+        "cancel_at_period_end": false
+    });
+    let active_pro = json!({
+        "subscription_id": "sub_chain_hos_active_pro",
+        "price_id": "price_hos_pro",
+        "end_ns": "2000000000000000000",
+        "status": "Active",
+        "cancel_at_period_end": false
+    });
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(near_rpc_wiremock_hos_subscriptions_by_price(vec![
+            ("price_hos_basic", expired_basic),
+            ("price_hos_pro", active_pro),
+        ]))
+        .mount(&mock)
+        .await;
+
+    let (server, db) = create_test_server_and_db(TestServerConfig {
+        near_rpc_url: Some(mock.uri().to_string()),
+        near_staking_contract_id: Some("staking.testnet".to_string()),
+        ..Default::default()
+    })
+    .await;
+
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": { "providers": { "house-of-stake": { "price_id": "price_hos_basic" } }, "agent_instances": { "max": 1 }, "monthly_credits": { "max": 1000000 } },
+            "pro": { "providers": { "house-of-stake": { "price_id": "price_hos_pro" } }, "agent_instances": { "max": 1 }, "monthly_credits": { "max": 1000000 } }
+        }),
+    )
+    .await;
+
+    let near_email = "hos_sync_prefers_active.testnet@near";
+    let login = json!({
+        "email": near_email,
+        "name": "HoS Sync Prefers Active",
+        "oauth_provider": "near"
+    });
+    let response = server.post("/v1/auth/mock-login").json(&login).await;
+    let token = response.json::<serde_json::Value>()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let response = server
+        .post("/v1/subscriptions/near/sync")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body: serde_json::Value = response.json();
+    assert_eq!(
+        body.get("upserted_house_of_stake_row")
+            .and_then(|x| x.as_bool()),
+        Some(true)
+    );
+
+    let user = db
+        .user_repository()
+        .get_user_by_email(near_email)
+        .await
+        .unwrap()
+        .unwrap();
+    let client = db.pool().get().await.unwrap();
+    let row = client
+        .query_one(
+            "SELECT subscription_id, price_id, status
+             FROM subscriptions
+             WHERE user_id = $1 AND provider = 'house-of-stake'",
+            &[&user.id],
+        )
+        .await
+        .expect("load synced HoS row");
+    assert_eq!(
+        row.get::<_, String>("subscription_id"),
+        "sub_chain_hos_active_pro"
+    );
+    assert_eq!(row.get::<_, String>("price_id"), "price_hos_pro");
+    assert_eq!(row.get::<_, String>("status"), "active");
 }
 
 #[tokio::test]

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -4621,7 +4621,14 @@ async fn test_near_staking_sync_restores_expired_hos_history_when_active_stripe_
     set_subscription_plans(
         &server,
         json!({
-            "basic": { "providers": { "house-of-stake": { "price_id": "price_hos_basic" } }, "agent_instances": { "max": 1 }, "monthly_credits": { "max": 1000000 } }
+            "basic": {
+                "providers": {
+                    "stripe": { "price_id": "price_test_basic" },
+                    "house-of-stake": { "price_id": "price_hos_basic" }
+                },
+                "agent_instances": { "max": 1 },
+                "monthly_credits": { "max": 1000000 }
+            }
         }),
     )
     .await;

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -4591,6 +4591,129 @@ async fn test_near_staking_sync_skipped_reason_when_upsert_blocked_by_active_str
 
 #[tokio::test]
 #[serial(subscription_tests)]
+async fn test_near_staking_sync_restores_expired_hos_history_when_active_stripe_exists() {
+    clear_proxy_env_for_local_wiremock();
+    let past_ns = (Utc::now() - Duration::hours(1))
+        .timestamp_nanos_opt()
+        .expect("timestamp nanos")
+        .to_string();
+    let chain_sub = json!({
+        "subscription_id": "sub_on_chain_hos_expired_restore",
+        "price_id": "price_hos_basic",
+        "end_ns": past_ns,
+        "status": "Expired",
+        "cancel_at_period_end": false
+    });
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(near_rpc_wiremock_hos_subscription_probe_only(chain_sub))
+        .mount(&mock)
+        .await;
+
+    let (server, db) = create_test_server_and_db(TestServerConfig {
+        near_rpc_url: Some(mock.uri().to_string()),
+        near_staking_contract_id: Some("staking.testnet".to_string()),
+        ..Default::default()
+    })
+    .await;
+
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": { "providers": { "house-of-stake": { "price_id": "price_hos_basic" } }, "agent_instances": { "max": 1 }, "monthly_credits": { "max": 1000000 } }
+        }),
+    )
+    .await;
+
+    let near_email = "hos_sync_restore_expired_with_stripe.testnet@near";
+    let login = json!({
+        "email": near_email,
+        "name": "HoS Restore Expired With Stripe",
+        "oauth_provider": "near"
+    });
+    let response = server.post("/v1/auth/mock-login").json(&login).await;
+    let token = response.json::<serde_json::Value>()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    insert_test_subscription(&server, &db, near_email, false).await;
+
+    let response = server
+        .post("/v1/subscriptions/near/sync")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body: serde_json::Value = response.json();
+    assert_eq!(body.get("skipped").and_then(|x| x.as_bool()), Some(false));
+    assert_eq!(
+        body.get("deleted_house_of_stake_rows")
+            .and_then(|x| x.as_u64()),
+        Some(0)
+    );
+    assert_eq!(
+        body.get("canceled_house_of_stake_rows")
+            .and_then(|x| x.as_u64()),
+        Some(0)
+    );
+    assert_eq!(
+        body.get("upserted_house_of_stake_row")
+            .and_then(|x| x.as_bool()),
+        Some(true)
+    );
+    assert!(body.get("skipped_reason").is_none());
+
+    let user = db
+        .user_repository()
+        .get_user_by_email(near_email)
+        .await
+        .unwrap()
+        .unwrap();
+    let client = db.pool().get().await.unwrap();
+    let row = client
+        .query_one(
+            "SELECT status, current_period_end
+             FROM subscriptions
+             WHERE user_id = $1
+               AND provider = 'house-of-stake'
+               AND subscription_id = 'sub_on_chain_hos_expired_restore'",
+            &[&user.id],
+        )
+        .await
+        .expect("expired HoS history should be restored from chain");
+    assert_eq!(row.get::<_, String>("status"), "canceled");
+    assert!(row.get::<_, chrono::DateTime<Utc>>("current_period_end") <= Utc::now());
+
+    let response = server
+        .get("/v1/subscriptions?include_inactive=true")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body: serde_json::Value = response.json();
+    let subscriptions = body["subscriptions"]
+        .as_array()
+        .expect("subscriptions should be an array");
+    assert!(
+        subscriptions.iter().any(|sub| {
+            sub.get("subscription_id").and_then(|v| v.as_str())
+                == Some("sub_on_chain_hos_expired_restore")
+                && sub.get("status").and_then(|v| v.as_str()) == Some("canceled")
+        }),
+        "restored expired HoS history should be listed when inactive rows are included"
+    );
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
 async fn test_near_staking_sync_marks_local_hos_canceled_when_chain_returns_null() {
     clear_proxy_env_for_local_wiremock();
     let mock = MockServer::start().await;

--- a/crates/services/src/subscription/near_staking.rs
+++ b/crates/services/src/subscription/near_staking.rs
@@ -361,20 +361,24 @@ pub fn subscription_row_from_chain(
         .map(ts_ns_to_datetime)
         .transpose()?;
 
-    let (pd_target, pd_from, pd_end, pd_status) = if let Some(ref tgt) = pending_down {
-        (
-            Some(tgt.clone()),
-            Some(price_id.clone()),
-            Some(pending_apply_at.unwrap_or(current_period_end)),
-            Some(DowngradeIntentStatus::Pending),
-        )
-    } else if has_stake_only_pending_update {
-        (
-            None,
-            Some(price_id.clone()),
-            Some(pending_apply_at.unwrap_or(current_period_end)),
-            Some(DowngradeIntentStatus::Pending),
-        )
+    let (pd_target, pd_from, pd_end, pd_status) = if status == "active" {
+        if let Some(ref tgt) = pending_down {
+            (
+                Some(tgt.clone()),
+                Some(price_id.clone()),
+                Some(pending_apply_at.unwrap_or(current_period_end)),
+                Some(DowngradeIntentStatus::Pending),
+            )
+        } else if has_stake_only_pending_update {
+            (
+                None,
+                Some(price_id.clone()),
+                Some(pending_apply_at.unwrap_or(current_period_end)),
+                Some(DowngradeIntentStatus::Pending),
+            )
+        } else {
+            (None, None, None, None)
+        }
     } else {
         (None, None, None, None)
     };
@@ -544,6 +548,34 @@ mod tests {
         );
         assert!(row.pending_downgrade_expected_period_end.is_some());
         assert!(row.pending_downgrade_updated_at.is_some());
+    }
+
+    #[test]
+    fn subscription_row_clears_pending_update_for_canceled_status() {
+        let future_end_ns = (Utc::now() + chrono::Duration::hours(1))
+            .timestamp_nanos_opt()
+            .expect("timestamp nanos")
+            .to_string();
+        let chain = chain_subscription(json!({
+            "subscription_id": "sub_hos_canceled_pending",
+            "price_id": "price_hos_pro",
+            "end_ns": future_end_ns,
+            "status": "Expired",
+            "pending_update": {
+                "target_price_id": "price_hos_basic",
+                "target_amount": null,
+                "apply_ns": future_end_ns
+            }
+        }));
+        let row = subscription_row_from_chain(UserId(Uuid::new_v4()), "alice.testnet", &chain)
+            .expect("parse chain subscription");
+
+        assert_eq!(row.status, "canceled");
+        assert_eq!(row.pending_downgrade_target_price_id, None);
+        assert_eq!(row.pending_downgrade_from_price_id, None);
+        assert_eq!(row.pending_downgrade_expected_period_end, None);
+        assert_eq!(row.pending_downgrade_status, None);
+        assert_eq!(row.pending_downgrade_updated_at, None);
     }
 
     #[test]

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1502,22 +1502,6 @@ impl SubscriptionServiceImpl {
         let has_active_non_hos = subs
             .iter()
             .any(|s| Self::is_active_or_trialing(&s.status) && s.provider != "house-of-stake");
-        let hos_subscription_ids: Vec<String> = subs
-            .iter()
-            .filter(|s| s.provider == "house-of-stake")
-            .map(|s| s.subscription_id.clone())
-            .collect();
-
-        if has_active_non_hos && hos_subscription_ids.is_empty() {
-            return Ok(Self::hos_reconcile_summary(
-                false,
-                0,
-                0,
-                false,
-                Some(NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS),
-            ));
-        }
-
         let configs = self
             .system_configs_service
             .get_configs()
@@ -1633,10 +1617,12 @@ impl SubscriptionServiceImpl {
         let row = subscription_row_from_chain(user_id, &near_account, chain_subscription)
             .map_err(SubscriptionError::InternalError)?;
 
-        // Do not insert/update a HoS row while a non-HoS subscription is active/trialing locally:
+        // Do not insert/update an active HoS row while a non-HoS subscription is active/trialing locally:
         // `get_active_subscription` picks newest `created_at`, so a fresh HoS upsert could wrongly
         // become the "active" row for Stripe-primary users who also staked on-chain separately.
-        if has_active_non_hos {
+        // Canceled/expired chain rows are safe to upsert as history and allow restoring HoS rows
+        // that were deleted before canceled history was preserved locally.
+        if has_active_non_hos && Self::is_active_or_trialing(&row.status) {
             let active_hos_subscriptions: Vec<Subscription> = subs
                 .iter()
                 .filter(|s| {

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1557,17 +1557,29 @@ impl SubscriptionServiceImpl {
         .await;
 
         let mut raw = None;
+        let mut active_raw = None;
+        let mut active_end_ns = 0;
         let mut first_err = None;
         for (_, result) in &probe_results {
             match result {
                 Ok(Some(v)) => {
-                    raw = Some(v.clone());
-                    break;
+                    if raw.is_none() {
+                        raw = Some(v.clone());
+                    }
+                    let candidate = subscription_row_from_chain(user_id, &near_account, v)
+                        .map_err(SubscriptionError::InternalError)?;
+                    if Self::is_active_or_trialing(&candidate.status) && v.end_ns >= active_end_ns {
+                        active_end_ns = v.end_ns;
+                        active_raw = Some(v.clone());
+                    }
                 }
                 Ok(None) => {}
                 Err(e) if first_err.is_none() => first_err = Some(e.clone()),
                 Err(_) => {}
             }
+        }
+        if active_raw.is_some() {
+            raw = active_raw;
         }
         if raw.is_none() {
             if let Some(err) = first_err {


### PR DESCRIPTION
## Summary

Restore canceled House-of-Stake subscription history from the smart contract when sync receives an expired subscription payload for the user.

## Root Cause

PR #344 preserved HoS rows that still existed locally, but rows already hard-deleted before that fix could not be restored. The sync path also skipped chain probing when a user had an active non-HoS subscription and no local HoS row, which prevented reconstructing deleted HoS history from an expired contract subscription.

## Changes

- Always probe configured HoS prices during explicit NEAR sync once HoS is configured and the user has a linked NEAR account.
- Keep blocking active/trialing HoS upserts when an active non-HoS subscription exists.
- Allow expired/canceled chain subscriptions through that guard so they can be upserted as canceled history rows.
- Add regression coverage for restoring an expired HoS row when local HoS history is missing and active Stripe exists.

## Validation

- `cargo fmt`
- `git diff --check -- crates/services/src/subscription/service.rs crates/api/tests/subscriptions_tests.rs`
- `cargo test -p api --features test --test subscriptions_tests test_near_staking_sync_restores_expired_hos_history_when_active_stripe_exists --no-run`
- `cargo test -p services subscription_row_marks_active_row_canceled_after_period_end`

Note: the DB-backed integration test binary builds locally, but the local test database auth currently fails before assertions with `FATAL: password authentication failed for user "postgres"`.