### PR TITLE
fix(usage): streaming chat usage tracking issue due to cloud-api stream options change

### DIFF
--- a/crates/api/src/routes/api.rs
+++ b/crates/api/src/routes/api.rs
@@ -3613,6 +3613,7 @@ async fn prepare_chat_completions_body(
                 modified = true;
             }
         }
+        modified |= ensure_stream_usage_options(&mut body);
         if modified || auto_routed {
             serde_json::to_vec(&body).map(Bytes::from).map_err(|_| {
                 (
@@ -3630,6 +3631,36 @@ async fn prepare_chat_completions_body(
         Ok(body_bytes)
     }?;
     Ok(modified_body_bytes)
+}
+
+fn ensure_stream_usage_options(body: &mut serde_json::Value) -> bool {
+    if body.get("stream").and_then(|v| v.as_bool()) != Some(true) {
+        return false;
+    }
+
+    let Some(body) = body.as_object_mut() else {
+        return false;
+    };
+
+    match body
+        .get_mut("stream_options")
+        .and_then(|v| v.as_object_mut())
+    {
+        Some(options) => {
+            if options.get("include_usage").and_then(|v| v.as_bool()) == Some(true) {
+                return false;
+            }
+            options.insert("include_usage".to_string(), serde_json::Value::Bool(true));
+        }
+        None => {
+            body.insert(
+                "stream_options".to_string(),
+                json!({ "include_usage": true }),
+            );
+        }
+    }
+
+    true
 }
 
 /// Configuration for proxying POST requests to cloud-api endpoints (no usage tracking).
@@ -5398,10 +5429,11 @@ async fn collect_stream_to_bytes(
 
 #[cfg(test)]
 mod tests {
-    use super::{decompress_if_encoded, validate_proxy_path_segment};
+    use super::{decompress_if_encoded, ensure_stream_usage_options, validate_proxy_path_segment};
     use bytes::Bytes;
     use flate2::{write::DeflateEncoder, write::GzEncoder, write::ZlibEncoder, Compression};
     use http::{HeaderMap, HeaderValue};
+    use serde_json::json;
     use std::io::Write;
 
     fn headers(content_encoding: &str) -> HeaderMap {
@@ -5474,6 +5506,51 @@ mod tests {
                 "segment should be rejected: {value}"
             );
         }
+    }
+
+    #[test]
+    fn streaming_chat_requests_enable_usage_options() {
+        let mut body = json!({
+            "model": "ironclaw-model",
+            "stream": true,
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        assert!(ensure_stream_usage_options(&mut body));
+        assert_eq!(
+            body["stream_options"]["include_usage"],
+            serde_json::Value::Bool(true)
+        );
+    }
+
+    #[test]
+    fn streaming_chat_requests_preserve_existing_stream_options() {
+        let mut body = json!({
+            "model": "ironclaw-model",
+            "stream": true,
+            "stream_options": {
+                "chunk_size": 3,
+                "include_usage": false
+            }
+        });
+
+        assert!(ensure_stream_usage_options(&mut body));
+        assert_eq!(
+            body["stream_options"]["include_usage"],
+            serde_json::Value::Bool(true)
+        );
+        assert_eq!(body["stream_options"]["chunk_size"], json!(3));
+    }
+
+    #[test]
+    fn non_streaming_chat_requests_do_not_add_usage_options() {
+        let mut body = json!({
+            "model": "ironclaw-model",
+            "stream": false
+        });
+
+        assert!(!ensure_stream_usage_options(&mut body));
+        assert!(body.get("stream_options").is_none());
     }
 
     #[test]

--- a/crates/api/src/usage_parsing.rs
+++ b/crates/api/src/usage_parsing.rs
@@ -56,17 +56,21 @@ pub fn parse_response_usage_from_bytes(bytes: &[u8]) -> Option<ParsedUsage> {
 }
 
 /// Chat completions: parse usage from a JSON value with top-level `usage` and `model`.
-/// Expects OpenAI-style fields: `prompt_tokens`, `completion_tokens`, optional `total_tokens`.
+/// Accepts OpenAI-style fields (`prompt_tokens`, `completion_tokens`) and cloud-api-style
+/// fields (`input_tokens`, `output_tokens`), with optional `total_tokens`.
 fn parse_chat_completion_usage_from_json(root: &serde_json::Value) -> Option<ParsedUsage> {
     let usage = root.get("usage")?.as_object()?;
-    let input_tokens = usage.get("prompt_tokens").and_then(|v| v.as_u64())?;
-    let output_tokens = usage.get("completion_tokens").and_then(|v| v.as_u64())?;
+    let input_tokens = token_count_from_usage(usage, "prompt_tokens", "input_tokens")?;
+    let output_tokens = token_count_from_usage(usage, "completion_tokens", "output_tokens")?;
     let total_tokens = usage
         .get("total_tokens")
         .and_then(|v| v.as_u64())
         .unwrap_or(input_tokens + output_tokens);
-    let cache_read_tokens =
-        cache_read_tokens_from_details(usage, "prompt_tokens_details", input_tokens);
+    let cache_read_tokens = cache_read_tokens_from_any_details(
+        usage,
+        &["prompt_tokens_details", "input_tokens_details"],
+        input_tokens,
+    );
     let model = root
         .get("model")
         .and_then(|v| v.as_str())
@@ -78,6 +82,17 @@ fn parse_chat_completion_usage_from_json(root: &serde_json::Value) -> Option<Par
         cache_read_tokens,
         model,
     })
+}
+
+fn token_count_from_usage(
+    usage: &serde_json::Map<String, serde_json::Value>,
+    primary_key: &str,
+    fallback_key: &str,
+) -> Option<u64> {
+    usage
+        .get(primary_key)
+        .or_else(|| usage.get(fallback_key))
+        .and_then(|v| v.as_u64())
 }
 
 /// /v1/responses: parse usage from a JSON value with top-level `usage` and `model`.
@@ -103,6 +118,24 @@ fn parse_response_usage_from_json(root: &serde_json::Value) -> Option<ParsedUsag
         cache_read_tokens,
         model,
     })
+}
+
+fn cache_read_tokens_from_any_details(
+    usage: &serde_json::Map<String, serde_json::Value>,
+    details_keys: &[&str],
+    input_tokens: u64,
+) -> u64 {
+    details_keys
+        .iter()
+        .find_map(|key| {
+            usage
+                .get(*key)
+                .and_then(|v| v.as_object())
+                .and_then(|details| details.get("cached_tokens"))
+                .and_then(|v| v.as_u64())
+        })
+        .unwrap_or(0)
+        .min(input_tokens)
 }
 
 fn cache_read_tokens_from_details(
@@ -466,6 +499,17 @@ mod tests {
     }
 
     #[test]
+    fn chat_completion_accepts_input_output_tokens() {
+        let body = br#"{"model":"ironclaw-model","usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15,"input_tokens_details":{"cached_tokens":4}}}"#;
+        let parsed = parse_chat_completion_usage_from_bytes(body).expect("should parse");
+        assert_eq!(parsed.input_tokens, 10);
+        assert_eq!(parsed.output_tokens, 5);
+        assert_eq!(parsed.total_tokens, 15);
+        assert_eq!(parsed.cache_read_tokens, 4);
+        assert_eq!(parsed.model, "ironclaw-model");
+    }
+
+    #[test]
     fn chat_completion_parses_cache_read_tokens() {
         let body = br#"{"model":"gpt-4","usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"prompt_tokens_details":{"cached_tokens":6}}}"#;
         let parsed = parse_chat_completion_usage_from_bytes(body).expect("should parse");
@@ -495,6 +539,17 @@ mod tests {
         assert_eq!(parsed.total_tokens, 20);
         assert_eq!(parsed.cache_read_tokens, 0);
         assert_eq!(parsed.model, "Qwen/Qwen3-VL-30B");
+    }
+
+    #[test]
+    fn sse_chat_completion_chunk_accepts_input_output_tokens() {
+        let line = r#"data: {"id":"chatcmpl-1","object":"chat.completion.chunk","model":"ironclaw-model","choices":[],"usage":{"input_tokens":9,"total_tokens":20,"output_tokens":11,"input_tokens_details":{"cached_tokens":3}}}"#;
+        let parsed = parse_usage_from_chat_completion_sse_line(line).expect("should parse");
+        assert_eq!(parsed.input_tokens, 9);
+        assert_eq!(parsed.output_tokens, 11);
+        assert_eq!(parsed.total_tokens, 20);
+        assert_eq!(parsed.cache_read_tokens, 3);
+        assert_eq!(parsed.model, "ironclaw-model");
     }
 
     #[test]

--- a/crates/api/src/usage_parsing.rs
+++ b/crates/api/src/usage_parsing.rs
@@ -91,8 +91,8 @@ fn token_count_from_usage(
 ) -> Option<u64> {
     usage
         .get(primary_key)
-        .or_else(|| usage.get(fallback_key))
         .and_then(|v| v.as_u64())
+        .or_else(|| usage.get(fallback_key).and_then(|v| v.as_u64()))
 }
 
 /// /v1/responses: parse usage from a JSON value with top-level `usage` and `model`.
@@ -507,6 +507,15 @@ mod tests {
         assert_eq!(parsed.total_tokens, 15);
         assert_eq!(parsed.cache_read_tokens, 4);
         assert_eq!(parsed.model, "ironclaw-model");
+    }
+
+    #[test]
+    fn chat_completion_falls_back_when_openai_token_fields_are_null() {
+        let body = br#"{"model":"ironclaw-model","usage":{"prompt_tokens":null,"input_tokens":10,"completion_tokens":null,"output_tokens":5,"total_tokens":15}}"#;
+        let parsed = parse_chat_completion_usage_from_bytes(body).expect("should parse");
+        assert_eq!(parsed.input_tokens, 10);
+        assert_eq!(parsed.output_tokens, 5);
+        assert_eq!(parsed.total_tokens, 15);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix usage tracking for streamed `/v1/chat/completions` requests, including agent API-key traffic from IronClaw instances.

## Root Cause

Streaming chat-completion accounting depended on the upstream SSE stream containing a top-level `usage` object. The proxy wrapped successful streams with `UsageTrackingStreamChatCompletions`, but `prepare_chat_completions_body` did not request usage chunks with `stream_options.include_usage = true`.

This became visible recently after `nearai/cloud-api` commit `b60a0027` from 2026-07-21 (`fix(api): strip stream usage on attested models when include_usage is unset`) in https://github.com/nearai/cloud-api/pull/891. Cloud-api now intentionally strips client-visible usage from streamed attested model responses unless the client explicitly requests `stream_options.include_usage: true`, while still recording its own internal billing before that route-level rewrite.

As a result, streamed completions could be served successfully while the chat-api stream wrapper parsed no usage and skipped writing `user_usage_event` / `agent_balance` updates.

## Changes

- When a chat-completion request has `stream: true`, merge `stream_options.include_usage = true` into the forwarded request body.
- Preserve existing `stream_options` fields while forcing `include_usage` on for tracking.
- Keep non-streaming requests unchanged.
- Broaden chat-completion usage parsing to accept both:
  - OpenAI-style `prompt_tokens` / `completion_tokens`
  - cloud-api-style `input_tokens` / `output_tokens`
- Add unit coverage for request rewriting and both usage field shapes.

## Validation

- `cargo fmt`
- `cargo test -p api usage_parsing::tests --lib`
- `cargo test -p api routes::api::tests --lib`
- `cargo check -p api`

Related investigation: nearai/chat-api#367