### PR TITLE
fix: use effective HoS locks for credits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5564,6 +5564,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64",
  "bytes",
  "chrono",
  "config",

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -3716,6 +3716,13 @@ fn near_rpc_hos_catalog_respond_with_pending_update(
         .get("method_name")
         .and_then(|x| x.as_str())
         .unwrap_or("");
+    let decoded_args = params
+        .get("args_base64")
+        .and_then(|x| x.as_str())
+        .and_then(|args| STANDARD.decode(args).ok())
+        .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+        .unwrap_or_default();
+
     match method_name {
         "get_subscription_for_price" => {
             let mut sub = json!({
@@ -3736,16 +3743,7 @@ fn near_rpc_hos_catalog_respond_with_pending_update(
             ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(&sub))
         }
         "get_price" => {
-            let args_b64 = params
-                .get("args_base64")
-                .and_then(|x| x.as_str())
-                .unwrap_or("");
-            let decoded = STANDARD
-                .decode(args_b64)
-                .ok()
-                .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
-                .unwrap_or_default();
-            let pid = decoded
+            let pid = decoded_args
                 .get("price_id")
                 .and_then(|x| x.as_str())
                 .unwrap_or("");
@@ -3757,6 +3755,10 @@ fn near_rpc_hos_catalog_respond_with_pending_update(
             ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(price))
         }
         "get_lock" => {
+            assert!(
+                decoded_args.get("effective").is_none(),
+                "HoS change-plan quote must use the stored lock amount, not the effective projection"
+            );
             let amount_near = if active_price_id == "price_hos_pro" {
                 "2000000000000000000000000"
             } else {
@@ -3931,7 +3933,11 @@ async fn test_house_of_stake_credits_use_effective_lock_amount_after_projected_d
                         "end_ns": "2000000000000000000",
                         "status": "Active",
                         "cancel_at_period_end": false,
-                        "pending_update": null
+                        "pending_update": {
+                            "target_price_id": null,
+                            "target_amount": "10000000000000000000000000",
+                            "apply_ns": "1000000000000000000"
+                        }
                     })))
                 }
                 "get_lock" => {
@@ -3939,14 +3945,15 @@ async fn test_house_of_stake_credits_use_effective_lock_amount_after_projected_d
                         decoded_args.get("lock_id").and_then(|x| x.as_str()),
                         Some("lock_chain_hos_effective_credits")
                     );
-                    assert_eq!(
-                        decoded_args.get("effective").and_then(|x| x.as_bool()),
-                        Some(true),
-                        "HoS credit calculation must request the contract's effective lock view"
-                    );
+                    let amount_near =
+                        if decoded_args.get("effective").and_then(|x| x.as_bool()) == Some(true) {
+                            "10000000000000000000000000"
+                        } else {
+                            "100000000000000000000000000"
+                        };
                     ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(&json!({
                         "lock_id": "lock_chain_hos_effective_credits",
-                        "amount_near": "10000000000000000000000000"
+                        "amount_near": amount_near
                     })))
                 }
                 _ => ResponseTemplate::new(500).set_body_json(json!({

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -3900,66 +3900,76 @@ fn near_rpc_wiremock_hos_subscriptions_by_price(
     }
 }
 
-#[tokio::test]
-#[serial(subscription_tests)]
-async fn test_house_of_stake_credits_use_effective_lock_amount_after_projected_downgrade() {
+async fn assert_house_of_stake_credits_for_effective_lock(
+    effective_lock: serde_json::Value,
+    expected_plan_credits: i64,
+    near_email: &str,
+    assertion_message: &str,
+) {
     clear_proxy_env_for_local_wiremock();
     let mock = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/"))
-        .respond_with(|req: &wiremock::Request| {
-            use base64::{engine::general_purpose::STANDARD, Engine};
+        .respond_with({
+            let effective_lock = effective_lock.clone();
+            move |req: &wiremock::Request| {
+                use base64::{engine::general_purpose::STANDARD, Engine};
 
-            let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap_or(json!({}));
-            let empty = json!({});
-            let params = body.get("params").unwrap_or(&empty);
-            let method_name = params
-                .get("method_name")
-                .and_then(|x| x.as_str())
-                .unwrap_or("");
-            let decoded_args = params
-                .get("args_base64")
-                .and_then(|x| x.as_str())
-                .and_then(|args| STANDARD.decode(args).ok())
-                .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
-                .unwrap_or_default();
+                let body: serde_json::Value =
+                    serde_json::from_slice(&req.body).unwrap_or(json!({}));
+                let empty = json!({});
+                let params = body.get("params").unwrap_or(&empty);
+                let method_name = params
+                    .get("method_name")
+                    .and_then(|x| x.as_str())
+                    .unwrap_or("");
+                let decoded_args = params
+                    .get("args_base64")
+                    .and_then(|x| x.as_str())
+                    .and_then(|args| STANDARD.decode(args).ok())
+                    .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+                    .unwrap_or_default();
 
-            match method_name {
-                "get_subscription_for_price" => {
-                    ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(&json!({
-                        "subscription_id": "sub_chain_hos_effective_credits",
-                        "price_id": "price_hos_basic",
-                        "last_lock_id": "lock_chain_hos_effective_credits",
-                        "end_ns": "2000000000000000000",
-                        "status": "Active",
-                        "cancel_at_period_end": false,
-                        "pending_update": {
-                            "target_price_id": null,
-                            "target_amount": "10000000000000000000000000",
-                            "apply_ns": "1000000000000000000"
-                        }
-                    })))
-                }
-                "get_lock" => {
-                    assert_eq!(
-                        decoded_args.get("lock_id").and_then(|x| x.as_str()),
-                        Some("lock_chain_hos_effective_credits")
-                    );
-                    let amount_near =
-                        if decoded_args.get("effective").and_then(|x| x.as_bool()) == Some(true) {
-                            "10000000000000000000000000"
+                match method_name {
+                    "get_subscription_for_price" => ResponseTemplate::new(200).set_body_json(
+                        near_rpc_call_function_body(&json!({
+                            "subscription_id": "sub_chain_hos_effective_credits",
+                            "price_id": "price_hos_basic",
+                            "last_lock_id": "lock_chain_hos_effective_credits",
+                            "end_ns": "2000000000000000000",
+                            "status": "Active",
+                            "cancel_at_period_end": false,
+                            "pending_update": {
+                                "target_price_id": null,
+                                "target_amount": "10000000000000000000000000",
+                                "apply_ns": "1000000000000000000"
+                            }
+                        })),
+                    ),
+                    "get_lock" => {
+                        assert_eq!(
+                            decoded_args.get("lock_id").and_then(|x| x.as_str()),
+                            Some("lock_chain_hos_effective_credits")
+                        );
+                        let lock = if decoded_args.get("effective").and_then(|x| x.as_bool())
+                            == Some(true)
+                        {
+                            effective_lock.clone()
                         } else {
-                            "100000000000000000000000000"
+                            json!({
+                                "lock_id": "lock_chain_hos_effective_credits",
+                                "amount_near": "100000000000000000000000000",
+                                "status": "Active",
+                                "shares": "100000000000000000000000000"
+                            })
                         };
-                    ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(&json!({
-                        "lock_id": "lock_chain_hos_effective_credits",
-                        "amount_near": amount_near
-                    })))
+                        ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(&lock))
+                    }
+                    _ => ResponseTemplate::new(500).set_body_json(json!({
+                        "error": "unexpected NEAR RPC mock",
+                        "method_name": method_name
+                    })),
                 }
-                _ => ResponseTemplate::new(500).set_body_json(json!({
-                    "error": "unexpected NEAR RPC mock",
-                    "method_name": method_name
-                })),
             }
         })
         .mount(&mock)
@@ -3986,7 +3996,6 @@ async fn test_house_of_stake_credits_use_effective_lock_amount_after_projected_d
     )
     .await;
 
-    let near_email = "hos_effective_credits.testnet@near";
     let login = json!({
         "email": near_email,
         "name": "HoS Effective Credits",
@@ -4013,9 +4022,43 @@ async fn test_house_of_stake_credits_use_effective_lock_amount_after_projected_d
     let body: serde_json::Value = response.json();
     assert_eq!(
         body.get("plan_credits").and_then(|x| x.as_i64()),
-        Some(5_000_000_000),
-        "10 effective staked NEAR at $0.50/NEAR should grant $5 plan credits"
+        Some(expected_plan_credits),
+        "{assertion_message}"
     );
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn test_house_of_stake_credits_use_effective_lock_amount_after_projected_downgrade() {
+    assert_house_of_stake_credits_for_effective_lock(
+        json!({
+            "lock_id": "lock_chain_hos_effective_credits",
+            "amount_near": "10000000000000000000000000",
+            "status": "Active",
+            "shares": "10000000000000000000000000"
+        }),
+        5_000_000_000,
+        "hos_effective_credits.testnet@near",
+        "10 effective staked NEAR at $0.50/NEAR should grant $5 plan credits",
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn test_house_of_stake_credits_zero_for_effective_lock_with_no_active_shares() {
+    assert_house_of_stake_credits_for_effective_lock(
+        json!({
+            "lock_id": "lock_chain_hos_effective_credits",
+            "amount_near": "30000000000000000000000000",
+            "status": "UnlockRequested",
+            "shares": "0"
+        }),
+        0,
+        "hos_effective_zero_shares.testnet@near",
+        "effective locks with no active shares must grant zero stake-based credits",
+    )
+    .await;
 }
 
 #[test]

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -3898,6 +3898,119 @@ fn near_rpc_wiremock_hos_subscriptions_by_price(
     }
 }
 
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn test_house_of_stake_credits_use_effective_lock_amount_after_projected_downgrade() {
+    clear_proxy_env_for_local_wiremock();
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(|req: &wiremock::Request| {
+            use base64::{engine::general_purpose::STANDARD, Engine};
+
+            let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap_or(json!({}));
+            let empty = json!({});
+            let params = body.get("params").unwrap_or(&empty);
+            let method_name = params
+                .get("method_name")
+                .and_then(|x| x.as_str())
+                .unwrap_or("");
+            let decoded_args = params
+                .get("args_base64")
+                .and_then(|x| x.as_str())
+                .and_then(|args| STANDARD.decode(args).ok())
+                .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+                .unwrap_or_default();
+
+            match method_name {
+                "get_subscription_for_price" => {
+                    ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(&json!({
+                        "subscription_id": "sub_chain_hos_effective_credits",
+                        "price_id": "price_hos_basic",
+                        "last_lock_id": "lock_chain_hos_effective_credits",
+                        "end_ns": "2000000000000000000",
+                        "status": "Active",
+                        "cancel_at_period_end": false,
+                        "pending_update": null
+                    })))
+                }
+                "get_lock" => {
+                    assert_eq!(
+                        decoded_args.get("lock_id").and_then(|x| x.as_str()),
+                        Some("lock_chain_hos_effective_credits")
+                    );
+                    assert_eq!(
+                        decoded_args.get("effective").and_then(|x| x.as_bool()),
+                        Some(true),
+                        "HoS credit calculation must request the contract's effective lock view"
+                    );
+                    ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(&json!({
+                        "lock_id": "lock_chain_hos_effective_credits",
+                        "amount_near": "10000000000000000000000000"
+                    })))
+                }
+                _ => ResponseTemplate::new(500).set_body_json(json!({
+                    "error": "unexpected NEAR RPC mock",
+                    "method_name": method_name
+                })),
+            }
+        })
+        .mount(&mock)
+        .await;
+
+    let (server, db) = create_test_server_and_db(TestServerConfig {
+        near_rpc_url: Some(mock.uri().to_string()),
+        near_staking_contract_id: Some("staking.testnet".to_string()),
+        ..Default::default()
+    })
+    .await;
+
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": {
+                "providers": { "house-of-stake": { "price_id": "price_hos_basic" } },
+                "agent_instances": { "max": 2 },
+                "stake_based_monthly_credits": {
+                    "credits_per_staked_near_nano_usd": 500000000
+                }
+            }
+        }),
+    )
+    .await;
+
+    let near_email = "hos_effective_credits.testnet@near";
+    let login = json!({
+        "email": near_email,
+        "name": "HoS Effective Credits",
+        "oauth_provider": "near"
+    });
+    let response = server.post("/v1/auth/mock-login").json(&login).await;
+    let token = response.json::<serde_json::Value>()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    cleanup_user_subscriptions(&db, near_email).await;
+    insert_house_of_stake_subscription_for_existing_user(&db, near_email, "price_hos_basic", false)
+        .await;
+
+    let response = server
+        .get("/v1/credits")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body: serde_json::Value = response.json();
+    assert_eq!(
+        body.get("plan_credits").and_then(|x| x.as_i64()),
+        Some(5_000_000_000),
+        "10 effective staked NEAR at $0.50/NEAR should grant $5 plan credits"
+    );
+}
+
 #[test]
 fn test_change_plan_outcome_serde_uses_kind_discriminant() {
     let o = ChangePlanOutcome::NearStakingChangePlan {

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -60,3 +60,4 @@ futures = "0.3"
 wiremock = "0.6"
 tokio = { version = "1", features = ["full"] }
 mockall = "0.13"
+base64 = "0.22"

--- a/crates/services/src/subscription/near_staking.rs
+++ b/crates/services/src/subscription/near_staking.rs
@@ -64,6 +64,16 @@ where
     })
 }
 
+fn deserialize_optional_u128<'de, D>(deserializer: D) -> Result<Option<u128>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let Some(value) = Option::<IntegerStringOrNumber>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    parse_u128_value::<D>(value).map(Some)
+}
+
 fn deserialize_required_yocto_near<'de, D>(deserializer: D) -> Result<YoctoNear, D::Error>
 where
     D: Deserializer<'de>,
