### PR TITLE
docs(claude): required pre-PR checklist for agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,3 +143,9 @@ Key variables (see `crates/config/src/lib.rs` for defaults):
 - `--features test` enables `/v1/auth/mock-login` for test authentication
 - E2E tests are `#[ignore]` because they call real OpenAI APIs
 - Tests expect PostgreSQL running with correct schema
+
+## Required before every PR
+- Add or update tests for the change; all CI checks must pass before merge.
+- Run the repo's dependency audit and introduce no new high or critical advisory; commit the lockfile.
+- Never commit secrets, keys, or tokens.
+- Fill the PR template (risk/impact, testing, rollback); a non-author reviews before merge.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,6 @@ Key variables (see `crates/config/src/lib.rs` for defaults):
 
 ## Required before every PR
 - Add or update tests for the change; all CI checks must pass before merge.
-- Run the repo's dependency audit and introduce no new high or critical advisory; commit the lockfile.
+- Run the repo's dependency audit and introduce no new high or critical advisories; commit the lockfile.
 - Never commit secrets, keys, or tokens.
-- Fill the PR template (risk/impact, testing, rollback); a non-author reviews before merge.
+- Fill the PR template (risk/impact, testing, rollback) and get a non-author review before merge.


### PR DESCRIPTION
Adds a short, self-contained pre-PR checklist to CLAUDE.md so agents consistently honor the engineering standards (tests + CI green, dependency audit with no new high/critical advisory, no committed secrets, and a filled change record reviewed by a non-author). Minimal by design; no references to docs outside the repo.