### PR TITLE
fix(metrics): bound Chat API HTTP endpoint labels

### DIFF
--- a/crates/api/src/middleware/metrics.rs
+++ b/crates/api/src/middleware/metrics.rs
@@ -3,10 +3,14 @@
 //! This middleware records low-cardinality metrics for all HTTP requests:
 //! - `chat_api.http.requests` - Count of HTTP requests by method, endpoint, status
 //! - `chat_api.http.duration` - Histogram of request durations by method, endpoint
-//!
-//! Endpoints are normalized to replace UUIDs with `{id}` to reduce cardinality.
 
-use axum::{body::Body, extract::State, http::Request, middleware::Next, response::Response};
+use axum::{
+    body::Body,
+    extract::{MatchedPath, State},
+    http::Request,
+    middleware::Next,
+    response::Response,
+};
 use services::metrics::{
     consts::{
         get_environment, METRIC_HTTP_DURATION, METRIC_HTTP_REQUESTS, TAG_ENDPOINT, TAG_ENVIRONMENT,
@@ -31,14 +35,17 @@ pub async fn http_metrics_middleware(
 ) -> Response {
     let start = Instant::now();
     let method = req.method().to_string();
-    let path = req.uri().path().to_string();
+    let endpoint = req
+        .extensions()
+        .get::<MatchedPath>()
+        .map(MatchedPath::as_str)
+        .unwrap_or("unmatched")
+        .to_owned();
 
     let response = next.run(req).await;
     let duration = start.elapsed();
     let status = response.status().as_u16();
 
-    // Normalize path to reduce cardinality (replace UUIDs with {id})
-    let endpoint = normalize_path(&path);
     let environment = get_environment();
 
     let tags = [
@@ -59,90 +66,115 @@ pub async fn http_metrics_middleware(
     response
 }
 
-/// Normalize path by replacing UUIDs and dynamic IDs with `{id}` to reduce cardinality.
-///
-/// Examples:
-/// - `/v1/conversations/abc12345-1234-5678-9abc-def012345678` -> `/v1/conversations/{id}`
-/// - `/v1/files/abc12345-1234-5678-9abc-def012345678/content` -> `/v1/files/{id}/content`
-fn normalize_path(path: &str) -> String {
-    path.split('/')
-        .map(|segment| {
-            if is_uuid(segment) || is_conversation_id(segment) {
-                "{id}"
-            } else {
-                segment
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("/")
-}
-
-/// Check if a string looks like a UUID (8-4-4-4-12 hex pattern)
-fn is_uuid(s: &str) -> bool {
-    if s.len() != 36 {
-        return false;
-    }
-    let parts: Vec<&str> = s.split('-').collect();
-    if parts.len() != 5 {
-        return false;
-    }
-    let expected_lens = [8, 4, 4, 4, 12];
-    parts
-        .iter()
-        .zip(expected_lens.iter())
-        .all(|(part, &len)| part.len() == len && part.chars().all(|c| c.is_ascii_hexdigit()))
-}
-
-/// Check if a string looks like an OpenAI-style conversation ID (e.g., conv_xxx)
-fn is_conversation_id(s: &str) -> bool {
-    // OpenAI conversation IDs typically start with "conv_" or similar prefixes
-    s.starts_with("conv_") || s.starts_with("chatcmpl-") || s.starts_with("resp_")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::{body::Body, http::Request, middleware::from_fn_with_state, routing::get, Router};
+    use services::metrics::capturing::MetricValue;
+    use services::metrics::{
+        capturing::{CapturingMetricsService, RecordedMetric},
+        consts::{METRIC_HTTP_DURATION, METRIC_HTTP_REQUESTS},
+    };
+    use std::sync::Arc;
+    use tower::ServiceExt;
 
-    #[test]
-    fn test_is_uuid() {
-        assert!(is_uuid("abc12345-1234-5678-9abc-def012345678"));
-        assert!(is_uuid("ABC12345-1234-5678-9ABC-DEF012345678"));
-        assert!(!is_uuid("not-a-uuid"));
-        assert!(!is_uuid("abc12345-1234-5678-9abc")); // too short
-        assert!(!is_uuid("abc12345-1234-5678-9abc-def012345678x")); // too long
+    async fn recorded_metrics_for_request(path: &str) -> Vec<RecordedMetric> {
+        let metrics_service = Arc::new(CapturingMetricsService::new());
+        let app = Router::new()
+            .route(
+                "/v1/conversations/{conversation_id}",
+                get(|| async { "ok" }),
+            )
+            .layer(from_fn_with_state(
+                MetricsState {
+                    metrics_service: metrics_service.clone(),
+                },
+                http_metrics_middleware,
+            ));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(path)
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should complete");
+
+        assert!(response.status().is_success() || response.status().is_client_error());
+        metrics_service.get_metrics()
     }
 
-    #[test]
-    fn test_is_conversation_id() {
-        assert!(is_conversation_id("conv_abc123xyz"));
-        assert!(is_conversation_id("chatcmpl-abc123xyz"));
-        assert!(is_conversation_id("resp_abc123"));
-        assert!(!is_conversation_id("models"));
-        assert!(!is_conversation_id("health"));
+    fn endpoint_tag(metrics: &[RecordedMetric], name: &str) -> String {
+        metrics
+            .iter()
+            .find(|metric| metric.name == name)
+            .and_then(|metric| metric.tags.iter().find(|tag| tag.starts_with("endpoint:")))
+            .cloned()
+            .expect("HTTP metric should have an endpoint tag")
     }
 
-    #[test]
-    fn test_normalize_path() {
-        // UUID normalization
-        assert_eq!(
-            normalize_path("/v1/conversations/abc12345-1234-5678-9abc-def012345678"),
-            "/v1/conversations/{id}"
-        );
+    fn assert_common_tags(metrics: &[RecordedMetric], status: u16) {
+        for metric in metrics {
+            assert!(metric.tags.iter().any(|tag| tag == "method:GET"));
+            assert!(metric
+                .tags
+                .iter()
+                .any(|tag| tag == &format!("status_code:{status}")));
+            assert!(metric
+                .tags
+                .iter()
+                .any(|tag| tag.starts_with("environment:")));
+        }
+    }
 
-        // Multiple UUIDs
-        assert_eq!(
-            normalize_path("/v1/files/abc12345-1234-5678-9abc-def012345678/content"),
-            "/v1/files/{id}/content"
-        );
+    #[tokio::test]
+    async fn matched_routes_use_route_template() {
+        for path in ["/v1/conversations/first-id", "/v1/conversations/second-id"] {
+            let metrics = recorded_metrics_for_request(path).await;
 
-        // Conversation IDs
-        assert_eq!(
-            normalize_path("/v1/conversations/conv_abc123xyz"),
-            "/v1/conversations/{id}"
-        );
+            assert_eq!(metrics.len(), 2);
+            assert!(metrics.iter().any(|metric| {
+                metric.name == METRIC_HTTP_DURATION
+                    && matches!(metric.value, MetricValue::Latency(_))
+            }));
+            assert!(metrics.iter().any(|metric| {
+                metric.name == METRIC_HTTP_REQUESTS && matches!(metric.value, MetricValue::Count(1))
+            }));
+            assert_common_tags(&metrics, 200);
+            assert_eq!(
+                endpoint_tag(&metrics, METRIC_HTTP_DURATION),
+                "endpoint:/v1/conversations/{conversation_id}"
+            );
+            assert_eq!(
+                endpoint_tag(&metrics, METRIC_HTTP_REQUESTS),
+                "endpoint:/v1/conversations/{conversation_id}"
+            );
+            assert!(metrics
+                .iter()
+                .all(|metric| metric.tags.iter().all(|tag| !tag.contains(path))));
+        }
+    }
 
-        // No IDs to normalize
-        assert_eq!(normalize_path("/v1/models"), "/v1/models");
-        assert_eq!(normalize_path("/health"), "/health");
+    #[tokio::test]
+    async fn unmatched_routes_use_bounded_label() {
+        for path in ["/.env", "/wp-admin/install.php"] {
+            let metrics = recorded_metrics_for_request(path).await;
+
+            assert_eq!(metrics.len(), 2);
+            assert_common_tags(&metrics, 404);
+            assert_eq!(
+                endpoint_tag(&metrics, METRIC_HTTP_DURATION),
+                "endpoint:unmatched"
+            );
+            assert_eq!(
+                endpoint_tag(&metrics, METRIC_HTTP_REQUESTS),
+                "endpoint:unmatched"
+            );
+            assert!(metrics
+                .iter()
+                .all(|metric| metric.tags.iter().all(|tag| !tag.contains(path))));
+        }
     }
 }

--- a/crates/api/src/middleware/metrics.rs
+++ b/crates/api/src/middleware/metrics.rs
@@ -34,7 +34,13 @@ pub async fn http_metrics_middleware(
     next: Next,
 ) -> Response {
     let start = Instant::now();
-    let method = req.method().to_string();
+    let method = match req.method().as_str() {
+        "CONNECT" | "DELETE" | "GET" | "HEAD" | "OPTIONS" | "PATCH" | "POST" | "PUT" | "TRACE" => {
+            req.method().as_str()
+        }
+        _ => "OTHER",
+    }
+    .to_owned();
     let endpoint = req
         .extensions()
         .get::<MatchedPath>()
@@ -78,7 +84,10 @@ mod tests {
     use std::sync::Arc;
     use tower::ServiceExt;
 
-    async fn recorded_metrics_for_request(path: &str) -> Vec<RecordedMetric> {
+    async fn recorded_metrics_for_request_with_method(
+        method: &str,
+        path: &str,
+    ) -> Vec<RecordedMetric> {
         let metrics_service = Arc::new(CapturingMetricsService::new());
         let app = Router::new()
             .route(
@@ -95,6 +104,7 @@ mod tests {
         let response = app
             .oneshot(
                 Request::builder()
+                    .method(method)
                     .uri(path)
                     .body(Body::empty())
                     .expect("request should build"),
@@ -104,6 +114,10 @@ mod tests {
 
         assert!(response.status().is_success() || response.status().is_client_error());
         metrics_service.get_metrics()
+    }
+
+    async fn recorded_metrics_for_request(path: &str) -> Vec<RecordedMetric> {
+        recorded_metrics_for_request_with_method("GET", path).await
     }
 
     fn endpoint_tag(metrics: &[RecordedMetric], name: &str) -> String {
@@ -117,6 +131,21 @@ mod tests {
 
     fn assert_common_tags(metrics: &[RecordedMetric], status: u16) {
         for metric in metrics {
+            let mut tag_keys = metric
+                .tags
+                .iter()
+                .map(|tag| {
+                    tag.split_once(':')
+                        .expect("metric tag should have a value")
+                        .0
+                })
+                .collect::<Vec<_>>();
+            tag_keys.sort_unstable();
+            assert_eq!(
+                tag_keys,
+                ["endpoint", "environment", "method", "status_code"],
+                "HTTP metric tag keys should match the Cloud API contract"
+            );
             assert!(metric.tags.iter().any(|tag| tag == "method:GET"));
             assert!(metric
                 .tags
@@ -175,6 +204,32 @@ mod tests {
             assert!(metrics
                 .iter()
                 .all(|metric| metric.tags.iter().all(|tag| !tag.contains(path))));
+        }
+    }
+
+    #[tokio::test]
+    async fn nonstandard_methods_use_bounded_label() {
+        let metrics = recorded_metrics_for_request_with_method("KLFQ", "/health").await;
+
+        assert_eq!(metrics.len(), 2);
+        assert!(metrics.iter().all(|metric| {
+            metric.tags.iter().any(|tag| tag == "method:OTHER")
+                && metric.tags.iter().all(|tag| tag != "method:KLFQ")
+        }));
+    }
+
+    #[tokio::test]
+    async fn standard_methods_preserve_method_label() {
+        for method in [
+            "CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "TRACE",
+        ] {
+            let metrics = recorded_metrics_for_request_with_method(method, "/health").await;
+            let expected_tag = format!("method:{method}");
+
+            assert_eq!(metrics.len(), 2);
+            assert!(metrics
+                .iter()
+                .all(|metric| metric.tags.iter().any(|tag| tag == &expected_tag)));
         }
     }
 }


### PR DESCRIPTION
## Summary

This bounds the `endpoint` and `method` tags on Chat API HTTP metrics so Grafana can group and alert on stable dimensions without retaining attacker-controlled request paths or extension methods.

The live audit found 898 endpoint-label values, 1,587 request-counter series, and 25,392 HTTP-duration bucket series. The middleware now reads Axum's matched route template and emits a single `unmatched` fallback when no route matched. The nine standard HTTP methods keep their Cloud API-compatible values; extension methods collapse to `OTHER`. Request and duration metrics retain exactly the shared `method`, `endpoint`, `status_code`, and `environment` tag keys.

Companion Grafana parity PR: https://github.com/nearai/cvm-ansible-playbooks/pull/468

## Risk & impact

- API behavior and responses are unchanged; only metric label values change.
- Dashboards or ad hoc queries that intentionally selected a concrete URI will consolidate under route templates or `unmatched`.
- Queries that intentionally selected a nonstandard HTTP method will consolidate under `OTHER`; standard methods are unchanged.
- Cardinality reduction is not live until an approved Chat API image containing these commits is deployed and Prometheus ages out old series.
- No request URI, customer identifier, or payload is added to logs or metrics.

## Testing

- `cargo test -p api --lib --features test` — 118 passed.
- Middleware contract tests — 4 passed through a real Axum router: concrete IDs collapse to the route template, unrelated paths collapse to `unmatched`, all nine standard methods retain their literal label, extension method `KLFQ` becomes `OTHER`, and both metric types expose exactly the four Cloud API-compatible tag keys.
- `cargo fmt --all -- --check` — passed.
- `cargo clippy -p api --lib --features test -- -D warnings` — passed.
- `cargo build --release` — passed on the earlier endpoint-bounding commit; the follow-up changes only middleware label normalization and tests.
- The broader library/binary test command reaches the existing database failover tests and has the same two failures on this branch and exact `origin/main`: `startup_pool_clones_follow_leader_across_failover` and `stale_candidate_is_discarded_when_leader_changes_during_verification`.
- Docker/PostgreSQL-backed integration coverage is deferred to CI because neither service is available locally. Required exact-head CI checks must pass before merge.

## Rollback plan

Revert these commits, build a new approved immutable Chat API tag, and deploy it through the normal production workflow. Old Prometheus series remain queryable until retention expires.

## Review

- [ ] Reviewed by a non-author
- [ ] Security review requested if this is a high-risk change

## Deploy path

This PR does not deploy. After approval and merge, publish an immutable release tag and use `deploy_chat_api_prod.yml --ref <approved-tag>`; do not deploy production from `main`.