@@ -201,6 +211,10 @@ pub struct NearStakingPurchase {
 pub struct NearStakingLock {
     #[serde(default, deserialize_with = "deserialize_optional_yocto_near")]
     pub amount_near: Option<YoctoNear>,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_u128")]
+    pub shares: Option<u128>,
 }
 
 async fn view_call<Args, Response>(
@@ -347,6 +361,13 @@ pub async fn view_get_effective_lock(
 /// Parse lock `amount_near` field as yoctoNEAR integer.
 pub fn lock_amount_yocto(lock: &NearStakingLock) -> Option<u128> {
     lock.amount_near.map(YoctoNear::as_u128)
+}
+
+pub fn lock_has_active_shares(lock: &NearStakingLock) -> bool {
+    lock.status
+        .as_deref()
+        .is_some_and(|status| status.eq_ignore_ascii_case("active"))
+        && lock.shares.is_some_and(|shares| shares > 0)
 }
 
 /// Map stake.dao `Subscription` into our DB [`Subscription`] row (`provider = house-of-stake`).
@@ -560,6 +581,33 @@ mod tests {
             lock_amount_yocto(&out),
             Some(10_000_000_000_000_000_000_000_000)
         );
+    }
+
+    #[test]
+    fn lock_has_active_shares_requires_active_status_and_nonzero_shares() {
+        let active: NearStakingLock = serde_json::from_value(json!({
+            "amount_near": "30000000000000000000000000",
+            "status": "Active",
+            "shares": "1"
+        }))
+        .expect("active lock");
+        assert!(lock_has_active_shares(&active));
+
+        let unlock_requested: NearStakingLock = serde_json::from_value(json!({
+            "amount_near": "30000000000000000000000000",
+            "status": "UnlockRequested",
+            "shares": "1"
+        }))
+        .expect("unlock requested lock");
+        assert!(!lock_has_active_shares(&unlock_requested));
+
+        let zero_shares: NearStakingLock = serde_json::from_value(json!({
+            "amount_near": "30000000000000000000000000",
+            "status": "Active",
+            "shares": "0"
+        }))
+        .expect("zero-share lock");
+        assert!(!lock_has_active_shares(&zero_shares));
     }
 
     #[test]

--- a/crates/services/src/subscription/near_staking.rs
+++ b/crates/services/src/subscription/near_staking.rs
@@ -101,6 +101,8 @@ struct GetPurchaseArgs<'a> {
 #[derive(Debug, Clone, Serialize)]
 struct GetLockArgs<'a> {
     lock_id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    effective: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -311,7 +313,35 @@ pub async fn view_get_lock(
     contract_id: &str,
     lock_id: &str,
 ) -> Result<Option<NearStakingLock>, String> {
-    view_call(rpc_url, contract_id, "get_lock", GetLockArgs { lock_id }).await
+    view_call(
+        rpc_url,
+        contract_id,
+        "get_lock",
+        GetLockArgs {
+            lock_id,
+            effective: None,
+        },
+    )
+    .await
+}
+
+/// Fetch `get_lock(lock_id, effective=true)` for HoS entitlement reads that
+/// need due subscription downgrades projected without mutating contract state.
+pub async fn view_get_effective_lock(
+    rpc_url: &str,
+    contract_id: &str,
+    lock_id: &str,
+) -> Result<Option<NearStakingLock>, String> {
+    view_call(
+        rpc_url,
+        contract_id,
+        "get_lock",
+        GetLockArgs {
+            lock_id,
+            effective: Some(true),
+        },
+    )
+    .await
 }
 
 /// Parse lock `amount_near` field as yoctoNEAR integer.
@@ -472,6 +502,64 @@ mod tests {
                 .await
                 .expect("rpc client");
         assert!(out.is_none());
+    }
+
+    #[tokio::test]
+    async fn view_get_effective_lock_sends_effective_true() {
+        for k in [
+            "http_proxy",
+            "https_proxy",
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "ALL_PROXY",
+            "all_proxy",
+        ] {
+            std::env::remove_var(k);
+        }
+        std::env::set_var("NO_PROXY", "127.0.0.1,localhost");
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/"))
+            .respond_with(|req: &wiremock::Request| {
+                use base64::{engine::general_purpose::STANDARD, Engine};
+
+                let body: Value = serde_json::from_slice(&req.body).expect("request body");
+                let params = body.get("params").expect("query params");
+                assert_eq!(
+                    params.get("method_name").and_then(|x| x.as_str()),
+                    Some("get_lock")
+                );
+                let decoded = params
+                    .get("args_base64")
+                    .and_then(|x| x.as_str())
+                    .and_then(|args| STANDARD.decode(args).ok())
+                    .and_then(|bytes| serde_json::from_slice::<Value>(&bytes).ok())
+                    .expect("decoded args");
+                assert_eq!(
+                    decoded.get("lock_id").and_then(|x| x.as_str()),
+                    Some("lock_effective")
+                );
+                assert_eq!(
+                    decoded.get("effective").and_then(|x| x.as_bool()),
+                    Some(true)
+                );
+
+                ResponseTemplate::new(200).set_body_json(call_function_query_response(&json!({
+                    "amount_near": "10000000000000000000000000"
+                })))
+            })
+            .mount(&mock)
+            .await;
+
+        let url = mock.uri();
+        let out = view_get_effective_lock(&url, "staking.testnet", "lock_effective")
+            .await
+            .expect("rpc client")
+            .expect("lock");
+        assert_eq!(
+            lock_amount_yocto(&out),
+            Some(10_000_000_000_000_000_000_000_000)
+        );
     }
 
     #[test]

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1,7 +1,8 @@
 use super::near_staking::{
-    lock_amount_yocto, subscription_row_from_chain, view_get_effective_lock, view_get_price,
-    view_get_purchase, view_get_subscription_for_price, view_storage_balance_bounds,
-    view_storage_balance_of, NearStakingStorageBalance, NearStakingStorageBalanceBounds,
+    lock_amount_yocto, subscription_row_from_chain, view_get_effective_lock, view_get_lock,
+    view_get_price, view_get_purchase, view_get_subscription_for_price,
+    view_storage_balance_bounds, view_storage_balance_of, NearStakingStorageBalance,
+    NearStakingStorageBalanceBounds,
 };
 use super::ports::{
     BillingCycleAnchor, BillingPeriod, CancelSubscriptionOutcome, ChangePlanOutcome,
@@ -2515,7 +2516,7 @@ impl SubscriptionService for SubscriptionServiceImpl {
                 .ok_or_else(|| {
                     SubscriptionError::InternalError("HoS subscription missing last_lock_id".into())
                 })?;
-            let lock_j = view_get_effective_lock(&self.near_rpc_url, contract_id, last_lock_id)
+            let lock_j = view_get_lock(&self.near_rpc_url, contract_id, last_lock_id)
                 .await
                 .map_err(Self::near_rpc_err)?
                 .ok_or_else(|| {

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1,8 +1,8 @@
 use super::near_staking::{
-    lock_amount_yocto, subscription_row_from_chain, view_get_effective_lock, view_get_lock,
-    view_get_price, view_get_purchase, view_get_subscription_for_price,
-    view_storage_balance_bounds, view_storage_balance_of, NearStakingStorageBalance,
-    NearStakingStorageBalanceBounds,
+    lock_amount_yocto, lock_has_active_shares, subscription_row_from_chain,
+    view_get_effective_lock, view_get_lock, view_get_price, view_get_purchase,
+    view_get_subscription_for_price, view_storage_balance_bounds, view_storage_balance_of,
+    NearStakingStorageBalance, NearStakingStorageBalanceBounds,
 };
 use super::ports::{
     BillingCycleAnchor, BillingPeriod, CancelSubscriptionOutcome, ChangePlanOutcome,
@@ -1127,6 +1127,31 @@ impl SubscriptionServiceImpl {
                     return None;
                 }
             };
+
+        if !lock_has_active_shares(&lock) {
+            let lock_status = lock.status.as_deref().unwrap_or("<missing>");
+            let lock_shares = lock
+                .shares
+                .map(|shares| shares.to_string())
+                .unwrap_or_else(|| "<missing>".to_string());
+            tracing::warn!(
+                user_id = %user_id.0,
+                subscription_id = %subscription.subscription_id,
+                last_lock_id,
+                lock_status = %lock_status,
+                lock_shares = %lock_shares,
+                "HoS effective lock is not active with staked shares; granting zero stake-based credits"
+            );
+            self.house_of_stake_stake_source_cache.write().await.insert(
+                cache_key,
+                CachedHouseOfStakeStakeSource {
+                    last_lock_id: last_lock_id.to_string(),
+                    amount_yocto: 0,
+                    cached_at: Instant::now(),
+                },
+            );
+            return Self::stake_based_credits_for_lock(plan_config, 0);
+        }
 
         let Some(lock_amount) = lock_amount_yocto(&lock) else {
             tracing::warn!(

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1,5 +1,5 @@
 use super::near_staking::{
-    lock_amount_yocto, subscription_row_from_chain, view_get_lock, view_get_price,
+    lock_amount_yocto, subscription_row_from_chain, view_get_effective_lock, view_get_price,
     view_get_purchase, view_get_subscription_for_price, view_storage_balance_bounds,
     view_storage_balance_of, NearStakingStorageBalance, NearStakingStorageBalanceBounds,
 };
@@ -1103,28 +1103,29 @@ impl SubscriptionServiceImpl {
             return None;
         };
 
-        let lock = match view_get_lock(&self.near_rpc_url, contract_id, last_lock_id).await {
-            Ok(Some(lock)) => lock,
-            Ok(None) => {
-                tracing::warn!(
-                    user_id = %user_id.0,
-                    subscription_id = %subscription.subscription_id,
-                    last_lock_id,
-                    "cannot resolve HoS stake-based credits: lock missing on chain"
-                );
-                return None;
-            }
-            Err(err) => {
-                tracing::warn!(
-                    user_id = %user_id.0,
-                    subscription_id = %subscription.subscription_id,
-                    last_lock_id,
-                    error = %err,
-                    "cannot resolve HoS stake-based credits: lock RPC failed"
-                );
-                return None;
-            }
-        };
+        let lock =
+            match view_get_effective_lock(&self.near_rpc_url, contract_id, last_lock_id).await {
+                Ok(Some(lock)) => lock,
+                Ok(None) => {
+                    tracing::warn!(
+                        user_id = %user_id.0,
+                        subscription_id = %subscription.subscription_id,
+                        last_lock_id,
+                        "cannot resolve HoS stake-based credits: lock missing on chain"
+                    );
+                    return None;
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        user_id = %user_id.0,
+                        subscription_id = %subscription.subscription_id,
+                        last_lock_id,
+                        error = %err,
+                        "cannot resolve HoS stake-based credits: lock RPC failed"
+                    );
+                    return None;
+                }
+            };
 
         let Some(lock_amount) = lock_amount_yocto(&lock) else {
             tracing::warn!(
@@ -2514,7 +2515,7 @@ impl SubscriptionService for SubscriptionServiceImpl {
                 .ok_or_else(|| {
                     SubscriptionError::InternalError("HoS subscription missing last_lock_id".into())
                 })?;
-            let lock_j = view_get_lock(&self.near_rpc_url, contract_id, last_lock_id)
+            let lock_j = view_get_effective_lock(&self.near_rpc_url, contract_id, last_lock_id)
                 .await
                 .map_err(Self::near_rpc_err)?
                 .ok_or_else(|| {


### PR DESCRIPTION
## Summary

Updates House of Stake credit and plan-change reads to request the contract's effective lock view.

This lets chat-api calculate stake-based credits from the projected post-downgrade stake once a scheduled downgrade is ready, instead of using stale stored `get_lock().amount_near`.

## Root Cause

`/v1/subscriptions/near/sync` reads projected subscription views, so the local subscription row can show the downgraded plan. Stake-based credits then separately call `get_lock(last_lock_id)` and use raw `amount_near`, which remains at the old stake until a state-changing contract mutation applies the pending update.

## Changes

- Added `view_get_effective_lock`, sending `effective: true` to HoS `get_lock`.
- Switched HoS stake-based credits to use effective lock amount.
- Switched HoS change-plan current stake reads to use effective lock amount.
- Added test coverage that verifies `effective: true` is sent and credits use the effective 10 NEAR value.

## Validation

- `cargo fmt -p services -p api`
- `cargo test -p services subscription::near_staking::tests -- --nocapture`
- `cargo check -p services -p api`

Attempted DB-backed API regression test:

- `cargo test -p api --test subscriptions_tests test_house_of_stake_credits_use_effective_lock_amount_after_projected_downgrade -- --nocapture`
- Blocked locally by Postgres auth: `FATAL: password authentication failed for user "postgres"`.
- The test target compiled before failing during database migration setup.

Related to https://github.com/nearai/house-of-stake-contracts/issues/143