### PR TITLE
chore: SOC2 change-mgmt PR + issue templates (ITIS-031/034/035/036)

### DIFF
--- a/.github/ISSUE_TEMPLATE/emergency-change.md
+++ b/.github/ISSUE_TEMPLATE/emergency-change.md
@@ -1,0 +1,18 @@
+---
+name: Emergency change
+about: Record an emergency change made outside the normal review flow (ITIS-036 3.8)
+title: "[Emergency change] <summary>"
+labels: ["emergency-change"]
+---
+
+## What changed and why it was an emergency
+<!-- The change and why it could not wait for the normal reviewed flow -->
+
+## Authorized by
+<!-- Designated per-domain emergency approver + time -->
+
+## PR / CI
+<!-- Link the PR and CI run where possible -->
+
+## Post-implementation review
+<!-- Retrospective + completed change record within 14 business days. Due date: -->

--- a/.github/ISSUE_TEMPLATE/exception-request.md
+++ b/.github/ISSUE_TEMPLATE/exception-request.md
@@ -1,0 +1,21 @@
+---
+name: Security exception request
+about: Request a documented, time-bound exception to a security control (ITIS-031 / 032 / 035)
+title: "[Exception] <control or requirement>"
+labels: ["security-exception"]
+---
+
+## Failing item / control
+<!-- Which requirement or control cannot be met, and where (repo / resource) -->
+
+## Business justification
+<!-- Why the exception is needed -->
+
+## Compensating control
+<!-- What reduces the risk while the exception is in place -->
+
+## Expiration / review date
+<!-- When this exception is re-evaluated or removed -->
+
+## Approval
+<!-- Management approver + date -->

--- a/.github/ISSUE_TEMPLATE/initiative.md
+++ b/.github/ISSUE_TEMPLATE/initiative.md
@@ -1,0 +1,37 @@
+---
+name: Initiative / large change (design record)
+about: Optional planning record for a large, multi-PR initiative. Not needed for routine issues or single PRs.
+title: "[Initiative] <name>"
+labels: ["initiative"]
+---
+
+<!-- Optional. Use this only for a large, multi-PR initiative, to agree the design up front.
+     Routine changes do not need it: open a normal issue or go straight to a PR.
+     This is a planning artifact, not a required change record. -->
+
+## Scope & goals
+<!-- What this initiative delivers, and explicitly what it does NOT -->
+
+## Affected systems
+<!-- Services / repos touched, blast radius, cross-team dependencies -->
+
+## Data & classification
+<!-- Data touched and its ITIS-004 classification; encryption / key impact (ITIS-034) -->
+
+## Security review
+<!-- Threat model / abuse cases, new attack surface. Does this need a design-stage security review? (ITIS-033) -->
+
+## Test strategy
+<!-- How we will prove it works: unit / integration / e2e coverage. Testability risks (what is hard to test, and the plan) -->
+
+## Rollout & rollback
+<!-- Phasing, feature flags, data migration, revert path -->
+
+## New dependencies
+<!-- New libraries / services / subprocessors (SCA + subprocessor impact) -->
+
+## Approvers / stakeholders
+<!-- Design sign-off before the first PR -->
+
+## Tracking
+<!-- Linked PRs; exit criteria / definition of done -->

--- a/.github/ISSUE_TEMPLATE/secret-exposure-incident.md
+++ b/.github/ISSUE_TEMPLATE/secret-exposure-incident.md
@@ -1,0 +1,21 @@
+---
+name: Secret exposure incident
+about: Record and respond to an exposed secret or credential (ITIS-034 3.5 / ITIS-035)
+title: "[Secret exposure] <what was exposed>"
+labels: ["security-incident"]
+---
+
+## What was exposed
+<!-- Secret / credential type and where. Do NOT paste the secret value. -->
+
+## Revoke
+- [ ] Secret revoked
+
+## Rotate
+- [ ] Replacement issued and deployed
+
+## Investigate
+<!-- Scope, who/what had access, blast radius -->
+
+## Record
+<!-- Timeline + follow-ups -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+<!-- What changes and why -->
+
+## Risk & impact
+<!-- Blast radius, affected systems/services, data-classification impact (if any) -->
+
+## Testing
+<!-- Tests added/updated and how verified. Required CI checks must pass before merge. -->
+
+## Rollback plan
+<!-- How to revert if this fails in production -->
+
+## Review
+- [ ] Reviewed by a non-author
+- [ ] Security review requested if this is a high-risk change
+
+## Deploy path
+<!-- How this reaches production (tag / branch / pipeline); immutable / digest deploy -->


### PR DESCRIPTION
Adds standard change-management PR + issue templates that operationalize the required records in the ITIS security policies (ITIS-036 change records + emergency change; ITIS-031/032/035 exception register; ITIS-034/035 secret-exposure response). No code or workflow changes; templates take effect on merge. Scope: this repo only (per-repo, not org-wide).