### PR TITLE
chore: remove retired IronLoop network settings

### DIFF
--- a/.ironloop/config.yaml
+++ b/.ironloop/config.yaml
@@ -1,10 +1,8 @@
 version: 1
 
-implementer:
-  network_access: true
+implementer: {}
 
 reviewer:
-  network_access: true
   auto_review:
     enabled: true
     max_runs: 10
@@ -12,7 +10,6 @@ reviewer:
     user_update: false
 
 resolver:
-  network_access: true
   auto_resolve:
     enabled: true
     max_runs: 10


### PR DESCRIPTION
Removes the retired role-level `network_access` settings from `.ironloop/config.yaml`.

Runner network policy is deployment-owned; existing Review and Resolve automation settings are unchanged.

Validation: configuration-only change; checked the resulting diff.