### PR TITLE
chore: add IronLoop configuration

### DIFF
--- a/.ironloop/config.yaml
+++ b/.ironloop/config.yaml
@@ -1,0 +1,18 @@
+version: 1
+
+implementer:
+  network_access: true
+
+reviewer:
+  network_access: true
+  auto_review:
+    enabled: true
+    max_runs: 10
+    user_open: true
+    user_update: false
+
+resolver:
+  network_access: true
+  auto_resolve:
+    enabled: true
+    max_runs: 10


### PR DESCRIPTION
Adds the standard IronLoop configuration with network access and automatic review and resolution enabled.