### PR TITLE
refactor(grant-owner): return the owner user id, let the caller grant it

### DIFF
--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -149,7 +149,6 @@ use utoipa::OpenApi;
         services::user::ports::AccountDeletion,
         services::user::ports::AccountDeletionStatus,
         crate::routes::admin::AdminRetryAccountDeletionResponse,
-        crate::routes::admin::GrantInstanceOwnerRequest,
         crate::routes::admin::GrantInstanceOwnerResponse,
         crate::models::AuthResponse,
         crate::error::ApiErrorResponse,

--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -149,6 +149,7 @@ use utoipa::OpenApi;
         services::user::ports::AccountDeletion,
         services::user::ports::AccountDeletionStatus,
         crate::routes::admin::AdminRetryAccountDeletionResponse,
+        crate::routes::admin::GrantInstanceOwnerRequest,
         crate::routes::admin::GrantInstanceOwnerResponse,
         crate::models::AuthResponse,
         crate::error::ApiErrorResponse,

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3647,6 +3647,14 @@ pub struct MigrateInstanceResponse {
     pub status: String,
     pub instance_name: String,
     pub message: String,
+    /// The CrabShack user id to grant as owner, derived from the user's `auth_secret`. A CrabShack
+    /// import lands ownerless, so the caller finishes the job:
+    /// `POST <crabshack>/instances/<instance_name>/access {"user_id": ..., "role": "owner"}` —
+    /// `instance_name` above is the name it was imported under, which is what the grant must use.
+    ///
+    /// `None` when the user has no passkey credentials to derive from, and on the `skipped` path
+    /// (nothing was migrated; use the grant-owner endpoint to look it up).
+    pub owner_user_id: Option<String>,
 }
 
 /// ironclaw-dind tags exist and are allow-listed contiguously from 0.23.0 up.
@@ -3726,6 +3734,8 @@ pub async fn admin_migrate_instance(
             status: "skipped".to_string(),
             instance_name,
             message: "Instance is already on CrabShack".to_string(),
+            // Nothing was migrated here; grant-owner returns the id if this one needs an owner.
+            owner_user_id: None,
         }));
     }
 
@@ -3785,8 +3795,13 @@ pub async fn admin_migrate_instance(
         );
     }
 
+    // Kept for the owner id in the response: the caller needs it to grant ownership on CrabShack.
+    let mut owner_auth_secret: Option<String> = None;
     let backup_passphrase = match creds {
-        Some((_auth_secret, passphrase)) => passphrase,
+        Some((auth_secret, passphrase)) => {
+            owner_auth_secret = Some(auth_secret);
+            passphrase
+        }
         None if request_has_backup_url => {
             return Err(ApiError::bad_request(
                 "backup_url requires existing passkey credentials — run a normal \
@@ -4495,57 +4510,52 @@ pub async fn admin_migrate_instance(
         instance_name,
     );
 
+    let owner_user_id = owner_auth_secret.as_deref().and_then(crabshack_user_id);
+    if owner_user_id.is_none() {
+        tracing::warn!(
+            "Migrate: no passkey credentials, so no owner id for the caller to grant: instance_id={}, name={}",
+            id,
+            target_name
+        );
+    }
     Ok(Json(MigrateInstanceResponse {
         status: "success".to_string(),
         instance_name: target_name,
         message: "Instance migrated to CrabShack".to_string(),
+        owner_user_id,
     }))
 }
 
 /// Response for the grant-owner endpoint.
 ///
-/// Intentionally omits the derived owner user id. It is computed from the user's
-/// `auth_secret`, and chat-api does not surface credential-derived identity to API
-/// callers (even admins) — the caller can't obtain it any other way. When the granted
-/// owner needs verifying, read it from CrabShack's own access endpoint
-/// (`GET /instances/{name}/access`), which is the source of truth.
-/// Optional request body for the grant-owner endpoint.
-///
-/// `deny_unknown_fields`: a typo'd field would otherwise deserialize to `None` and silently fall back
-/// to the record name, which is the case this exists to avoid.
-#[derive(Deserialize, Default, utoipa::ToSchema)]
-#[serde(deny_unknown_fields)]
-pub struct GrantInstanceOwnerRequest {
-    /// The name the instance carries on CrabShack, when this record holds a different one: a migrate
-    /// renamed on collision renames the record only in its last bookkeeping step, so one that failed
-    /// earlier leaves the legacy name behind — and on CrabShack that name is a different tenant's
-    /// instance. Defaults to the record name.
-    pub crabshack_name: Option<String>,
-}
-
+/// Carries the derived owner user id, because the caller is the one that writes the grant and cannot
+/// compute this id itself — it comes from the user's `auth_secret`, which never leaves chat-api. Admin
+/// scope only. Knowing the id lets a caller grant, check or revoke that user's access on CrabShack;
+/// it reveals nothing about the secret it derives from.
 #[derive(Serialize, utoipa::ToSchema)]
 pub struct GrantInstanceOwnerResponse {
     pub status: String,
     pub instance_name: String,
     pub message: String,
+    /// The CrabShack user id of this instance's owner: `sha256(hex_decode(auth_secret))`, the same
+    /// derivation CrabShack does on login. Grant it with
+    /// `POST <crabshack>/instances/<name>/access {"user_id": ..., "role": "owner"}`.
+    pub owner_user_id: String,
 }
 
-/// Admin endpoint: Grant CrabShack owner access for an already-migrated instance.
+/// Admin endpoint: the CrabShack owner user id for an instance.
 ///
-/// Migration (`admin_migrate_instance`) imports the instance and seeds the CrabShack backup
-/// vault, but never establishes an owner access row — CrabShack imports run with the admin
-/// token, so the instance lands ownerless. Without an owner, CrabShack's scheduled backups skip
-/// the instance ("no owner") and the owning user can't see it in the portal.
+/// CrabShack imports run with the admin token, so a migrated instance lands ownerless: its scheduled
+/// backups are skipped and the owning user cannot see it in the portal. Establishing the owner needs
+/// one thing only chat-api has — the user id CrabShack derives on login,
+/// `sha256(hex_decode(auth_secret))` (mirroring orchestrator-api's `userIdFromAuthSecret`).
 ///
-/// This reconciles ownership: it derives the CrabShack user id the same way CrabShack does on
-/// login (`sha256(hex_decode(auth_secret))`, mirroring orchestrator-api's `userIdFromAuthSecret`)
-/// and calls CrabShack's admin access-grant endpoint. Idempotent — CrabShack's grant is
-/// last-write-wins, so re-running is safe.
-///
-/// Guarded on the instance already pointing at CrabShack (`agent_api_base_url == crabshack url`),
-/// which chat-api only sets after a fully successful migration. This prevents granting ownership
-/// to a half-migrated instance whose data restore may still be running (a backup of it would
-/// capture an incomplete volume).
+/// This returns that id and writes nothing. The caller grants it on CrabShack itself
+/// (`POST <crabshack>/instances/<name>/access`), which is where the decisions live: which instance
+/// name to write it on, whether an existing owner row should be revoked first, and whether the
+/// instance is far enough along to own. chat-api cannot answer those — the name in this record is not
+/// always the name the instance carries on CrabShack, and a grant on the wrong name silently lands on
+/// another tenant's agent.
 #[utoipa::path(
     post,
     path = "/v1/admin/agents/instances/{id}/grant-owner",
@@ -4553,9 +4563,8 @@ pub struct GrantInstanceOwnerResponse {
     params(
         ("id" = String, Path, description = "Instance ID")
     ),
-    request_body(content = GrantInstanceOwnerRequest, description = "Optional: the instance's CrabShack name"),
     responses(
-        (status = 200, description = "Owner access granted", body = GrantInstanceOwnerResponse),
+        (status = 200, description = "Owner user id derived", body = GrantInstanceOwnerResponse),
         (status = 400, description = "Bad request", body = crate::error::ApiErrorResponse),
         (status = 401, description = "Unauthorized", body = crate::error::ApiErrorResponse),
         (status = 403, description = "Forbidden - admin only", body = crate::error::ApiErrorResponse),
@@ -4568,7 +4577,6 @@ pub async fn admin_grant_instance_owner(
     State(app_state): State<AppState>,
     Extension(_user): Extension<AuthenticatedUser>,
     Path(instance_id): Path<String>,
-    body: Option<Json<GrantInstanceOwnerRequest>>,
 ) -> Result<Json<GrantInstanceOwnerResponse>, ApiError> {
     let id = Uuid::parse_str(&instance_id)
         .map_err(|_| ApiError::bad_request("Invalid instance ID format"))?;
@@ -4588,23 +4596,6 @@ pub async fn admin_grant_instance_owner(
         .ok_or_else(|| ApiError::not_found("Instance not found"))?;
 
     let instance_name = instance.name.clone();
-
-    // Require the instance to already be on CrabShack. chat-api flips agent_api_base_url to the
-    // CrabShack url only after a fully successful migration, so this is the "migration complete"
-    // signal — granting before it would risk owning a still-restoring instance.
-    let crabshack_manager = app_state
-        .agent_service
-        .find_crabshack_manager()
-        .ok_or_else(|| ApiError::internal_server_error("No CrabShack manager configured"))?;
-    let agent_api_base_url = instance
-        .agent_api_base_url
-        .as_deref()
-        .ok_or_else(|| ApiError::bad_request("Instance has no agent_api_base_url"))?;
-    if agent_api_base_url.trim_end_matches('/') != crabshack_manager.url.trim_end_matches('/') {
-        return Err(ApiError::bad_request(
-            "Instance is not on CrabShack — migrate it first",
-        ));
-    }
 
     // Look up the owning user's passkey credentials. The auth_secret is the root of the CrabShack
     // user identity. Never mint new credentials here: fresh creds would derive a different identity
@@ -4629,130 +4620,66 @@ pub async fn admin_grant_instance_owner(
         }
     };
 
-    // CrabShack user id = hex(sha256(hex_decode(auth_secret))).
-    // Mirrors CrabShack's userIdFromAuthSecret (orchestrator-api/src/auth/user-queries.ts).
-    let auth_secret_bytes = hex::decode(auth_secret.trim()).map_err(|e| {
+    let owner_user_id = crabshack_user_id(&auth_secret).ok_or_else(|| {
         tracing::error!(
-            "grant-owner: stored auth_secret is not valid hex: instance_id={}, error={}",
-            id,
-            e
+            "grant-owner: stored auth_secret is not valid hex: instance_id={}",
+            id
         );
         ApiError::internal_server_error("Stored auth_secret is not valid hex")
     })?;
-    let owner_user_id = hex::encode(Sha256::digest(&auth_secret_bytes));
-
-    // Grant owner access on CrabShack (admin endpoint). Idempotent: last-write-wins.
-    //
-    // On the name: CrabShack's access route takes whatever name it is given and does not check the
-    // instance exists, so granting on the wrong one writes owner access onto another tenant's agent
-    // and reports success. The record's name is not always the instance's name on CrabShack, so the
-    // caller passes the name it migrated under. Everything else — checking what the instance already
-    // has, clearing a stale owner — is the caller's to do with its own CrabShack admin token.
-    let crabshack_name = grant_target_name(
-        body.as_ref().and_then(|b| b.crabshack_name.as_deref()),
-        &instance.name,
-    )
-    .ok_or_else(|| {
-        ApiError::bad_request(
-            "crabshack_name must be a single lowercase DNS label (letters, digits, dashes)",
-        )
-    })?;
-    let grant_url = format!(
-        "{}/instances/{}/access",
-        crabshack_manager.url.trim_end_matches('/'),
-        encode(&crabshack_name)
-    );
-    let resp = app_state
-        .http_client
-        .post(&grant_url)
-        .bearer_auth(&crabshack_manager.token)
-        .json(&serde_json::json!({ "user_id": owner_user_id, "role": "owner" }))
-        .timeout(std::time::Duration::from_secs(30))
-        .send()
-        .await
-        .map_err(|e| {
-            tracing::error!(
-                "grant-owner: CrabShack access call failed: instance_id={}, error={}",
-                id,
-                e
-            );
-            ApiError::internal_server_error("Failed to call CrabShack access endpoint")
-        })?;
-    let status = resp.status();
-    if !status.is_success() {
-        // Read the body for diagnosis and surface CrabShack's status to the caller, so a
-        // misconfigured-admin-token 401 or a CrabShack 5xx is distinguishable from a generic
-        // failure. (CrabShack's grant is idempotent and does not check instance existence, so it
-        // never returns 404/409 here — only 4xx for a malformed request or auth/transport errors.)
-        let body = resp.text().await.unwrap_or_default();
-        tracing::error!(
-            "grant-owner: CrabShack access grant failed: instance_id={}, status={}, body={}",
-            id,
-            status,
-            body.chars().take(300).collect::<String>()
-        );
-        return Err(ApiError::internal_server_error(format!(
-            "CrabShack rejected the access grant (status {status})"
-        )));
-    }
 
     tracing::info!(
-        "grant-owner: granted CrabShack owner: instance_id={}, crabshack_name={}, record_name={}, owner_user_id={}",
+        "grant-owner: derived CrabShack owner: instance_id={}, record_name={}, owner_user_id={}",
         id,
-        crabshack_name,
         instance_name,
         owner_user_id
     );
     Ok(Json(GrantInstanceOwnerResponse {
         status: "success".to_string(),
-        instance_name: crabshack_name,
-        message: "Owner access granted on CrabShack".to_string(),
+        instance_name,
+        message: "Grant this user_id on CrabShack to own the instance".to_string(),
+        owner_user_id,
     }))
 }
 
-/// The name to grant on: the caller's `crabshack_name` when it is a valid CrabShack label, else this
-/// record's name. `None` rejects a malformed name rather than passing it to CrabShack.
-fn grant_target_name(requested: Option<&str>, record_name: &str) -> Option<String> {
-    match requested {
-        Some(name) if is_valid_crabshack_name(name) => Some(name.to_string()),
-        Some(_) => None,
-        None => Some(record_name.to_string()),
-    }
+/// CrabShack user id = hex(sha256(hex_decode(auth_secret))).
+/// Mirrors CrabShack's userIdFromAuthSecret (orchestrator-api/src/auth/user-queries.ts).
+fn crabshack_user_id(auth_secret: &str) -> Option<String> {
+    hex::decode(auth_secret.trim())
+        .ok()
+        .map(|bytes| hex::encode(Sha256::digest(&bytes)))
 }
 
 #[cfg(test)]
-mod grant_owner_name_tests {
-    use super::grant_target_name;
+mod crabshack_user_id_tests {
+    use super::crabshack_user_id;
 
     #[test]
-    fn caller_supplied_name_wins() {
-        // The record still says rich-orca; CrabShack holds it as rich-orca-fibir.
+    fn matches_crabshacks_own_derivation() {
+        // sha256 of the DECODED secret, not of its hex text — the distinction CrabShack's
+        // userIdFromAuthSecret makes, and the one an owner id would silently be wrong about.
         assert_eq!(
-            grant_target_name(Some("rich-orca-fibir"), "rich-orca"),
-            Some("rich-orca-fibir".to_string())
+            crabshack_user_id("00").as_deref(),
+            Some("6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d")
+        );
+        assert_eq!(
+            crabshack_user_id("deadbeef").as_deref(),
+            Some("5f78c33274e43fa9de5659265c1d917e25c03722dcb0b8d27db8d5feaa813953")
         );
     }
 
     #[test]
-    fn falls_back_to_the_record_name() {
+    fn tolerates_surrounding_whitespace() {
         assert_eq!(
-            grant_target_name(None, "wise-fish"),
-            Some("wise-fish".to_string())
+            crabshack_user_id(" deadbeef\n"),
+            crabshack_user_id("deadbeef")
         );
     }
 
     #[test]
-    fn rejects_a_malformed_name() {
-        // A url, spaces, a slash or an empty string is refused rather than passed to CrabShack's
-        // access route, which accepts any name it is given.
-        for bad in [
-            "https://wise-fish.agents.near.ai/",
-            "wise fish",
-            "wise/fish",
-            "",
-        ] {
-            assert_eq!(grant_target_name(Some(bad), "wise-fish"), None, "{bad}");
-        }
+    fn refuses_a_non_hex_secret() {
+        assert_eq!(crabshack_user_id("not-hex"), None);
+        assert_eq!(crabshack_user_id("abc"), None); // odd length
     }
 }
 

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -4518,6 +4518,10 @@ pub async fn admin_migrate_instance(
                 &crabshack_manager.token,
                 &target_name,
                 &owner_user_id,
+                // migrate chose this name and just imported under it, so clearing any other owner row
+                // is safe here. 10s per leg: a failure only costs `owner_granted: false`.
+                true,
+                std::time::Duration::from_secs(10),
             )
             .await
             {
@@ -4561,8 +4565,12 @@ pub async fn admin_migrate_instance(
     }))
 }
 
-/// Optional request body for the grant-owner endpoint
+/// Optional request body for the grant-owner endpoint.
+///
+/// `deny_unknown_fields`: a typo'd field would otherwise deserialize to `None` and silently take the
+/// record-name fallback, which is the path this endpoint exists to avoid.
 #[derive(Deserialize, Default, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
 pub struct GrantInstanceOwnerRequest {
     /// The name the instance carries on CrabShack, for when this record holds a different one: a
     /// migrate renamed on collision renames the record only in its last bookkeeping step, so one that
@@ -4587,9 +4595,13 @@ pub struct GrantInstanceOwnerResponse {
     pub changed: bool,
     /// Owner rows for other users that this call revoked, so the instance ends with one owner.
     pub revoked_owners: usize,
-    /// Owner rows for other users that could NOT be revoked. Above zero means the instance still has
-    /// more than one owner, which also makes it appear twice in CrabShack's instance list.
+    /// Owner rows for other users still in place — either left because the caller did not name the
+    /// instance, or a revoke that failed. Above zero means the instance has more than one owner,
+    /// which also makes it appear twice in CrabShack's instance list.
     pub stale_owners_left: usize,
+    /// True when CrabShack's access list could not be read. The grant still happened, but nothing was
+    /// revoked and `stale_owners_left` is not a measurement — re-run to find out.
+    pub owners_unknown: bool,
 }
 
 /// Admin endpoint: Grant CrabShack owner access for an already-migrated instance.
@@ -4713,36 +4725,45 @@ pub async fn admin_grant_instance_owner(
         ApiError::internal_server_error("Stored auth_secret is not valid hex")
     })?;
 
+    // Only replace other owners when the caller named the instance. Falling back to the record name
+    // and then revoking would delete the rightful owner of whatever instance holds that name.
+    let caller_named = body
+        .as_ref()
+        .and_then(|b| b.crabshack_name.as_deref())
+        .is_some();
     let outcome = write_crabshack_owner(
         &app_state.http_client,
         &crabshack_manager.url,
         &crabshack_manager.token,
         &crabshack_name,
         &owner_user_id,
+        caller_named,
+        std::time::Duration::from_secs(30),
     )
     .await?;
 
     tracing::info!(
-        "grant-owner: instance_id={}, crabshack_name={}, record_name={}, owner_user_id={}, changed={}, previous_owners=[{}]",
+        "grant-owner: instance_id={}, crabshack_name={}, record_name={}, owner_user_id={}, changed={}, replaced={}, previous_owners=[{}]",
         id,
         crabshack_name,
         instance_name,
         owner_user_id,
         outcome.changed,
-        outcome.previous_owners.join(",")
+        caller_named,
+        outcome
+            .previous_owners
+            .as_ref()
+            .map(|p| p.join(","))
+            .unwrap_or_else(|| "unreadable".to_string())
     );
-    let others = outcome
-        .previous_owners
-        .iter()
-        .filter(|u| **u != owner_user_id)
-        .count();
     Ok(Json(GrantInstanceOwnerResponse {
         status: "success".to_string(),
         instance_name: crabshack_name,
         message: outcome.message,
         changed: outcome.changed,
         revoked_owners: outcome.revoked.len(),
-        stale_owners_left: others - outcome.revoked.len(),
+        stale_owners_left: outcome.left,
+        owners_unknown: outcome.previous_owners.is_none(),
     }))
 }
 
@@ -4765,24 +4786,45 @@ fn crabshack_user_id(auth_secret: &str) -> Option<String> {
 }
 
 /// What making a user the owner on CrabShack did.
+#[derive(Debug)]
 struct OwnerGrantOutcome {
-    previous_owners: Vec<String>,
+    /// `None` when CrabShack's access list could not be read. "No owners" and "unknown" must not look
+    /// alike, or a report of zero leftover owners would be a guess.
+    previous_owners: Option<Vec<String>>,
     revoked: Vec<String>,
+    /// Other owner rows still in place: either left deliberately or a revoke that failed.
+    left: usize,
     changed: bool,
     message: String,
 }
 
-/// Reads as: this instance ended up owned by `owner_user_id`, and by nobody else.
-fn owner_grant_message(previous_owners: &[String], revoked: &[String], owner: &str) -> String {
-    let already = previous_owners.iter().any(|u| u == owner);
-    match (already, revoked.len()) {
-        (true, 0) => "Owner already granted on CrabShack — nothing changed".to_string(),
-        (true, n) => format!("Owner already granted on CrabShack; revoked {n} stale owner row(s)"),
-        (false, 0) => "Owner access granted on CrabShack".to_string(),
-        (false, n) => {
-            format!("Owner access granted on CrabShack; revoked {n} stale owner row(s)")
-        }
+/// Reads as: who owns this instance now, and what this call moved to get there.
+fn owner_grant_message(
+    previous_owners: Option<&[String]>,
+    revoked: &[String],
+    left: usize,
+    owner: &str,
+) -> String {
+    let already = previous_owners.is_some_and(|prev| prev.iter().any(|u| u == owner));
+    let mut msg = if already {
+        "Owner already granted on CrabShack".to_string()
+    } else {
+        "Owner access granted on CrabShack".to_string()
+    };
+    if previous_owners.is_none() {
+        msg.push_str("; could not read its existing owners, so none were cleared");
+        return msg;
     }
+    if !revoked.is_empty() {
+        msg.push_str(&format!("; revoked {} stale owner row(s)", revoked.len()));
+    }
+    if left > 0 {
+        msg.push_str(&format!("; left {left} other owner row(s) in place"));
+    }
+    if already && revoked.is_empty() && left == 0 {
+        msg.push_str(" — nothing changed");
+    }
+    msg
 }
 
 /// Make `owner_user_id` the instance's sole owner on CrabShack.
@@ -4797,6 +4839,8 @@ async fn write_crabshack_owner(
     crabshack_token: &str,
     instance_name: &str,
     owner_user_id: &str,
+    replace_other_owners: bool,
+    timeout: std::time::Duration,
 ) -> Result<OwnerGrantOutcome, ApiError> {
     let base = crabshack_url.trim_end_matches('/');
     let enc = encode(instance_name);
@@ -4806,36 +4850,43 @@ async fn write_crabshack_owner(
     let probe = http
         .get(format!("{base}/instances/{enc}"))
         .bearer_auth(crabshack_token)
-        .timeout(std::time::Duration::from_secs(30))
+        .timeout(timeout)
         .send()
         .await
         .map_err(|e| {
             tracing::error!(
                 "grant-owner: CrabShack lookup failed: name={instance_name}, error={e}"
             );
-            ApiError::internal_server_error("Failed to look up the instance on CrabShack")
+            ApiError::bad_gateway("Failed to look up the instance on CrabShack")
         })?;
-    if !probe.status().is_success() {
+    // Only a 404 means the name is wrong. A 401 from a stale admin token or a 503 during a CrabShack
+    // blip is worth retrying, and must not read as "no such instance".
+    if probe.status() == reqwest::StatusCode::NOT_FOUND {
         return Err(ApiError::bad_request(format!(
-            "CrabShack has no instance named {instance_name} (status {}) — nothing to grant",
+            "CrabShack has no instance named {instance_name} — nothing to grant"
+        )));
+    }
+    if !probe.status().is_success() {
+        return Err(ApiError::bad_gateway(format!(
+            "CrabShack lookup for {instance_name} failed (status {})",
             probe.status()
         )));
     }
 
-    let previous_owners = read_crabshack_owners(http, base, crabshack_token, &enc).await;
+    let previous_owners = read_crabshack_owners(http, base, crabshack_token, &enc, timeout).await;
 
     let resp = http
         .post(format!("{base}/instances/{enc}/access"))
         .bearer_auth(crabshack_token)
         .json(&serde_json::json!({ "user_id": owner_user_id, "role": "owner" }))
-        .timeout(std::time::Duration::from_secs(30))
+        .timeout(timeout)
         .send()
         .await
         .map_err(|e| {
             tracing::error!(
                 "grant-owner: CrabShack access call failed: name={instance_name}, error={e}"
             );
-            ApiError::internal_server_error("Failed to call CrabShack access endpoint")
+            ApiError::bad_gateway("Failed to call CrabShack access endpoint")
         })?;
     let status = resp.status();
     if !status.is_success() {
@@ -4853,70 +4904,112 @@ async fn write_crabshack_owner(
         )));
     }
 
-    // Clear the other owners. The right owner is already in place, so a failure here is logged and
-    // does not fail the call — it leaves an extra owner row, which the response reports.
+    // Clear the other owners, but only when the caller vouched for the target name. On the fallback
+    // path the name comes from the chat-api record, and for the very records this exists to repair
+    // that name belongs to a DIFFERENT tenant whose instance passes the probe — revoking there would
+    // lock the rightful owner out of their own agent. Additive is recoverable; a delete is not.
+    let others: Vec<&String> = previous_owners
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .filter(|u| *u != owner_user_id)
+        .collect();
     let mut revoked = Vec::new();
-    for other in previous_owners.iter().filter(|u| *u != owner_user_id) {
-        let del = http
-            .delete(format!("{base}/instances/{enc}/access/{}", encode(other)))
-            .bearer_auth(crabshack_token)
-            .timeout(std::time::Duration::from_secs(30))
-            .send()
-            .await;
-        match del {
-            Ok(r) if r.status().is_success() => {
-                tracing::info!(
-                    "grant-owner: revoked stale owner: name={instance_name}, user_id={other}"
-                );
-                revoked.push(other.clone());
+    let mut left = others.len();
+    if replace_other_owners {
+        for other in others {
+            let del = http
+                .delete(format!("{base}/instances/{enc}/access/{}", encode(other)))
+                .bearer_auth(crabshack_token)
+                .timeout(timeout)
+                .send()
+                .await;
+            match del {
+                // The right owner is already in place, so a failed revoke is logged and reported
+                // rather than failing the call.
+                Ok(r) if r.status().is_success() => {
+                    tracing::info!(
+                        "grant-owner: revoked stale owner: name={instance_name}, user_id={other}"
+                    );
+                    revoked.push(other.clone());
+                    left -= 1;
+                }
+                Ok(r) => tracing::error!(
+                    "grant-owner: revoke failed: name={instance_name}, user_id={other}, status={}",
+                    r.status()
+                ),
+                Err(e) => tracing::error!(
+                    "grant-owner: revoke call failed: name={instance_name}, user_id={other}, error={e}"
+                ),
             }
-            Ok(r) => tracing::error!(
-                "grant-owner: revoke failed: name={instance_name}, user_id={other}, status={}",
-                r.status()
-            ),
-            Err(e) => tracing::error!(
-                "grant-owner: revoke call failed: name={instance_name}, user_id={other}, error={e}"
-            ),
         }
+    } else if left > 0 {
+        tracing::warn!(
+            "grant-owner: left {left} other owner row(s) on {instance_name}: the name came from the \
+             chat-api record, not the caller, so replacing them is not safe here"
+        );
     }
 
-    let changed = !previous_owners.iter().any(|u| u == owner_user_id) || !revoked.is_empty();
-    let message = owner_grant_message(&previous_owners, &revoked, owner_user_id);
+    let already_owner = previous_owners
+        .as_deref()
+        .is_some_and(|prev| prev.iter().any(|u| u == owner_user_id));
+    let changed = !already_owner || !revoked.is_empty();
+    let message = owner_grant_message(previous_owners.as_deref(), &revoked, left, owner_user_id);
     Ok(OwnerGrantOutcome {
         previous_owners,
         revoked,
+        left,
         changed,
         message,
     })
 }
 
-/// Owner user ids CrabShack currently holds for an instance. An unreadable response is treated as
-/// "none known": the grant below still runs, it just cannot report what it replaced.
+/// Owner user ids CrabShack currently holds for an instance, or `None` when the list could not be
+/// read. The caller must not treat that as "no owners": the grant still goes ahead, but nothing is
+/// revoked and the response says so, rather than reporting a clean single owner it never saw.
 async fn read_crabshack_owners(
     http: &reqwest::Client,
     base: &str,
     crabshack_token: &str,
     encoded_name: &str,
-) -> Vec<String> {
-    let rows = http
+    timeout: std::time::Duration,
+) -> Option<Vec<String>> {
+    let resp = http
         .get(format!("{base}/instances/{encoded_name}/access"))
         .bearer_auth(crabshack_token)
-        .timeout(std::time::Duration::from_secs(30))
+        .timeout(timeout)
         .send()
         .await
-        .ok();
-    let Some(rows) = rows else { return Vec::new() };
-    let Ok(rows) = rows.json::<Vec<serde_json::Value>>().await else {
-        return Vec::new();
-    };
-    rows.iter()
-        .filter(|r| r.get("role").and_then(|v| v.as_str()) == Some("owner"))
-        .filter_map(|r| {
-            r.get("user_id")
-                .and_then(|v| v.as_str())
-                .map(str::to_string)
+        .inspect_err(|e| {
+            tracing::error!("grant-owner: could not read owners: name={encoded_name}, error={e}")
         })
-        .collect()
+        .ok()?;
+    if !resp.status().is_success() {
+        tracing::error!(
+            "grant-owner: could not read owners: name={}, status={}",
+            encoded_name,
+            resp.status()
+        );
+        return None;
+    }
+    // CrabShack returns a bare array here (`jsonOk(listAccess(...))`), not an envelope.
+    let rows = resp
+        .json::<Vec<serde_json::Value>>()
+        .await
+        .inspect_err(|e| {
+            tracing::error!("grant-owner: owner list did not parse: name={encoded_name}, error={e}")
+        })
+        .ok()?;
+    Some(
+        rows.iter()
+            .filter(|r| r.get("role").and_then(|v| v.as_str()) == Some("owner"))
+            .filter_map(|r| {
+                r.get("user_id")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            })
+            .collect(),
+    )
 }
 
 #[cfg(test)]
@@ -4929,7 +5022,7 @@ mod grant_owner_message_tests {
     #[test]
     fn fresh_grant() {
         assert_eq!(
-            owner_grant_message(&[], &[], ME),
+            owner_grant_message(Some(&[]), &[], 0, ME),
             "Owner access granted on CrabShack"
         );
     }
@@ -4937,7 +5030,7 @@ mod grant_owner_message_tests {
     #[test]
     fn already_the_only_owner() {
         assert_eq!(
-            owner_grant_message(&[ME.to_string()], &[], ME),
+            owner_grant_message(Some(&[ME.to_string()]), &[], 0, ME),
             "Owner already granted on CrabShack — nothing changed"
         );
     }
@@ -4945,7 +5038,7 @@ mod grant_owner_message_tests {
     #[test]
     fn replaced_a_wrong_owner() {
         assert_eq!(
-            owner_grant_message(&[OTHER.to_string()], &[OTHER.to_string()], ME),
+            owner_grant_message(Some(&[OTHER.to_string()]), &[OTHER.to_string()], 0, ME),
             "Owner access granted on CrabShack; revoked 1 stale owner row(s)"
         );
     }
@@ -4954,12 +5047,183 @@ mod grant_owner_message_tests {
     fn cleared_a_second_owner_from_an_already_owned_instance() {
         assert_eq!(
             owner_grant_message(
-                &[ME.to_string(), OTHER.to_string()],
+                Some(&[ME.to_string(), OTHER.to_string()]),
                 &[OTHER.to_string()],
+                0,
                 ME
             ),
             "Owner already granted on CrabShack; revoked 1 stale owner row(s)"
         );
+    }
+
+    #[test]
+    fn left_a_foreign_owner_alone() {
+        assert_eq!(
+            owner_grant_message(Some(&[OTHER.to_string()]), &[], 1, ME),
+            "Owner access granted on CrabShack; left 1 other owner row(s) in place"
+        );
+    }
+
+    #[test]
+    fn says_so_when_the_owners_could_not_be_read() {
+        // Never "nothing changed" here: the call cannot know what it did not see.
+        assert_eq!(
+            owner_grant_message(None, &[], 0, ME),
+            "Owner access granted on CrabShack; could not read its existing owners, \
+             so none were cleared"
+        );
+    }
+}
+
+#[cfg(test)]
+mod write_crabshack_owner_tests {
+    use super::write_crabshack_owner;
+    use std::time::Duration;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const ME: &str = "aaaa";
+    const OTHER: &str = "bbbb";
+    const NAME: &str = "wise-fish";
+
+    fn owner_row(user: &str) -> serde_json::Value {
+        serde_json::json!({
+            "instance_name": NAME, "user_id": user, "role": "owner",
+            "granted_at": "2026-08-13T00:00:00Z"
+        })
+    }
+
+    /// A CrabShack that has the instance, answers its access list with `owners`, and accepts the
+    /// grant. DELETEs are matched by the caller when it cares.
+    async fn crabshack_with(owners: Vec<serde_json::Value>) -> MockServer {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/instances/{NAME}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "name": NAME, "status": "running"
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/instances/{NAME}/access")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(owners))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(format!("/instances/{NAME}/access")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .mount(&server)
+            .await;
+        server
+    }
+
+    async fn grant(server: &MockServer, replace: bool) -> super::OwnerGrantOutcome {
+        write_crabshack_owner(
+            &reqwest::Client::new(),
+            &server.uri(),
+            "token",
+            NAME,
+            ME,
+            replace,
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("grant should succeed")
+    }
+
+    #[tokio::test]
+    async fn already_sole_owner_revokes_nothing() {
+        let server = crabshack_with(vec![owner_row(ME)]).await;
+        let outcome = grant(&server, true).await;
+        assert!(!outcome.changed);
+        assert!(outcome.revoked.is_empty());
+        assert_eq!(outcome.left, 0);
+        // No DELETE was issued: nothing but the three mounted mocks was called.
+        assert!(!server
+            .received_requests()
+            .await
+            .unwrap()
+            .iter()
+            .any(|r| r.method == wiremock::http::Method::DELETE));
+    }
+
+    #[tokio::test]
+    async fn replaces_a_foreign_owner_when_the_caller_named_the_instance() {
+        let server = crabshack_with(vec![owner_row(OTHER)]).await;
+        Mock::given(method("DELETE"))
+            .and(path(format!("/instances/{NAME}/access/{OTHER}")))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let outcome = grant(&server, true).await;
+        assert_eq!(outcome.revoked, vec![OTHER.to_string()]);
+        assert_eq!(outcome.left, 0);
+        assert!(outcome.changed);
+    }
+
+    #[tokio::test]
+    async fn leaves_a_foreign_owner_when_the_name_came_from_the_record() {
+        // The dangerous path: the target may be someone else's instance, so it must stay additive.
+        let server = crabshack_with(vec![owner_row(OTHER)]).await;
+        let outcome = grant(&server, false).await;
+        assert!(outcome.revoked.is_empty());
+        assert_eq!(outcome.left, 1);
+        assert!(!server
+            .received_requests()
+            .await
+            .unwrap()
+            .iter()
+            .any(|r| r.method == wiremock::http::Method::DELETE));
+    }
+
+    #[tokio::test]
+    async fn an_unreadable_owner_list_revokes_nothing_and_admits_it() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/instances/{NAME}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/instances/{NAME}/access")))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(format!("/instances/{NAME}/access")))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+        let outcome = grant(&server, true).await;
+        assert!(outcome.previous_owners.is_none());
+        assert!(outcome.revoked.is_empty());
+        assert_eq!(outcome.left, 0);
+        assert!(outcome.message.contains("could not read"));
+    }
+
+    #[tokio::test]
+    async fn a_missing_instance_is_a_400_and_a_blip_is_a_502() {
+        for (status, expected) in [(404, 400), (503, 502)] {
+            let server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path(format!("/instances/{NAME}")))
+                .respond_with(ResponseTemplate::new(status))
+                .mount(&server)
+                .await;
+            let err = write_crabshack_owner(
+                &reqwest::Client::new(),
+                &server.uri(),
+                "token",
+                NAME,
+                ME,
+                true,
+                Duration::from_secs(5),
+            )
+            .await
+            .expect_err("should refuse to grant");
+            assert_eq!(err.status.as_u16(), expected, "probe {status}");
+        }
     }
 }
 

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3647,9 +3647,6 @@ pub struct MigrateInstanceResponse {
     pub status: String,
     pub instance_name: String,
     pub message: String,
-    /// True when the migrate also made the owning user the instance's owner on CrabShack. False means
-    /// the instance is migrated but ownerless — retry with the grant-owner endpoint.
-    pub owner_granted: bool,
 }
 
 /// ironclaw-dind tags exist and are allow-listed contiguously from 0.23.0 up.
@@ -3729,8 +3726,6 @@ pub async fn admin_migrate_instance(
             status: "skipped".to_string(),
             instance_name,
             message: "Instance is already on CrabShack".to_string(),
-            // Nothing ran, so nothing was granted. Use grant-owner if this one needs an owner.
-            owner_granted: false,
         }));
     }
 
@@ -3790,13 +3785,8 @@ pub async fn admin_migrate_instance(
         );
     }
 
-    // The auth_secret is kept for the owner grant at the end: the CrabShack owner id derives from it.
-    let mut owner_auth_secret: Option<String> = None;
     let backup_passphrase = match creds {
-        Some((auth_secret, passphrase)) => {
-            owner_auth_secret = Some(auth_secret);
-            passphrase
-        }
+        Some((_auth_secret, passphrase)) => passphrase,
         None if request_has_backup_url => {
             return Err(ApiError::bad_request(
                 "backup_url requires existing passkey credentials — run a normal \
@@ -4497,58 +4487,6 @@ pub async fn admin_migrate_instance(
         ));
     }
 
-    // Own the instance here, while the name it was imported under is in hand. CrabShack's import
-    // creates it ownerless and its grant is keyed by name, so leaving this to a later grant-owner call
-    // means that call has to work out the name — which is how renamed instances ended up granting a
-    // stranger. A failure here does not fail the migration: the instance is migrated either way and
-    // grant-owner retries it.
-    let owner_granted = match owner_auth_secret.as_deref().and_then(crabshack_user_id) {
-        None => {
-            tracing::warn!(
-                "Migrate: no passkey credentials, so no CrabShack owner: instance_id={}, name={}",
-                id,
-                target_name
-            );
-            false
-        }
-        Some(owner_user_id) => {
-            match write_crabshack_owner(
-                &app_state.http_client,
-                &crabshack_manager.url,
-                &crabshack_manager.token,
-                &target_name,
-                &owner_user_id,
-                // migrate chose this name and just imported under it, so clearing any other owner row
-                // is safe here. 10s per leg: a failure only costs `owner_granted: false`.
-                true,
-                std::time::Duration::from_secs(10),
-            )
-            .await
-            {
-                Ok(outcome) => {
-                    tracing::info!(
-                        "Migrate: owner granted: instance_id={}, name={}, owner_user_id={}, changed={}, revoked={}",
-                        id,
-                        target_name,
-                        owner_user_id,
-                        outcome.changed,
-                        outcome.revoked.len()
-                    );
-                    true
-                }
-                Err(e) => {
-                    tracing::error!(
-                        "Migrate: owner grant failed, retry with grant-owner: instance_id={}, name={}, error={:?}",
-                        id,
-                        target_name,
-                        e
-                    );
-                    false
-                }
-            }
-        }
-    };
-
     tracing::info!(
         "Migrate: completed successfully, elapsed={:.1}s, instance_id={}, name={}, previous_name={}",
         migrate_start.elapsed().as_secs_f64(),
@@ -4561,21 +4499,7 @@ pub async fn admin_migrate_instance(
         status: "success".to_string(),
         instance_name: target_name,
         message: "Instance migrated to CrabShack".to_string(),
-        owner_granted,
     }))
-}
-
-/// Optional request body for the grant-owner endpoint.
-///
-/// `deny_unknown_fields`: a typo'd field would otherwise deserialize to `None` and silently take the
-/// record-name fallback, which is the path this endpoint exists to avoid.
-#[derive(Deserialize, Default, utoipa::ToSchema)]
-#[serde(deny_unknown_fields)]
-pub struct GrantInstanceOwnerRequest {
-    /// The name the instance carries on CrabShack, for when this record holds a different one: a
-    /// migrate renamed on collision renames the record only in its last bookkeeping step, so one that
-    /// failed earlier leaves the legacy name behind. Defaults to the record name.
-    pub crabshack_name: Option<String>,
 }
 
 /// Response for the grant-owner endpoint.
@@ -4584,24 +4508,26 @@ pub struct GrantInstanceOwnerRequest {
 /// `auth_secret`, and chat-api does not surface credential-derived identity to API
 /// callers (even admins) — the caller can't obtain it any other way. When the granted
 /// owner needs verifying, read it from CrabShack's own access endpoint
-/// (`GET /instances/{name}/access`), which is the source of truth. The ids this call
-/// saw go to the logs for the same reason.
+/// (`GET /instances/{name}/access`), which is the source of truth.
+/// Optional request body for the grant-owner endpoint.
+///
+/// `deny_unknown_fields`: a typo'd field would otherwise deserialize to `None` and silently fall back
+/// to the record name, which is the case this exists to avoid.
+#[derive(Deserialize, Default, utoipa::ToSchema)]
+#[serde(deny_unknown_fields)]
+pub struct GrantInstanceOwnerRequest {
+    /// The name the instance carries on CrabShack, when this record holds a different one: a migrate
+    /// renamed on collision renames the record only in its last bookkeeping step, so one that failed
+    /// earlier leaves the legacy name behind — and on CrabShack that name is a different tenant's
+    /// instance. Defaults to the record name.
+    pub crabshack_name: Option<String>,
+}
+
 #[derive(Serialize, utoipa::ToSchema)]
 pub struct GrantInstanceOwnerResponse {
     pub status: String,
     pub instance_name: String,
     pub message: String,
-    /// False when CrabShack already held this exact owner and there was nothing to clear.
-    pub changed: bool,
-    /// Owner rows for other users that this call revoked, so the instance ends with one owner.
-    pub revoked_owners: usize,
-    /// Owner rows for other users still in place — either left because the caller did not name the
-    /// instance, or a revoke that failed. Above zero means the instance has more than one owner,
-    /// which also makes it appear twice in CrabShack's instance list.
-    pub stale_owners_left: usize,
-    /// True when CrabShack's access list could not be read. The grant still happened, but nothing was
-    /// revoked and `stale_owners_left` is not a measurement — re-run to find out.
-    pub owners_unknown: bool,
 }
 
 /// Admin endpoint: Grant CrabShack owner access for an already-migrated instance.
@@ -4680,20 +4606,6 @@ pub async fn admin_grant_instance_owner(
         ));
     }
 
-    // Grant on the name the instance carries on CrabShack, which is not always this record's name: a
-    // migrate renamed on collision renames the record in its last bookkeeping step, so one that failed
-    // earlier keeps the legacy name — and on CrabShack that name belongs to a different tenant. The
-    // caller knows the name it migrated under and passes it here.
-    let crabshack_name = grant_target_name(
-        body.as_ref().and_then(|b| b.crabshack_name.as_deref()),
-        &instance.name,
-    )
-    .ok_or_else(|| {
-        ApiError::bad_request(
-            "crabshack_name must be a single lowercase DNS label (letters, digits, dashes)",
-        )
-    })?;
-
     // Look up the owning user's passkey credentials. The auth_secret is the root of the CrabShack
     // user identity. Never mint new credentials here: fresh creds would derive a different identity
     // and backup key than the migrated backup was encrypted with.
@@ -4717,185 +4629,65 @@ pub async fn admin_grant_instance_owner(
         }
     };
 
-    let owner_user_id = crabshack_user_id(&auth_secret).ok_or_else(|| {
+    // CrabShack user id = hex(sha256(hex_decode(auth_secret))).
+    // Mirrors CrabShack's userIdFromAuthSecret (orchestrator-api/src/auth/user-queries.ts).
+    let auth_secret_bytes = hex::decode(auth_secret.trim()).map_err(|e| {
         tracing::error!(
-            "grant-owner: stored auth_secret is not valid hex: instance_id={}",
-            id
+            "grant-owner: stored auth_secret is not valid hex: instance_id={}, error={}",
+            id,
+            e
         );
         ApiError::internal_server_error("Stored auth_secret is not valid hex")
     })?;
+    let owner_user_id = hex::encode(Sha256::digest(&auth_secret_bytes));
 
-    // Only replace other owners when the caller named the instance. Falling back to the record name
-    // and then revoking would delete the rightful owner of whatever instance holds that name.
-    let caller_named = body
-        .as_ref()
-        .and_then(|b| b.crabshack_name.as_deref())
-        .is_some();
-    let outcome = write_crabshack_owner(
-        &app_state.http_client,
-        &crabshack_manager.url,
-        &crabshack_manager.token,
-        &crabshack_name,
-        &owner_user_id,
-        caller_named,
-        std::time::Duration::from_secs(30),
+    // Grant owner access on CrabShack (admin endpoint). Idempotent: last-write-wins.
+    //
+    // On the name: CrabShack's access route takes whatever name it is given and does not check the
+    // instance exists, so granting on the wrong one writes owner access onto another tenant's agent
+    // and reports success. The record's name is not always the instance's name on CrabShack, so the
+    // caller passes the name it migrated under. Everything else — checking what the instance already
+    // has, clearing a stale owner — is the caller's to do with its own CrabShack admin token.
+    let crabshack_name = grant_target_name(
+        body.as_ref().and_then(|b| b.crabshack_name.as_deref()),
+        &instance.name,
     )
-    .await?;
-
-    tracing::info!(
-        "grant-owner: instance_id={}, crabshack_name={}, record_name={}, owner_user_id={}, changed={}, replaced={}, previous_owners=[{}]",
-        id,
-        crabshack_name,
-        instance_name,
-        owner_user_id,
-        outcome.changed,
-        caller_named,
-        outcome
-            .previous_owners
-            .as_ref()
-            .map(|p| p.join(","))
-            .unwrap_or_else(|| "unreadable".to_string())
+    .ok_or_else(|| {
+        ApiError::bad_request(
+            "crabshack_name must be a single lowercase DNS label (letters, digits, dashes)",
+        )
+    })?;
+    let grant_url = format!(
+        "{}/instances/{}/access",
+        crabshack_manager.url.trim_end_matches('/'),
+        encode(&crabshack_name)
     );
-    Ok(Json(GrantInstanceOwnerResponse {
-        status: "success".to_string(),
-        instance_name: crabshack_name,
-        message: outcome.message,
-        changed: outcome.changed,
-        revoked_owners: outcome.revoked.len(),
-        stale_owners_left: outcome.left,
-        owners_unknown: outcome.previous_owners.is_none(),
-    }))
-}
-
-/// The name to grant on: the caller's `crabshack_name` when it is a valid CrabShack label, else this
-/// record's name. `None` rejects a malformed name rather than sending it to CrabShack.
-fn grant_target_name(requested: Option<&str>, record_name: &str) -> Option<String> {
-    match requested {
-        Some(name) if is_valid_crabshack_name(name) => Some(name.to_string()),
-        Some(_) => None,
-        None => Some(record_name.to_string()),
-    }
-}
-
-/// CrabShack user id = hex(sha256(hex_decode(auth_secret))).
-/// Mirrors CrabShack's userIdFromAuthSecret (orchestrator-api/src/auth/user-queries.ts).
-fn crabshack_user_id(auth_secret: &str) -> Option<String> {
-    hex::decode(auth_secret.trim())
-        .ok()
-        .map(|bytes| hex::encode(Sha256::digest(&bytes)))
-}
-
-/// What making a user the owner on CrabShack did.
-#[derive(Debug)]
-struct OwnerGrantOutcome {
-    /// `None` when CrabShack's access list could not be read. "No owners" and "unknown" must not look
-    /// alike, or a report of zero leftover owners would be a guess.
-    previous_owners: Option<Vec<String>>,
-    revoked: Vec<String>,
-    /// Other owner rows still in place: either left deliberately or a revoke that failed.
-    left: usize,
-    changed: bool,
-    message: String,
-}
-
-/// Reads as: who owns this instance now, and what this call moved to get there.
-fn owner_grant_message(
-    previous_owners: Option<&[String]>,
-    revoked: &[String],
-    left: usize,
-    owner: &str,
-) -> String {
-    let already = previous_owners.is_some_and(|prev| prev.iter().any(|u| u == owner));
-    let mut msg = if already {
-        "Owner already granted on CrabShack".to_string()
-    } else {
-        "Owner access granted on CrabShack".to_string()
-    };
-    if previous_owners.is_none() {
-        msg.push_str("; could not read its existing owners, so none were cleared");
-        return msg;
-    }
-    if !revoked.is_empty() {
-        msg.push_str(&format!("; revoked {} stale owner row(s)", revoked.len()));
-    }
-    if left > 0 {
-        msg.push_str(&format!("; left {left} other owner row(s) in place"));
-    }
-    if already && revoked.is_empty() && left == 0 {
-        msg.push_str(" — nothing changed");
-    }
-    msg
-}
-
-/// Make `owner_user_id` the instance's sole owner on CrabShack.
-///
-/// CrabShack keys a grant on (instance, user) and never replaces, so granting a second user leaves
-/// two owner rows — and its own owner join (`role = 'owner'`) then returns that instance twice in
-/// `GET /instances`. One owner is the model, so any other owner row is revoked here. `member` rows
-/// are left alone. Re-granting the same user rewrites the same row, so this is idempotent.
-async fn write_crabshack_owner(
-    http: &reqwest::Client,
-    crabshack_url: &str,
-    crabshack_token: &str,
-    instance_name: &str,
-    owner_user_id: &str,
-    replace_other_owners: bool,
-    timeout: std::time::Duration,
-) -> Result<OwnerGrantOutcome, ApiError> {
-    let base = crabshack_url.trim_end_matches('/');
-    let enc = encode(instance_name);
-
-    // CrabShack's access route takes any name without checking the instance exists, so a wrong name
-    // would write a grant onto another tenant (or nowhere) and report success. Confirm first.
-    let probe = http
-        .get(format!("{base}/instances/{enc}"))
-        .bearer_auth(crabshack_token)
-        .timeout(timeout)
-        .send()
-        .await
-        .map_err(|e| {
-            tracing::error!(
-                "grant-owner: CrabShack lookup failed: name={instance_name}, error={e}"
-            );
-            ApiError::bad_gateway("Failed to look up the instance on CrabShack")
-        })?;
-    // Only a 404 means the name is wrong. A 401 from a stale admin token or a 503 during a CrabShack
-    // blip is worth retrying, and must not read as "no such instance".
-    if probe.status() == reqwest::StatusCode::NOT_FOUND {
-        return Err(ApiError::bad_request(format!(
-            "CrabShack has no instance named {instance_name} — nothing to grant"
-        )));
-    }
-    if !probe.status().is_success() {
-        return Err(ApiError::bad_gateway(format!(
-            "CrabShack lookup for {instance_name} failed (status {})",
-            probe.status()
-        )));
-    }
-
-    let previous_owners = read_crabshack_owners(http, base, crabshack_token, &enc, timeout).await;
-
-    let resp = http
-        .post(format!("{base}/instances/{enc}/access"))
-        .bearer_auth(crabshack_token)
+    let resp = app_state
+        .http_client
+        .post(&grant_url)
+        .bearer_auth(&crabshack_manager.token)
         .json(&serde_json::json!({ "user_id": owner_user_id, "role": "owner" }))
-        .timeout(timeout)
+        .timeout(std::time::Duration::from_secs(30))
         .send()
         .await
         .map_err(|e| {
             tracing::error!(
-                "grant-owner: CrabShack access call failed: name={instance_name}, error={e}"
+                "grant-owner: CrabShack access call failed: instance_id={}, error={}",
+                id,
+                e
             );
-            ApiError::bad_gateway("Failed to call CrabShack access endpoint")
+            ApiError::internal_server_error("Failed to call CrabShack access endpoint")
         })?;
     let status = resp.status();
     if !status.is_success() {
-        // Read the body for diagnosis and surface CrabShack's status, so a misconfigured-admin-token
-        // 401 or a CrabShack 5xx is distinguishable from a generic failure.
+        // Read the body for diagnosis and surface CrabShack's status to the caller, so a
+        // misconfigured-admin-token 401 or a CrabShack 5xx is distinguishable from a generic
+        // failure. (CrabShack's grant is idempotent and does not check instance existence, so it
+        // never returns 404/409 here — only 4xx for a malformed request or auth/transport errors.)
         let body = resp.text().await.unwrap_or_default();
         tracing::error!(
-            "grant-owner: CrabShack access grant failed: name={}, status={}, body={}",
-            instance_name,
+            "grant-owner: CrabShack access grant failed: instance_id={}, status={}, body={}",
+            id,
             status,
             body.chars().take(300).collect::<String>()
         );
@@ -4904,326 +4696,27 @@ async fn write_crabshack_owner(
         )));
     }
 
-    // Clear the other owners, but only when the caller vouched for the target name. On the fallback
-    // path the name comes from the chat-api record, and for the very records this exists to repair
-    // that name belongs to a DIFFERENT tenant whose instance passes the probe — revoking there would
-    // lock the rightful owner out of their own agent. Additive is recoverable; a delete is not.
-    let others: Vec<&String> = previous_owners
-        .as_deref()
-        .unwrap_or_default()
-        .iter()
-        .filter(|u| *u != owner_user_id)
-        .collect();
-    let mut revoked = Vec::new();
-    let mut left = others.len();
-    if replace_other_owners {
-        for other in others {
-            let del = http
-                .delete(format!("{base}/instances/{enc}/access/{}", encode(other)))
-                .bearer_auth(crabshack_token)
-                .timeout(timeout)
-                .send()
-                .await;
-            match del {
-                // The right owner is already in place, so a failed revoke is logged and reported
-                // rather than failing the call.
-                Ok(r) if r.status().is_success() => {
-                    tracing::info!(
-                        "grant-owner: revoked stale owner: name={instance_name}, user_id={other}"
-                    );
-                    revoked.push(other.clone());
-                    left -= 1;
-                }
-                Ok(r) => tracing::error!(
-                    "grant-owner: revoke failed: name={instance_name}, user_id={other}, status={}",
-                    r.status()
-                ),
-                Err(e) => tracing::error!(
-                    "grant-owner: revoke call failed: name={instance_name}, user_id={other}, error={e}"
-                ),
-            }
-        }
-    } else if left > 0 {
-        tracing::warn!(
-            "grant-owner: left {left} other owner row(s) on {instance_name}: the name came from the \
-             chat-api record, not the caller, so replacing them is not safe here"
-        );
-    }
-
-    let already_owner = previous_owners
-        .as_deref()
-        .is_some_and(|prev| prev.iter().any(|u| u == owner_user_id));
-    let changed = !already_owner || !revoked.is_empty();
-    let message = owner_grant_message(previous_owners.as_deref(), &revoked, left, owner_user_id);
-    Ok(OwnerGrantOutcome {
-        previous_owners,
-        revoked,
-        left,
-        changed,
-        message,
-    })
+    tracing::info!(
+        "grant-owner: granted CrabShack owner: instance_id={}, crabshack_name={}, record_name={}, owner_user_id={}",
+        id,
+        crabshack_name,
+        instance_name,
+        owner_user_id
+    );
+    Ok(Json(GrantInstanceOwnerResponse {
+        status: "success".to_string(),
+        instance_name: crabshack_name,
+        message: "Owner access granted on CrabShack".to_string(),
+    }))
 }
 
-/// Owner user ids CrabShack currently holds for an instance, or `None` when the list could not be
-/// read. The caller must not treat that as "no owners": the grant still goes ahead, but nothing is
-/// revoked and the response says so, rather than reporting a clean single owner it never saw.
-async fn read_crabshack_owners(
-    http: &reqwest::Client,
-    base: &str,
-    crabshack_token: &str,
-    encoded_name: &str,
-    timeout: std::time::Duration,
-) -> Option<Vec<String>> {
-    let resp = http
-        .get(format!("{base}/instances/{encoded_name}/access"))
-        .bearer_auth(crabshack_token)
-        .timeout(timeout)
-        .send()
-        .await
-        .inspect_err(|e| {
-            tracing::error!("grant-owner: could not read owners: name={encoded_name}, error={e}")
-        })
-        .ok()?;
-    if !resp.status().is_success() {
-        tracing::error!(
-            "grant-owner: could not read owners: name={}, status={}",
-            encoded_name,
-            resp.status()
-        );
-        return None;
-    }
-    // CrabShack returns a bare array here (`jsonOk(listAccess(...))`), not an envelope.
-    let rows = resp
-        .json::<Vec<serde_json::Value>>()
-        .await
-        .inspect_err(|e| {
-            tracing::error!("grant-owner: owner list did not parse: name={encoded_name}, error={e}")
-        })
-        .ok()?;
-    Some(
-        rows.iter()
-            .filter(|r| r.get("role").and_then(|v| v.as_str()) == Some("owner"))
-            .filter_map(|r| {
-                r.get("user_id")
-                    .and_then(|v| v.as_str())
-                    .map(str::to_string)
-            })
-            .collect(),
-    )
-}
-
-#[cfg(test)]
-mod grant_owner_message_tests {
-    use super::owner_grant_message;
-
-    const ME: &str = "aaaa";
-    const OTHER: &str = "bbbb";
-
-    #[test]
-    fn fresh_grant() {
-        assert_eq!(
-            owner_grant_message(Some(&[]), &[], 0, ME),
-            "Owner access granted on CrabShack"
-        );
-    }
-
-    #[test]
-    fn already_the_only_owner() {
-        assert_eq!(
-            owner_grant_message(Some(&[ME.to_string()]), &[], 0, ME),
-            "Owner already granted on CrabShack — nothing changed"
-        );
-    }
-
-    #[test]
-    fn replaced_a_wrong_owner() {
-        assert_eq!(
-            owner_grant_message(Some(&[OTHER.to_string()]), &[OTHER.to_string()], 0, ME),
-            "Owner access granted on CrabShack; revoked 1 stale owner row(s)"
-        );
-    }
-
-    #[test]
-    fn cleared_a_second_owner_from_an_already_owned_instance() {
-        assert_eq!(
-            owner_grant_message(
-                Some(&[ME.to_string(), OTHER.to_string()]),
-                &[OTHER.to_string()],
-                0,
-                ME
-            ),
-            "Owner already granted on CrabShack; revoked 1 stale owner row(s)"
-        );
-    }
-
-    #[test]
-    fn left_a_foreign_owner_alone() {
-        assert_eq!(
-            owner_grant_message(Some(&[OTHER.to_string()]), &[], 1, ME),
-            "Owner access granted on CrabShack; left 1 other owner row(s) in place"
-        );
-    }
-
-    #[test]
-    fn says_so_when_the_owners_could_not_be_read() {
-        // Never "nothing changed" here: the call cannot know what it did not see.
-        assert_eq!(
-            owner_grant_message(None, &[], 0, ME),
-            "Owner access granted on CrabShack; could not read its existing owners, \
-             so none were cleared"
-        );
-    }
-}
-
-#[cfg(test)]
-mod write_crabshack_owner_tests {
-    use super::write_crabshack_owner;
-    use std::time::Duration;
-    use wiremock::matchers::{method, path};
-    use wiremock::{Mock, MockServer, ResponseTemplate};
-
-    const ME: &str = "aaaa";
-    const OTHER: &str = "bbbb";
-    const NAME: &str = "wise-fish";
-
-    fn owner_row(user: &str) -> serde_json::Value {
-        serde_json::json!({
-            "instance_name": NAME, "user_id": user, "role": "owner",
-            "granted_at": "2026-08-13T00:00:00Z"
-        })
-    }
-
-    /// A CrabShack that has the instance, answers its access list with `owners`, and accepts the
-    /// grant. DELETEs are matched by the caller when it cares.
-    async fn crabshack_with(owners: Vec<serde_json::Value>) -> MockServer {
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path(format!("/instances/{NAME}")))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "name": NAME, "status": "running"
-            })))
-            .mount(&server)
-            .await;
-        Mock::given(method("GET"))
-            .and(path(format!("/instances/{NAME}/access")))
-            .respond_with(ResponseTemplate::new(200).set_body_json(owners))
-            .mount(&server)
-            .await;
-        Mock::given(method("POST"))
-            .and(path(format!("/instances/{NAME}/access")))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
-            .mount(&server)
-            .await;
-        server
-    }
-
-    async fn grant(server: &MockServer, replace: bool) -> super::OwnerGrantOutcome {
-        write_crabshack_owner(
-            &reqwest::Client::new(),
-            &server.uri(),
-            "token",
-            NAME,
-            ME,
-            replace,
-            Duration::from_secs(5),
-        )
-        .await
-        .expect("grant should succeed")
-    }
-
-    #[tokio::test]
-    async fn already_sole_owner_revokes_nothing() {
-        let server = crabshack_with(vec![owner_row(ME)]).await;
-        let outcome = grant(&server, true).await;
-        assert!(!outcome.changed);
-        assert!(outcome.revoked.is_empty());
-        assert_eq!(outcome.left, 0);
-        // No DELETE was issued: nothing but the three mounted mocks was called.
-        assert!(!server
-            .received_requests()
-            .await
-            .unwrap()
-            .iter()
-            .any(|r| r.method == wiremock::http::Method::DELETE));
-    }
-
-    #[tokio::test]
-    async fn replaces_a_foreign_owner_when_the_caller_named_the_instance() {
-        let server = crabshack_with(vec![owner_row(OTHER)]).await;
-        Mock::given(method("DELETE"))
-            .and(path(format!("/instances/{NAME}/access/{OTHER}")))
-            .respond_with(ResponseTemplate::new(200))
-            .expect(1)
-            .mount(&server)
-            .await;
-        let outcome = grant(&server, true).await;
-        assert_eq!(outcome.revoked, vec![OTHER.to_string()]);
-        assert_eq!(outcome.left, 0);
-        assert!(outcome.changed);
-    }
-
-    #[tokio::test]
-    async fn leaves_a_foreign_owner_when_the_name_came_from_the_record() {
-        // The dangerous path: the target may be someone else's instance, so it must stay additive.
-        let server = crabshack_with(vec![owner_row(OTHER)]).await;
-        let outcome = grant(&server, false).await;
-        assert!(outcome.revoked.is_empty());
-        assert_eq!(outcome.left, 1);
-        assert!(!server
-            .received_requests()
-            .await
-            .unwrap()
-            .iter()
-            .any(|r| r.method == wiremock::http::Method::DELETE));
-    }
-
-    #[tokio::test]
-    async fn an_unreadable_owner_list_revokes_nothing_and_admits_it() {
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path(format!("/instances/{NAME}")))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
-            .mount(&server)
-            .await;
-        Mock::given(method("GET"))
-            .and(path(format!("/instances/{NAME}/access")))
-            .respond_with(ResponseTemplate::new(500))
-            .mount(&server)
-            .await;
-        Mock::given(method("POST"))
-            .and(path(format!("/instances/{NAME}/access")))
-            .respond_with(ResponseTemplate::new(200))
-            .mount(&server)
-            .await;
-        let outcome = grant(&server, true).await;
-        assert!(outcome.previous_owners.is_none());
-        assert!(outcome.revoked.is_empty());
-        assert_eq!(outcome.left, 0);
-        assert!(outcome.message.contains("could not read"));
-    }
-
-    #[tokio::test]
-    async fn a_missing_instance_is_a_400_and_a_blip_is_a_502() {
-        for (status, expected) in [(404, 400), (503, 502)] {
-            let server = MockServer::start().await;
-            Mock::given(method("GET"))
-                .and(path(format!("/instances/{NAME}")))
-                .respond_with(ResponseTemplate::new(status))
-                .mount(&server)
-                .await;
-            let err = write_crabshack_owner(
-                &reqwest::Client::new(),
-                &server.uri(),
-                "token",
-                NAME,
-                ME,
-                true,
-                Duration::from_secs(5),
-            )
-            .await
-            .expect_err("should refuse to grant");
-            assert_eq!(err.status.as_u16(), expected, "probe {status}");
-        }
+/// The name to grant on: the caller's `crabshack_name` when it is a valid CrabShack label, else this
+/// record's name. `None` rejects a malformed name rather than passing it to CrabShack.
+fn grant_target_name(requested: Option<&str>, record_name: &str) -> Option<String> {
+    match requested {
+        Some(name) if is_valid_crabshack_name(name) => Some(name.to_string()),
+        Some(_) => None,
+        None => Some(record_name.to_string()),
     }
 }
 
@@ -5250,8 +4743,8 @@ mod grant_owner_name_tests {
 
     #[test]
     fn rejects_a_malformed_name() {
-        // Anything that is not a single DNS label — a url, a path, an empty string — is refused
-        // instead of being sent on to CrabShack's access route, which accepts any name it is given.
+        // A url, spaces, a slash or an empty string is refused rather than passed to CrabShack's
+        // access route, which accepts any name it is given.
         for bad in [
             "https://wise-fish.agents.near.ai/",
             "wise fish",

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -4509,6 +4509,15 @@ pub async fn admin_migrate_instance(
 /// callers (even admins) — the caller can't obtain it any other way. When the granted
 /// owner needs verifying, read it from CrabShack's own access endpoint
 /// (`GET /instances/{name}/access`), which is the source of truth.
+/// Optional request body for the grant-owner endpoint
+#[derive(Deserialize, Default, utoipa::ToSchema)]
+pub struct GrantInstanceOwnerRequest {
+    /// The name the instance carries on CrabShack, for when this record holds a different one: a
+    /// migrate renamed on collision renames the record only in its last bookkeeping step, so one that
+    /// failed earlier leaves the legacy name behind. Defaults to the record name.
+    pub crabshack_name: Option<String>,
+}
+
 #[derive(Serialize, utoipa::ToSchema)]
 pub struct GrantInstanceOwnerResponse {
     pub status: String,
@@ -4539,6 +4548,7 @@ pub struct GrantInstanceOwnerResponse {
     params(
         ("id" = String, Path, description = "Instance ID")
     ),
+    request_body(content = GrantInstanceOwnerRequest, description = "Optional: the instance's CrabShack name"),
     responses(
         (status = 200, description = "Owner access granted", body = GrantInstanceOwnerResponse),
         (status = 400, description = "Bad request", body = crate::error::ApiErrorResponse),
@@ -4553,6 +4563,7 @@ pub async fn admin_grant_instance_owner(
     State(app_state): State<AppState>,
     Extension(_user): Extension<AuthenticatedUser>,
     Path(instance_id): Path<String>,
+    body: Option<Json<GrantInstanceOwnerRequest>>,
 ) -> Result<Json<GrantInstanceOwnerResponse>, ApiError> {
     let id = Uuid::parse_str(&instance_id)
         .map_err(|_| ApiError::bad_request("Invalid instance ID format"))?;
@@ -4590,17 +4601,20 @@ pub async fn admin_grant_instance_owner(
         ));
     }
 
-    // The record name is not always the name the instance carries on CrabShack. A migrate renamed on
-    // collision renames the record in its last bookkeeping step, so one that failed before that — or
-    // was repaired by hand — keeps the legacy name, which on CrabShack belongs to a different tenant.
-    // CrabShack's access route takes any name, so granting on it silently hands that tenant's agent
-    // to this user. Read the name off the url the migrate wrote, then confirm CrabShack has it.
-    let crabshack_name = crabshack_instance_name(
-        instance.instance_url.as_deref(),
-        instance.dashboard_url.as_deref(),
-        &crabshack_manager.url,
+    // Grant on the name the instance carries on CrabShack, which is not always this record's name: a
+    // migrate renamed on collision renames the record in its last bookkeeping step, so one that failed
+    // earlier keeps the legacy name — and on CrabShack that name belongs to a different tenant. The
+    // caller knows the name it migrated under and passes it here; CrabShack's access route takes any
+    // name it is given, so we confirm the instance exists before writing the grant.
+    let crabshack_name = grant_target_name(
+        body.as_ref().and_then(|b| b.crabshack_name.as_deref()),
+        &instance.name,
     )
-    .unwrap_or_else(|| instance.name.clone());
+    .ok_or_else(|| {
+        ApiError::bad_request(
+            "crabshack_name must be a single lowercase DNS label (letters, digits, dashes)",
+        )
+    })?;
     let probe = app_state
         .http_client
         .get(format!(
@@ -4717,76 +4731,49 @@ pub async fn admin_grant_instance_owner(
     }))
 }
 
-/// The name an instance carries on CrabShack, read from the urls a migrate wrote for it
-/// (`https://<name>.<crabshack host>/…`). `None` when neither url points at CrabShack, which leaves
-/// the caller on the record name.
-fn crabshack_instance_name(
-    instance_url: Option<&str>,
-    dashboard_url: Option<&str>,
-    crabshack_url: &str,
-) -> Option<String> {
-    let host = url::Url::parse(crabshack_url).ok()?.host_str()?.to_string();
-    let suffix = format!(".{host}");
-    [instance_url, dashboard_url]
-        .into_iter()
-        .flatten()
-        .filter_map(|u| url::Url::parse(u).ok())
-        .filter_map(|u| u.host_str().map(str::to_string))
-        .find_map(|h| {
-            h.strip_suffix(&suffix)
-                .filter(|label| !label.is_empty() && !label.contains('.'))
-                .map(str::to_string)
-        })
+/// The name to grant on: the caller's `crabshack_name` when it is a valid CrabShack label, else this
+/// record's name. `None` rejects a malformed name rather than sending it to CrabShack.
+fn grant_target_name(requested: Option<&str>, record_name: &str) -> Option<String> {
+    match requested {
+        Some(name) if is_valid_crabshack_name(name) => Some(name.to_string()),
+        Some(_) => None,
+        None => Some(record_name.to_string()),
+    }
 }
 
 #[cfg(test)]
 mod grant_owner_name_tests {
-    use super::crabshack_instance_name;
-
-    const CRAB: &str = "https://agents.near.ai/api/crabshack";
+    use super::grant_target_name;
 
     #[test]
-    fn reads_the_name_a_rename_gave_the_instance() {
+    fn caller_supplied_name_wins() {
         // The record still says rich-orca; CrabShack holds it as rich-orca-fibir.
         assert_eq!(
-            crabshack_instance_name(
-                Some("https://rich-orca-fibir.agents.near.ai/?token=abc"),
-                Some("https://rich-orca-fibir.agents.near.ai/"),
-                CRAB
-            ),
+            grant_target_name(Some("rich-orca-fibir"), "rich-orca"),
             Some("rich-orca-fibir".to_string())
         );
     }
 
     #[test]
-    fn falls_back_to_the_dashboard_url() {
+    fn falls_back_to_the_record_name() {
         assert_eq!(
-            crabshack_instance_name(None, Some("https://wise-fish.agents.near.ai/"), CRAB),
+            grant_target_name(None, "wise-fish"),
             Some("wise-fish".to_string())
         );
     }
 
     #[test]
-    fn ignores_a_legacy_url() {
-        // api.agentN urls must never be mistaken for a CrabShack name.
-        assert_eq!(
-            crabshack_instance_name(
-                Some("https://dark-pike.agent1.near.ai/"),
-                Some("https://dark-pike.agent1.near.ai/"),
-                CRAB
-            ),
-            None
-        );
-    }
-
-    #[test]
-    fn ignores_urls_without_a_single_label() {
-        assert_eq!(
-            crabshack_instance_name(Some("https://agents.near.ai/"), None, CRAB),
-            None
-        );
-        assert_eq!(crabshack_instance_name(Some("not a url"), None, CRAB), None);
-        assert_eq!(crabshack_instance_name(None, None, CRAB), None);
+    fn rejects_a_malformed_name() {
+        // Anything that is not a single DNS label — a url, a path, an empty string — is refused
+        // instead of being sent on to CrabShack's access route, which accepts any name it is given.
+        for bad in [
+            "https://wise-fish.agents.near.ai/",
+            "wise fish",
+            "wise/fish",
+            "",
+        ] {
+            assert_eq!(grant_target_name(Some(bad), "wise-fish"), None, "{bad}");
+        }
     }
 }
 

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -4590,6 +4590,44 @@ pub async fn admin_grant_instance_owner(
         ));
     }
 
+    // The record name is not always the name the instance carries on CrabShack. A migrate renamed on
+    // collision renames the record in its last bookkeeping step, so one that failed before that — or
+    // was repaired by hand — keeps the legacy name, which on CrabShack belongs to a different tenant.
+    // CrabShack's access route takes any name, so granting on it silently hands that tenant's agent
+    // to this user. Read the name off the url the migrate wrote, then confirm CrabShack has it.
+    let crabshack_name = crabshack_instance_name(
+        instance.instance_url.as_deref(),
+        instance.dashboard_url.as_deref(),
+        &crabshack_manager.url,
+    )
+    .unwrap_or_else(|| instance.name.clone());
+    let probe = app_state
+        .http_client
+        .get(format!(
+            "{}/instances/{}",
+            crabshack_manager.url.trim_end_matches('/'),
+            encode(&crabshack_name)
+        ))
+        .bearer_auth(&crabshack_manager.token)
+        .timeout(std::time::Duration::from_secs(30))
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "grant-owner: CrabShack lookup failed: instance_id={}, name={}, error={}",
+                id,
+                crabshack_name,
+                e
+            );
+            ApiError::internal_server_error("Failed to look up the instance on CrabShack")
+        })?;
+    if !probe.status().is_success() {
+        return Err(ApiError::bad_request(format!(
+            "CrabShack has no instance named {crabshack_name} (status {}) — nothing to grant",
+            probe.status()
+        )));
+    }
+
     // Look up the owning user's passkey credentials. The auth_secret is the root of the CrabShack
     // user identity. Never mint new credentials here: fresh creds would derive a different identity
     // and backup key than the migrated backup was encrypted with.
@@ -4629,7 +4667,7 @@ pub async fn admin_grant_instance_owner(
     let grant_url = format!(
         "{}/instances/{}/access",
         crabshack_manager.url.trim_end_matches('/'),
-        encode(&instance.name)
+        encode(&crabshack_name)
     );
     let resp = app_state
         .http_client
@@ -4666,15 +4704,90 @@ pub async fn admin_grant_instance_owner(
     }
 
     tracing::info!(
-        "grant-owner: granted CrabShack owner: instance_id={}, owner_user_id={}",
+        "grant-owner: granted CrabShack owner: instance_id={}, crabshack_name={}, record_name={}, owner_user_id={}",
         id,
+        crabshack_name,
+        instance_name,
         owner_user_id
     );
     Ok(Json(GrantInstanceOwnerResponse {
         status: "success".to_string(),
-        instance_name,
+        instance_name: crabshack_name,
         message: "Owner access granted on CrabShack".to_string(),
     }))
+}
+
+/// The name an instance carries on CrabShack, read from the urls a migrate wrote for it
+/// (`https://<name>.<crabshack host>/…`). `None` when neither url points at CrabShack, which leaves
+/// the caller on the record name.
+fn crabshack_instance_name(
+    instance_url: Option<&str>,
+    dashboard_url: Option<&str>,
+    crabshack_url: &str,
+) -> Option<String> {
+    let host = url::Url::parse(crabshack_url).ok()?.host_str()?.to_string();
+    let suffix = format!(".{host}");
+    [instance_url, dashboard_url]
+        .into_iter()
+        .flatten()
+        .filter_map(|u| url::Url::parse(u).ok())
+        .filter_map(|u| u.host_str().map(str::to_string))
+        .find_map(|h| {
+            h.strip_suffix(&suffix)
+                .filter(|label| !label.is_empty() && !label.contains('.'))
+                .map(str::to_string)
+        })
+}
+
+#[cfg(test)]
+mod grant_owner_name_tests {
+    use super::crabshack_instance_name;
+
+    const CRAB: &str = "https://agents.near.ai/api/crabshack";
+
+    #[test]
+    fn reads_the_name_a_rename_gave_the_instance() {
+        // The record still says rich-orca; CrabShack holds it as rich-orca-fibir.
+        assert_eq!(
+            crabshack_instance_name(
+                Some("https://rich-orca-fibir.agents.near.ai/?token=abc"),
+                Some("https://rich-orca-fibir.agents.near.ai/"),
+                CRAB
+            ),
+            Some("rich-orca-fibir".to_string())
+        );
+    }
+
+    #[test]
+    fn falls_back_to_the_dashboard_url() {
+        assert_eq!(
+            crabshack_instance_name(None, Some("https://wise-fish.agents.near.ai/"), CRAB),
+            Some("wise-fish".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_a_legacy_url() {
+        // api.agentN urls must never be mistaken for a CrabShack name.
+        assert_eq!(
+            crabshack_instance_name(
+                Some("https://dark-pike.agent1.near.ai/"),
+                Some("https://dark-pike.agent1.near.ai/"),
+                CRAB
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn ignores_urls_without_a_single_label() {
+        assert_eq!(
+            crabshack_instance_name(Some("https://agents.near.ai/"), None, CRAB),
+            None
+        );
+        assert_eq!(crabshack_instance_name(Some("not a url"), None, CRAB), None);
+        assert_eq!(crabshack_instance_name(None, None, CRAB), None);
+    }
 }
 
 /// Maximum buffer size for SSE parsing (1 MB).

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3647,6 +3647,9 @@ pub struct MigrateInstanceResponse {
     pub status: String,
     pub instance_name: String,
     pub message: String,
+    /// True when the migrate also made the owning user the instance's owner on CrabShack. False means
+    /// the instance is migrated but ownerless — retry with the grant-owner endpoint.
+    pub owner_granted: bool,
 }
 
 /// ironclaw-dind tags exist and are allow-listed contiguously from 0.23.0 up.
@@ -3726,6 +3729,8 @@ pub async fn admin_migrate_instance(
             status: "skipped".to_string(),
             instance_name,
             message: "Instance is already on CrabShack".to_string(),
+            // Nothing ran, so nothing was granted. Use grant-owner if this one needs an owner.
+            owner_granted: false,
         }));
     }
 
@@ -3785,8 +3790,13 @@ pub async fn admin_migrate_instance(
         );
     }
 
+    // The auth_secret is kept for the owner grant at the end: the CrabShack owner id derives from it.
+    let mut owner_auth_secret: Option<String> = None;
     let backup_passphrase = match creds {
-        Some((_auth_secret, passphrase)) => passphrase,
+        Some((auth_secret, passphrase)) => {
+            owner_auth_secret = Some(auth_secret);
+            passphrase
+        }
         None if request_has_backup_url => {
             return Err(ApiError::bad_request(
                 "backup_url requires existing passkey credentials — run a normal \
@@ -4487,6 +4497,54 @@ pub async fn admin_migrate_instance(
         ));
     }
 
+    // Own the instance here, while the name it was imported under is in hand. CrabShack's import
+    // creates it ownerless and its grant is keyed by name, so leaving this to a later grant-owner call
+    // means that call has to work out the name — which is how renamed instances ended up granting a
+    // stranger. A failure here does not fail the migration: the instance is migrated either way and
+    // grant-owner retries it.
+    let owner_granted = match owner_auth_secret.as_deref().and_then(crabshack_user_id) {
+        None => {
+            tracing::warn!(
+                "Migrate: no passkey credentials, so no CrabShack owner: instance_id={}, name={}",
+                id,
+                target_name
+            );
+            false
+        }
+        Some(owner_user_id) => {
+            match write_crabshack_owner(
+                &app_state.http_client,
+                &crabshack_manager.url,
+                &crabshack_manager.token,
+                &target_name,
+                &owner_user_id,
+            )
+            .await
+            {
+                Ok(outcome) => {
+                    tracing::info!(
+                        "Migrate: owner granted: instance_id={}, name={}, owner_user_id={}, changed={}, revoked={}",
+                        id,
+                        target_name,
+                        owner_user_id,
+                        outcome.changed,
+                        outcome.revoked.len()
+                    );
+                    true
+                }
+                Err(e) => {
+                    tracing::error!(
+                        "Migrate: owner grant failed, retry with grant-owner: instance_id={}, name={}, error={:?}",
+                        id,
+                        target_name,
+                        e
+                    );
+                    false
+                }
+            }
+        }
+    };
+
     tracing::info!(
         "Migrate: completed successfully, elapsed={:.1}s, instance_id={}, name={}, previous_name={}",
         migrate_start.elapsed().as_secs_f64(),
@@ -4499,16 +4557,10 @@ pub async fn admin_migrate_instance(
         status: "success".to_string(),
         instance_name: target_name,
         message: "Instance migrated to CrabShack".to_string(),
+        owner_granted,
     }))
 }
 
-/// Response for the grant-owner endpoint.
-///
-/// Intentionally omits the derived owner user id. It is computed from the user's
-/// `auth_secret`, and chat-api does not surface credential-derived identity to API
-/// callers (even admins) — the caller can't obtain it any other way. When the granted
-/// owner needs verifying, read it from CrabShack's own access endpoint
-/// (`GET /instances/{name}/access`), which is the source of truth.
 /// Optional request body for the grant-owner endpoint
 #[derive(Deserialize, Default, utoipa::ToSchema)]
 pub struct GrantInstanceOwnerRequest {
@@ -4518,11 +4570,26 @@ pub struct GrantInstanceOwnerRequest {
     pub crabshack_name: Option<String>,
 }
 
+/// Response for the grant-owner endpoint.
+///
+/// Intentionally omits the derived owner user id. It is computed from the user's
+/// `auth_secret`, and chat-api does not surface credential-derived identity to API
+/// callers (even admins) — the caller can't obtain it any other way. When the granted
+/// owner needs verifying, read it from CrabShack's own access endpoint
+/// (`GET /instances/{name}/access`), which is the source of truth. The ids this call
+/// saw go to the logs for the same reason.
 #[derive(Serialize, utoipa::ToSchema)]
 pub struct GrantInstanceOwnerResponse {
     pub status: String,
     pub instance_name: String,
     pub message: String,
+    /// False when CrabShack already held this exact owner and there was nothing to clear.
+    pub changed: bool,
+    /// Owner rows for other users that this call revoked, so the instance ends with one owner.
+    pub revoked_owners: usize,
+    /// Owner rows for other users that could NOT be revoked. Above zero means the instance still has
+    /// more than one owner, which also makes it appear twice in CrabShack's instance list.
+    pub stale_owners_left: usize,
 }
 
 /// Admin endpoint: Grant CrabShack owner access for an already-migrated instance.
@@ -4604,8 +4671,7 @@ pub async fn admin_grant_instance_owner(
     // Grant on the name the instance carries on CrabShack, which is not always this record's name: a
     // migrate renamed on collision renames the record in its last bookkeeping step, so one that failed
     // earlier keeps the legacy name — and on CrabShack that name belongs to a different tenant. The
-    // caller knows the name it migrated under and passes it here; CrabShack's access route takes any
-    // name it is given, so we confirm the instance exists before writing the grant.
+    // caller knows the name it migrated under and passes it here.
     let crabshack_name = grant_target_name(
         body.as_ref().and_then(|b| b.crabshack_name.as_deref()),
         &instance.name,
@@ -4615,32 +4681,6 @@ pub async fn admin_grant_instance_owner(
             "crabshack_name must be a single lowercase DNS label (letters, digits, dashes)",
         )
     })?;
-    let probe = app_state
-        .http_client
-        .get(format!(
-            "{}/instances/{}",
-            crabshack_manager.url.trim_end_matches('/'),
-            encode(&crabshack_name)
-        ))
-        .bearer_auth(&crabshack_manager.token)
-        .timeout(std::time::Duration::from_secs(30))
-        .send()
-        .await
-        .map_err(|e| {
-            tracing::error!(
-                "grant-owner: CrabShack lookup failed: instance_id={}, name={}, error={}",
-                id,
-                crabshack_name,
-                e
-            );
-            ApiError::internal_server_error("Failed to look up the instance on CrabShack")
-        })?;
-    if !probe.status().is_success() {
-        return Err(ApiError::bad_request(format!(
-            "CrabShack has no instance named {crabshack_name} (status {}) — nothing to grant",
-            probe.status()
-        )));
-    }
 
     // Look up the owning user's passkey credentials. The auth_secret is the root of the CrabShack
     // user identity. Never mint new credentials here: fresh creds would derive a different identity
@@ -4665,69 +4705,44 @@ pub async fn admin_grant_instance_owner(
         }
     };
 
-    // CrabShack user id = hex(sha256(hex_decode(auth_secret))).
-    // Mirrors CrabShack's userIdFromAuthSecret (orchestrator-api/src/auth/user-queries.ts).
-    let auth_secret_bytes = hex::decode(auth_secret.trim()).map_err(|e| {
+    let owner_user_id = crabshack_user_id(&auth_secret).ok_or_else(|| {
         tracing::error!(
-            "grant-owner: stored auth_secret is not valid hex: instance_id={}, error={}",
-            id,
-            e
+            "grant-owner: stored auth_secret is not valid hex: instance_id={}",
+            id
         );
         ApiError::internal_server_error("Stored auth_secret is not valid hex")
     })?;
-    let owner_user_id = hex::encode(Sha256::digest(&auth_secret_bytes));
 
-    // Grant owner access on CrabShack (admin endpoint). Idempotent: last-write-wins.
-    let grant_url = format!(
-        "{}/instances/{}/access",
-        crabshack_manager.url.trim_end_matches('/'),
-        encode(&crabshack_name)
-    );
-    let resp = app_state
-        .http_client
-        .post(&grant_url)
-        .bearer_auth(&crabshack_manager.token)
-        .json(&serde_json::json!({ "user_id": owner_user_id, "role": "owner" }))
-        .timeout(std::time::Duration::from_secs(30))
-        .send()
-        .await
-        .map_err(|e| {
-            tracing::error!(
-                "grant-owner: CrabShack access call failed: instance_id={}, error={}",
-                id,
-                e
-            );
-            ApiError::internal_server_error("Failed to call CrabShack access endpoint")
-        })?;
-    let status = resp.status();
-    if !status.is_success() {
-        // Read the body for diagnosis and surface CrabShack's status to the caller, so a
-        // misconfigured-admin-token 401 or a CrabShack 5xx is distinguishable from a generic
-        // failure. (CrabShack's grant is idempotent and does not check instance existence, so it
-        // never returns 404/409 here — only 4xx for a malformed request or auth/transport errors.)
-        let body = resp.text().await.unwrap_or_default();
-        tracing::error!(
-            "grant-owner: CrabShack access grant failed: instance_id={}, status={}, body={}",
-            id,
-            status,
-            body.chars().take(300).collect::<String>()
-        );
-        return Err(ApiError::internal_server_error(format!(
-            "CrabShack rejected the access grant (status {status})"
-        )));
-    }
+    let outcome = write_crabshack_owner(
+        &app_state.http_client,
+        &crabshack_manager.url,
+        &crabshack_manager.token,
+        &crabshack_name,
+        &owner_user_id,
+    )
+    .await?;
 
     tracing::info!(
-        "grant-owner: granted CrabShack owner: instance_id={}, crabshack_name={}, record_name={}, owner_user_id={}",
+        "grant-owner: instance_id={}, crabshack_name={}, record_name={}, owner_user_id={}, changed={}, previous_owners=[{}]",
         id,
         crabshack_name,
         instance_name,
-        owner_user_id
+        owner_user_id,
+        outcome.changed,
+        outcome.previous_owners.join(",")
     );
+    let others = outcome
+        .previous_owners
+        .iter()
+        .filter(|u| **u != owner_user_id)
+        .count();
     Ok(Json(GrantInstanceOwnerResponse {
         status: "success".to_string(),
         instance_name: crabshack_name,
-        message: "Owner access granted on CrabShack".to_string(),
+        message: outcome.message,
+        changed: outcome.changed,
+        revoked_owners: outcome.revoked.len(),
+        stale_owners_left: others - outcome.revoked.len(),
     }))
 }
 
@@ -4738,6 +4753,213 @@ fn grant_target_name(requested: Option<&str>, record_name: &str) -> Option<Strin
         Some(name) if is_valid_crabshack_name(name) => Some(name.to_string()),
         Some(_) => None,
         None => Some(record_name.to_string()),
+    }
+}
+
+/// CrabShack user id = hex(sha256(hex_decode(auth_secret))).
+/// Mirrors CrabShack's userIdFromAuthSecret (orchestrator-api/src/auth/user-queries.ts).
+fn crabshack_user_id(auth_secret: &str) -> Option<String> {
+    hex::decode(auth_secret.trim())
+        .ok()
+        .map(|bytes| hex::encode(Sha256::digest(&bytes)))
+}
+
+/// What making a user the owner on CrabShack did.
+struct OwnerGrantOutcome {
+    previous_owners: Vec<String>,
+    revoked: Vec<String>,
+    changed: bool,
+    message: String,
+}
+
+/// Reads as: this instance ended up owned by `owner_user_id`, and by nobody else.
+fn owner_grant_message(previous_owners: &[String], revoked: &[String], owner: &str) -> String {
+    let already = previous_owners.iter().any(|u| u == owner);
+    match (already, revoked.len()) {
+        (true, 0) => "Owner already granted on CrabShack — nothing changed".to_string(),
+        (true, n) => format!("Owner already granted on CrabShack; revoked {n} stale owner row(s)"),
+        (false, 0) => "Owner access granted on CrabShack".to_string(),
+        (false, n) => {
+            format!("Owner access granted on CrabShack; revoked {n} stale owner row(s)")
+        }
+    }
+}
+
+/// Make `owner_user_id` the instance's sole owner on CrabShack.
+///
+/// CrabShack keys a grant on (instance, user) and never replaces, so granting a second user leaves
+/// two owner rows — and its own owner join (`role = 'owner'`) then returns that instance twice in
+/// `GET /instances`. One owner is the model, so any other owner row is revoked here. `member` rows
+/// are left alone. Re-granting the same user rewrites the same row, so this is idempotent.
+async fn write_crabshack_owner(
+    http: &reqwest::Client,
+    crabshack_url: &str,
+    crabshack_token: &str,
+    instance_name: &str,
+    owner_user_id: &str,
+) -> Result<OwnerGrantOutcome, ApiError> {
+    let base = crabshack_url.trim_end_matches('/');
+    let enc = encode(instance_name);
+
+    // CrabShack's access route takes any name without checking the instance exists, so a wrong name
+    // would write a grant onto another tenant (or nowhere) and report success. Confirm first.
+    let probe = http
+        .get(format!("{base}/instances/{enc}"))
+        .bearer_auth(crabshack_token)
+        .timeout(std::time::Duration::from_secs(30))
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "grant-owner: CrabShack lookup failed: name={instance_name}, error={e}"
+            );
+            ApiError::internal_server_error("Failed to look up the instance on CrabShack")
+        })?;
+    if !probe.status().is_success() {
+        return Err(ApiError::bad_request(format!(
+            "CrabShack has no instance named {instance_name} (status {}) — nothing to grant",
+            probe.status()
+        )));
+    }
+
+    let previous_owners = read_crabshack_owners(http, base, crabshack_token, &enc).await;
+
+    let resp = http
+        .post(format!("{base}/instances/{enc}/access"))
+        .bearer_auth(crabshack_token)
+        .json(&serde_json::json!({ "user_id": owner_user_id, "role": "owner" }))
+        .timeout(std::time::Duration::from_secs(30))
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "grant-owner: CrabShack access call failed: name={instance_name}, error={e}"
+            );
+            ApiError::internal_server_error("Failed to call CrabShack access endpoint")
+        })?;
+    let status = resp.status();
+    if !status.is_success() {
+        // Read the body for diagnosis and surface CrabShack's status, so a misconfigured-admin-token
+        // 401 or a CrabShack 5xx is distinguishable from a generic failure.
+        let body = resp.text().await.unwrap_or_default();
+        tracing::error!(
+            "grant-owner: CrabShack access grant failed: name={}, status={}, body={}",
+            instance_name,
+            status,
+            body.chars().take(300).collect::<String>()
+        );
+        return Err(ApiError::internal_server_error(format!(
+            "CrabShack rejected the access grant (status {status})"
+        )));
+    }
+
+    // Clear the other owners. The right owner is already in place, so a failure here is logged and
+    // does not fail the call — it leaves an extra owner row, which the response reports.
+    let mut revoked = Vec::new();
+    for other in previous_owners.iter().filter(|u| *u != owner_user_id) {
+        let del = http
+            .delete(format!("{base}/instances/{enc}/access/{}", encode(other)))
+            .bearer_auth(crabshack_token)
+            .timeout(std::time::Duration::from_secs(30))
+            .send()
+            .await;
+        match del {
+            Ok(r) if r.status().is_success() => {
+                tracing::info!(
+                    "grant-owner: revoked stale owner: name={instance_name}, user_id={other}"
+                );
+                revoked.push(other.clone());
+            }
+            Ok(r) => tracing::error!(
+                "grant-owner: revoke failed: name={instance_name}, user_id={other}, status={}",
+                r.status()
+            ),
+            Err(e) => tracing::error!(
+                "grant-owner: revoke call failed: name={instance_name}, user_id={other}, error={e}"
+            ),
+        }
+    }
+
+    let changed = !previous_owners.iter().any(|u| u == owner_user_id) || !revoked.is_empty();
+    let message = owner_grant_message(&previous_owners, &revoked, owner_user_id);
+    Ok(OwnerGrantOutcome {
+        previous_owners,
+        revoked,
+        changed,
+        message,
+    })
+}
+
+/// Owner user ids CrabShack currently holds for an instance. An unreadable response is treated as
+/// "none known": the grant below still runs, it just cannot report what it replaced.
+async fn read_crabshack_owners(
+    http: &reqwest::Client,
+    base: &str,
+    crabshack_token: &str,
+    encoded_name: &str,
+) -> Vec<String> {
+    let rows = http
+        .get(format!("{base}/instances/{encoded_name}/access"))
+        .bearer_auth(crabshack_token)
+        .timeout(std::time::Duration::from_secs(30))
+        .send()
+        .await
+        .ok();
+    let Some(rows) = rows else { return Vec::new() };
+    let Ok(rows) = rows.json::<Vec<serde_json::Value>>().await else {
+        return Vec::new();
+    };
+    rows.iter()
+        .filter(|r| r.get("role").and_then(|v| v.as_str()) == Some("owner"))
+        .filter_map(|r| {
+            r.get("user_id")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod grant_owner_message_tests {
+    use super::owner_grant_message;
+
+    const ME: &str = "aaaa";
+    const OTHER: &str = "bbbb";
+
+    #[test]
+    fn fresh_grant() {
+        assert_eq!(
+            owner_grant_message(&[], &[], ME),
+            "Owner access granted on CrabShack"
+        );
+    }
+
+    #[test]
+    fn already_the_only_owner() {
+        assert_eq!(
+            owner_grant_message(&[ME.to_string()], &[], ME),
+            "Owner already granted on CrabShack — nothing changed"
+        );
+    }
+
+    #[test]
+    fn replaced_a_wrong_owner() {
+        assert_eq!(
+            owner_grant_message(&[OTHER.to_string()], &[OTHER.to_string()], ME),
+            "Owner access granted on CrabShack; revoked 1 stale owner row(s)"
+        );
+    }
+
+    #[test]
+    fn cleared_a_second_owner_from_an_already_owned_instance() {
+        assert_eq!(
+            owner_grant_message(
+                &[ME.to_string(), OTHER.to_string()],
+                &[OTHER.to_string()],
+                ME
+            ),
+            "Owner already granted on CrabShack; revoked 1 stale owner row(s)"
+        );
     }
 }
 

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3647,13 +3647,7 @@ pub struct MigrateInstanceResponse {
     pub status: String,
     pub instance_name: String,
     pub message: String,
-    /// The CrabShack user id to grant as owner, derived from the user's `auth_secret`. A CrabShack
-    /// import lands ownerless, so the caller finishes the job:
-    /// `POST <crabshack>/instances/<instance_name>/access {"user_id": ..., "role": "owner"}` —
-    /// `instance_name` above is the name it was imported under, which is what the grant must use.
-    ///
-    /// `None` when the user has no passkey credentials to derive from, and on the `skipped` path
-    /// (nothing was migrated; use the grant-owner endpoint to look it up).
+    /// `None` when the user has no passkey credentials, and on the `skipped` path.
     pub owner_user_id: Option<String>,
 }
 
@@ -4527,19 +4521,11 @@ pub async fn admin_migrate_instance(
 }
 
 /// Response for the grant-owner endpoint.
-///
-/// Carries the derived owner user id, because the caller is the one that writes the grant and cannot
-/// compute this id itself — it comes from the user's `auth_secret`, which never leaves chat-api. Admin
-/// scope only. Knowing the id lets a caller grant, check or revoke that user's access on CrabShack;
-/// it reveals nothing about the secret it derives from.
 #[derive(Serialize, utoipa::ToSchema)]
 pub struct GrantInstanceOwnerResponse {
     pub status: String,
     pub instance_name: String,
     pub message: String,
-    /// The CrabShack user id of this instance's owner: `sha256(hex_decode(auth_secret))`, the same
-    /// derivation CrabShack does on login. Grant it with
-    /// `POST <crabshack>/instances/<name>/access {"user_id": ..., "role": "owner"}`.
     pub owner_user_id: String,
 }
 

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3647,7 +3647,8 @@ pub struct MigrateInstanceResponse {
     pub status: String,
     pub instance_name: String,
     pub message: String,
-    /// `None` when the user has no passkey credentials, and on the `skipped` path.
+    /// `None` only on the `skipped` path or a corrupt stored secret — never a reason to skip the
+    /// grant, resolve the id another way.
     pub owner_user_id: Option<String>,
 }
 
@@ -3789,13 +3790,11 @@ pub async fn admin_migrate_instance(
         );
     }
 
-    // Kept for the owner id in the response: the caller needs it to grant ownership on CrabShack.
-    let mut owner_auth_secret: Option<String> = None;
-    let backup_passphrase = match creds {
-        Some((auth_secret, passphrase)) => {
-            owner_auth_secret = Some(auth_secret);
-            passphrase
-        }
+    // Both halves matter downstream: the passphrase encrypts the backup, and the auth_secret is what
+    // the owner id in the response derives from. Every arm states both, so neither can be dropped by
+    // accident — a missing owner id makes the caller skip the grant and the instance lands ownerless.
+    let (owner_auth_secret, backup_passphrase) = match creds {
+        Some((auth_secret, passphrase)) => (auth_secret, passphrase),
         None if request_has_backup_url => {
             return Err(ApiError::bad_request(
                 "backup_url requires existing passkey credentials — run a normal \
@@ -3826,7 +3825,7 @@ pub async fn admin_migrate_instance(
                     );
                     ApiError::internal_server_error("Failed to store credentials")
                 })?;
-            passphrase
+            (auth_secret, passphrase)
         }
     };
 
@@ -4504,10 +4503,10 @@ pub async fn admin_migrate_instance(
         instance_name,
     );
 
-    let owner_user_id = owner_auth_secret.as_deref().and_then(crabshack_user_id);
+    let owner_user_id = crabshack_user_id(&owner_auth_secret);
     if owner_user_id.is_none() {
-        tracing::warn!(
-            "Migrate: no passkey credentials, so no owner id for the caller to grant: instance_id={}, name={}",
+        tracing::error!(
+            "Migrate: stored auth_secret is not valid hex, so the caller gets no owner id: instance_id={}, name={}",
             id,
             target_name
         );
@@ -4524,6 +4523,7 @@ pub async fn admin_migrate_instance(
 #[derive(Serialize, utoipa::ToSchema)]
 pub struct GrantInstanceOwnerResponse {
     pub status: String,
+    /// chat-api's record name — NOT necessarily the name CrabShack knows. Do not grant on it.
     pub instance_name: String,
     pub message: String,
     pub owner_user_id: String,


### PR DESCRIPTION
## Summary

`admin_grant_instance_owner` wrote its grant to CrabShack using the chat-api record's own name:

```rust
"{}/instances/{}/access", crabshack_manager.url, encode(&instance.name)
```

That is not always the name the instance carries on CrabShack. `/migrate` renames the record to the
CrabShack name in its **last** bookkeeping step, so a migrate that failed earlier — or an instance
repaired by hand — keeps the legacy name, which for a row renamed on collision is a **different
tenant's** instance. CrabShack's access route takes any name without checking the instance exists, so
the call returned 200 while writing `role=owner` for this user on the other tenant's agent and leaving
the migrated instance ownerless. Measured on prod 2026-08-13: **11 of 102 renamed instances**.

**The endpoint no longer grants.** It derives the CrabShack user id —
`sha256(hex_decode(auth_secret))`, the one thing only chat-api can compute, since the secret never
leaves it — and returns it. `/migrate` returns the same id alongside the name it imported under.

The caller writes the grant on CrabShack itself, because that is where the decisions live:

- **which name** to grant on — chat-api's record name is not authoritative, the caller's is;
- **whether to revoke** an existing owner row first — CrabShack keys a grant on `(instance, user)`, so
  granting a second user is *additive*: two `role = 'owner'` rows coexist and its owner join then
  returns that instance **twice** in `GET /instances`;
- **whether the instance is far enough along** to own at all.

chat-api could not answer any of those, and guessing is what caused the bug.

Removed along with the write: the CrabShack POST and its error handling, and the "instance must already
point at CrabShack" guard — nothing is written now, and a repair often needs the id *before* the record
has been repointed. Net effect on the file is 93 insertions against 87 deletions.

## ⚠️ Breaking for callers that relied on this granting

The route and method are unchanged, so a caller that ignores the body will now silently stop
establishing owners — and an ownerless instance gets **no scheduled backups** and is invisible to its
user in the portal (CrabShack's watchdog and backup scheduler both filter `status = 'running'` *and*
require an owner). Our migration toolkit is updated in the same breath: it reads `owner_user_id`, then
`POST <crabshack>/instances/<name>/access`, treating an absent id as an older chat-api that granted by
itself. Any other caller needs the same two-step.

Worth deciding in review: the name `grant-owner` now describes what it no longer does. Renaming it
(e.g. `crabshack-owner-id`) would be honest but is a second breaking change, so I left the route alone.

## Risk & impact

- One admin-only endpoint plus one added response field on `/migrate`. No schema, no migration, no
  dependency change (lockfile untouched, so `cargo deny` sees nothing new).
- **Security posture change, flagged deliberately:** the response struct previously documented that it
  *intentionally* withheld this id ("chat-api does not surface credential-derived identity to API
  callers, even admins"). This PR reverses that, because the caller now needs it to grant. The id is a
  one-way hash of the passkey secret and reveals nothing about it, but the decision belongs to a
  CODEOWNER — please confirm rather than rubber-stamp.
- chat-api now makes *fewer* outbound calls: the CrabShack write is gone.

## Testing

- `cargo fmt -p api`, `cargo check -p api` clean; `cargo test -p api --lib` — **123 passing**.
- 3 unit tests on the derivation, including the one that matters: the hash is over the **decoded**
  secret, not its hex text (a wrong owner id would otherwise be silently plausible), plus whitespace
  tolerance and non-hex rejection. Vectors computed independently of the implementation.
- Behaviour verified on prod before the change: grant-owner returned `{"status":"success"}` for renamed
  instances while the CrabShack owner stayed null and the access row appeared on the legacy-named
  tenant instead (`GET /instances/<legacy>/access`).

## Rollback plan

Revert the commits — one file, no state. Callers that already moved to the two-step keep working
against the reverted build, since the old endpoint still granted (on the record name).

## Review

- [ ] Reviewed by a non-author
- [ ] Security review — returns a credential-derived identity to admin callers, reversing a documented
      decision; and the bug being fixed granted one user owner access on another user's instance.

## Deploy path

Normal chat-api pipeline. Ship the toolkit change and this together, or landings go ownerless in
between.

## Follow-ups (not in this PR)

1. **CrabShack side:** `POST /instances/<name>/access` should 404 an unknown instance — a grant on a
   name it has never seen currently returns 200, which is what made the bug silent.
2. **Ownership could move into the import.** CrabShack grants an owner at creation
   (`orchestrateCreate` → `grantAccess(db, writer, inst.name, ownerUserId, "owner")`) but
   `orchestrateImport` has no owner concept, so migrated instances are born ownerless and need this
   round trip at all. Passing `owner_user_id` into the import payload would close it.
3. **`/migrate` failure path:** when the post-import DB update fails, chat-api restarts the legacy
   instance and returns an error while the CrabShack copy keeps running under the new name, record
   never repointed — two live copies of one agent.
