### PR TITLE
feat(admin): proxy compose-api's instance PATCH, and let /migrate carry a supplied master key

### DIFF
--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -124,6 +124,7 @@ use utoipa::OpenApi;
         crate::routes::agents::restart_instance,
         crate::routes::agents::upgrade_instance,
         crate::routes::agents::check_upgrade_available,
+        crate::routes::admin::admin_get_instance_config,
         crate::routes::admin::admin_patch_instance_config,
         crate::routes::admin::admin_create_backup,
         crate::routes::admin::admin_list_backups,
@@ -138,6 +139,7 @@ use utoipa::OpenApi;
     ),
     components(schemas(
         // Request/Response models
+        crate::routes::admin::InstanceComposeConfig,
         crate::routes::HealthResponse,
         crate::models::UserResponse,
         crate::models::UserListResponse,

--- a/crates/api/src/openapi.rs
+++ b/crates/api/src/openapi.rs
@@ -124,6 +124,7 @@ use utoipa::OpenApi;
         crate::routes::agents::restart_instance,
         crate::routes::agents::upgrade_instance,
         crate::routes::agents::check_upgrade_available,
+        crate::routes::admin::admin_patch_instance_config,
         crate::routes::admin::admin_create_backup,
         crate::routes::admin::admin_list_backups,
         crate::routes::admin::admin_get_backup,

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3786,8 +3786,6 @@ pub struct MigrateInstanceResponse {
 const MIGRATE_MIN_ASIS_DIND_VERSION: (u64, u64, u64) = (0, 23, 0);
 const MIGRATE_FALLBACK_DIND_VERSION: &str = "0.29.1";
 
-/// True if `name` works as a CrabShack instance name: a single lowercase DNS label.
-/// It becomes the gateway hostname, so a dot would split it.
 /// ironclaw's key is 32 bytes as lowercase hex (`openssl rand -hex 32`). Checked before it
 /// reaches the imported instance's env, because a malformed one decrypts nothing and the
 /// agent gives no signal beyond failing to read its own secrets.
@@ -3800,6 +3798,8 @@ fn valid_secrets_master_key(key: &str) -> Result<String, ApiError> {
     Ok(key.to_ascii_lowercase())
 }
 
+/// True if `name` works as a CrabShack instance name: a single lowercase DNS label.
+/// It becomes the gateway hostname, so a dot would split it.
 fn is_valid_crabshack_name(name: &str) -> bool {
     !name.is_empty()
         && name.len() <= 63

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -2791,7 +2791,10 @@ pub async fn admin_patch_instance_config(
         .patch(&url)
         .bearer_auth(&manager.token)
         .json(&body)
-        .timeout(std::time::Duration::from_secs(180))
+        // The recreate on the far side pulls the image when the host does not have it, which
+        // outlasts a request timeout. A timeout here does not mean the patch was not applied —
+        // read the instance back with GET before sending it again.
+        .timeout(std::time::Duration::from_secs(600))
         .send()
         .await
         .map_err(|e| {

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -2575,6 +2575,121 @@ pub async fn admin_set_aml_report_active(
     Ok(Json(report.into()))
 }
 
+/// Admin: patch an instance's configuration on the compose-api that hosts it.
+///
+/// A thin forward to compose-api's `PATCH /instances/{name}`. Admins have no route to
+/// compose-api of their own — the manager tokens are not handed out — so repairing an
+/// instance whose recorded service_type or image drifted from what it runs has to come
+/// through here.
+///
+/// The body is passed through untouched and compose-api validates it, so a field added
+/// there works without redeploying chat-api. It rejects an image that is not a digest
+/// reference, an extra_env key it manages itself, and a service_type that contradicts the
+/// image; it recreates the container and keeps the named volumes.
+#[utoipa::path(
+    patch,
+    path = "/v1/admin/agents/instances/{id}/config",
+    tag = "Admin",
+    params(("id" = String, Path, description = "Instance ID")),
+    request_body = serde_json::Value,
+    responses(
+        (status = 200, description = "compose-api response, passed through"),
+        (status = 400, description = "Rejected by compose-api, or the instance is not on a legacy manager", body = crate::error::ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = crate::error::ApiErrorResponse),
+        (status = 404, description = "Instance not found", body = crate::error::ApiErrorResponse),
+    ),
+    security(("session_token" = []))
+)]
+pub async fn admin_patch_instance_config(
+    State(app_state): State<AppState>,
+    Extension(_user): Extension<AuthenticatedUser>,
+    Path(instance_id): Path<String>,
+    Json(body): Json<serde_json::Value>,
+) -> Result<Response, ApiError> {
+    let instance_uuid = Uuid::parse_str(&instance_id)
+        .map_err(|_| ApiError::bad_request("Invalid instance ID format"))?;
+
+    if !body.is_object() {
+        return Err(ApiError::bad_request("Body must be a JSON object"));
+    }
+
+    let instance = app_state
+        .agent_repository
+        .get_instance(instance_uuid)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "Failed to fetch instance: instance_id={}, error={}",
+                instance_uuid,
+                e
+            );
+            ApiError::internal_server_error("Failed to fetch instance")
+        })?
+        .ok_or_else(|| ApiError::not_found("Instance not found"))?;
+
+    let agent_api_base_url = instance
+        .agent_api_base_url
+        .as_deref()
+        .ok_or_else(|| ApiError::bad_request("Instance has no agent_api_base_url"))?;
+
+    let manager = app_state
+        .agent_service
+        .find_manager_for_url(agent_api_base_url)
+        .ok_or_else(|| {
+            ApiError::bad_request("No manager configured for this instance's agent_api_base_url")
+        })?;
+
+    let url = format!(
+        "{}/instances/{}",
+        manager.url.trim_end_matches('/'),
+        urlencoding::encode(&instance.name)
+    );
+
+    // The body may carry extra_env values, so it is never logged — only ids.
+    tracing::info!(
+        "Admin: patching instance config: instance_id={}, manager={}",
+        instance_uuid,
+        manager.url
+    );
+
+    let response = app_state
+        .http_client
+        .patch(&url)
+        .bearer_auth(&manager.token)
+        .json(&body)
+        .timeout(std::time::Duration::from_secs(180))
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "Failed to reach compose-api: instance_id={}, error={}",
+                instance_uuid,
+                e
+            );
+            ApiError::internal_server_error("Failed to reach compose-api")
+        })?;
+
+    let status = response.status();
+    let payload = response.bytes().await.map_err(|e| {
+        tracing::error!(
+            "Failed to read compose-api response: instance_id={}, error={}",
+            instance_uuid,
+            e
+        );
+        ApiError::internal_server_error("Failed to read compose-api response")
+    })?;
+
+    tracing::info!(
+        "Admin: patch instance config returned: instance_id={}, status={}",
+        instance_uuid,
+        status
+    );
+
+    let mut out = Response::new(axum::body::Body::from(payload));
+    *out.status_mut() = status;
+    Ok(out)
+}
+
 /// Create a backup of an agent instance
 #[utoipa::path(
     post,
@@ -5047,6 +5162,10 @@ pub fn create_admin_router() -> Router<AppState> {
                 .route("/instances/{id}/stop", post(admin_stop_instance))
                 .route("/instances/{id}/restart", post(admin_restart_instance))
                 .route("/instances/{id}/migrate", post(admin_migrate_instance))
+                .route(
+                    "/instances/{id}/config",
+                    axum::routing::patch(admin_patch_instance_config),
+                )
                 .route(
                     "/instances/{id}/grant-owner",
                     post(admin_grant_instance_owner),

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -2575,6 +2575,164 @@ pub async fn admin_set_aml_report_active(
     Ok(Json(report.into()))
 }
 
+/// The instance plus the compose-api that hosts it, for the two admin routes that forward to
+/// it. An instance's own `agent_api_base_url` picks the manager, so a forward can only ever
+/// address the compose-api that already holds that instance.
+async fn legacy_manager_for_instance(
+    app_state: &AppState,
+    instance_uuid: Uuid,
+) -> Result<(AgentInstance, config::AgentManager), ApiError> {
+    let instance = app_state
+        .agent_repository
+        .get_instance(instance_uuid)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "Failed to fetch instance: instance_id={}, error={}",
+                instance_uuid,
+                e
+            );
+            ApiError::internal_server_error("Failed to fetch instance")
+        })?
+        .ok_or_else(|| ApiError::not_found("Instance not found"))?;
+
+    let agent_api_base_url = instance
+        .agent_api_base_url
+        .as_deref()
+        .ok_or_else(|| ApiError::bad_request("Instance has no agent_api_base_url"))?;
+
+    let manager = app_state
+        .agent_service
+        .find_manager_for_url(agent_api_base_url)
+        .ok_or_else(|| {
+            ApiError::bad_request("No manager configured for this instance's agent_api_base_url")
+        })?;
+
+    Ok((instance, manager))
+}
+
+/// What compose-api holds for an instance, minus everything that authenticates it.
+///
+/// compose-api's own response carries the gateway token, the tenant's NEAR AI key and the
+/// secrets master key, and the repair needs none of them — so this reports the fields it does
+/// need instead of forwarding the body. A read cannot borrow the passthrough argument the
+/// patch below makes: there is no downstream validator, and a secret added to that response
+/// later would start flowing through here on its own.
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct InstanceComposeConfig {
+    /// The name compose-api knows it by — the legacy name, not the CrabShack one.
+    pub name: String,
+    /// compose-api's own status for the container, e.g. "running" or "stopped".
+    pub status: Option<String>,
+    /// The image the container actually runs. On a drifted instance this is the openclaw
+    /// image while chat-api's record says ironclaw; after a repair it names ironclaw.
+    pub image: Option<String>,
+    pub image_digest: Option<String>,
+    /// Whether compose-api can report a SECRETS_MASTER_KEY for this instance — the exact field
+    /// `/migrate`'s preflight reads, so it answers whether a migration will get past it without
+    /// running one.
+    ///
+    /// Absent when the running image names openclaw: compose-api does not look for an ironclaw
+    /// key then, so neither `true` nor `false` would be the truth. That is the state a drifted
+    /// instance is in, and the patch below reports what it found instead — from before its
+    /// recreate, which is the only moment the answer is still readable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub master_key_present: Option<bool>,
+}
+
+/// Admin: read what the compose-api hosting an instance holds for it.
+///
+/// The counterpart to the patch below: it reports the running image, the container status and
+/// whether a master key is readable, none of which chat-api's own record can answer. Use it to
+/// check an instance before repairing it, to confirm the repair took, and to re-read state
+/// after a patch that timed out.
+#[utoipa::path(
+    get,
+    path = "/v1/admin/agents/instances/{id}/config",
+    tag = "Admin",
+    params(("id" = String, Path, description = "Instance ID")),
+    responses(
+        (status = 200, description = "What compose-api holds for the instance", body = InstanceComposeConfig),
+        (status = 400, description = "The instance is not on a legacy manager", body = crate::error::ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = crate::error::ApiErrorResponse),
+        (status = 404, description = "Instance not found", body = crate::error::ApiErrorResponse),
+    ),
+    security(("session_token" = []))
+)]
+pub async fn admin_get_instance_config(
+    State(app_state): State<AppState>,
+    Extension(_user): Extension<AuthenticatedUser>,
+    Path(instance_id): Path<String>,
+) -> Result<Json<InstanceComposeConfig>, ApiError> {
+    let instance_uuid = Uuid::parse_str(&instance_id)
+        .map_err(|_| ApiError::bad_request("Invalid instance ID format"))?;
+    let (instance, manager) = legacy_manager_for_instance(&app_state, instance_uuid).await?;
+
+    let url = format!(
+        "{}/instances/{}",
+        manager.url.trim_end_matches('/'),
+        urlencoding::encode(&instance.name)
+    );
+
+    let response = app_state
+        .http_client
+        .get(&url)
+        .bearer_auth(&manager.token)
+        .timeout(std::time::Duration::from_secs(60))
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "Failed to reach compose-api: instance_id={}, error={}",
+                instance_uuid,
+                e
+            );
+            ApiError::internal_server_error("Failed to reach compose-api")
+        })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        tracing::error!(
+            "Admin: compose-api instance read returned: instance_id={}, status={}",
+            instance_uuid,
+            status
+        );
+        return Err(ApiError::bad_request(format!(
+            "compose-api returned {} for instance '{}'",
+            status, instance.name
+        )));
+    }
+
+    let data: serde_json::Value = response.json().await.map_err(|e| {
+        tracing::error!(
+            "Failed to parse compose-api response: instance_id={}, error={}",
+            instance_uuid,
+            e
+        );
+        ApiError::internal_server_error("Failed to parse compose-api response")
+    })?;
+
+    let string_field = |key: &str| {
+        data.get(key)
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+    };
+    let image = string_field("image");
+    let looks_for_a_key = !image.as_deref().is_some_and(|i| i.contains("openclaw"));
+    Ok(Json(InstanceComposeConfig {
+        name: instance.name,
+        status: string_field("status"),
+        image,
+        image_digest: string_field("image_digest"),
+        master_key_present: looks_for_a_key.then(|| {
+            data.get("extra_env")
+                .and_then(|v| v.get("SECRETS_MASTER_KEY"))
+                .and_then(|v| v.as_str())
+                .is_some_and(|s| !s.is_empty())
+        }),
+    }))
+}
+
 /// Admin: patch an instance's configuration on the compose-api that hosts it.
 ///
 /// A thin forward to compose-api's `PATCH /instances/{name}`. Admins have no route to
@@ -2613,31 +2771,7 @@ pub async fn admin_patch_instance_config(
         return Err(ApiError::bad_request("Body must be a JSON object"));
     }
 
-    let instance = app_state
-        .agent_repository
-        .get_instance(instance_uuid)
-        .await
-        .map_err(|e| {
-            tracing::error!(
-                "Failed to fetch instance: instance_id={}, error={}",
-                instance_uuid,
-                e
-            );
-            ApiError::internal_server_error("Failed to fetch instance")
-        })?
-        .ok_or_else(|| ApiError::not_found("Instance not found"))?;
-
-    let agent_api_base_url = instance
-        .agent_api_base_url
-        .as_deref()
-        .ok_or_else(|| ApiError::bad_request("Instance has no agent_api_base_url"))?;
-
-    let manager = app_state
-        .agent_service
-        .find_manager_for_url(agent_api_base_url)
-        .ok_or_else(|| {
-            ApiError::bad_request("No manager configured for this instance's agent_api_base_url")
-        })?;
+    let (instance, manager) = legacy_manager_for_instance(&app_state, instance_uuid).await?;
 
     let url = format!(
         "{}/instances/{}",
@@ -5164,7 +5298,7 @@ pub fn create_admin_router() -> Router<AppState> {
                 .route("/instances/{id}/migrate", post(admin_migrate_instance))
                 .route(
                     "/instances/{id}/config",
-                    axum::routing::patch(admin_patch_instance_config),
+                    get(admin_get_instance_config).patch(admin_patch_instance_config),
                 )
                 .route(
                     "/instances/{id}/grant-owner",

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3619,6 +3619,19 @@ pub struct MigrateInstanceRequest {
     /// `crabshack_name` when that is set. The legacy instance will NOT be
     /// started — stop it before taking the external backup to avoid data loss.
     pub backup_url: Option<String>,
+    /// Supply the instance's `SECRETS_MASTER_KEY` when compose-api cannot report it.
+    ///
+    /// ironclaw persists the key on the config volume and only falls back to minting a
+    /// fresh one when it finds neither the env var nor the file — at which point the
+    /// instance's stored secrets are undecryptable, silently. The preflight below exists
+    /// to stop a migration reaching that state, so this does not disable it: it satisfies
+    /// it with a key the caller has recovered another way (e.g. read out of the
+    /// pre-migration archive), and that key is passed to the imported instance.
+    ///
+    /// Needed for an instance whose legacy container no longer reports as ironclaw — a
+    /// mislabelled record, or one recreated onto the wrong image — since compose-api only
+    /// looks for the key when it believes the instance is ironclaw.
+    pub secrets_master_key: Option<String>,
     /// Override the CrabShack service_type, bypassing the config-derived
     /// ironclaw_service_type/openclaw_service_type mapping (e.g. "ironclaw-dind"
     /// to force the dind runtime regardless of the current hosting policy).
@@ -3660,6 +3673,18 @@ const MIGRATE_FALLBACK_DIND_VERSION: &str = "0.29.1";
 
 /// True if `name` works as a CrabShack instance name: a single lowercase DNS label.
 /// It becomes the gateway hostname, so a dot would split it.
+/// ironclaw's key is 32 bytes as lowercase hex (`openssl rand -hex 32`). Checked before it
+/// reaches the imported instance's env, because a malformed one decrypts nothing and the
+/// agent gives no signal beyond failing to read its own secrets.
+fn valid_secrets_master_key(key: &str) -> Result<String, ApiError> {
+    if key.len() != 64 || !key.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(ApiError::bad_request(
+            "secrets_master_key must be 64 hexadecimal characters",
+        ));
+    }
+    Ok(key.to_ascii_lowercase())
+}
+
 fn is_valid_crabshack_name(name: &str) -> bool {
     !name.is_empty()
         && name.len() <= 63
@@ -3982,11 +4007,18 @@ pub async fn admin_migrate_instance(
     // Preflight: ironclaw instances must have SECRETS_MASTER_KEY available.
     // compose-api reads it via docker exec at startup — stopped containers are
     // unreachable so the key is missing. Fail early before any side effects.
-    let has_master_key = compose_data
-        .get("extra_env")
-        .and_then(|v| v.get("SECRETS_MASTER_KEY"))
-        .and_then(|v| v.as_str())
-        .is_some_and(|s| !s.is_empty());
+    // A caller-supplied key satisfies this too; it is overlaid onto extra_env below so the
+    // imported instance starts with it rather than minting a replacement.
+    let supplied_master_key = match request.secrets_master_key.as_deref().map(str::trim) {
+        None => None,
+        Some(key) => Some(valid_secrets_master_key(key)?),
+    };
+    let has_master_key = supplied_master_key.is_some()
+        || compose_data
+            .get("extra_env")
+            .and_then(|v| v.get("SECRETS_MASTER_KEY"))
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| !s.is_empty());
     if !has_master_key && (service_type == "ironclaw" || service_type.starts_with("ironclaw-")) {
         tracing::error!(
             "Migrate: SECRETS_MASTER_KEY not found — aborting before side effects. \
@@ -4316,6 +4348,14 @@ pub async fn admin_migrate_instance(
                 extra_env_map.insert(k.clone(), v.clone());
             }
         }
+    }
+    // Overlaid after the legacy vars: when the caller supplied the key, theirs is the one
+    // that was verified against the data being imported.
+    if let Some(ref key) = supplied_master_key {
+        extra_env_map.insert(
+            "SECRETS_MASTER_KEY".into(),
+            serde_json::Value::String(key.clone()),
+        );
     }
     extra_env_map.insert(
         "LEGACY_API_BASE_URL".into(),
@@ -5111,6 +5151,43 @@ mod migrate_name_tests {
             &"a".repeat(64),
         ] {
             assert!(!is_valid_crabshack_name(n), "{n:?} should be rejected");
+        }
+    }
+}
+
+#[cfg(test)]
+mod migrate_master_key_tests {
+    use super::valid_secrets_master_key;
+
+    #[test]
+    fn accepts_a_32_byte_hex_key_in_either_case() {
+        // `openssl rand -hex 32`, which is what ironclaw's entrypoint writes.
+        let key = "a1b2c3d4e5f6".repeat(5) + "abcd";
+        assert_eq!(key.len(), 64);
+        assert_eq!(valid_secrets_master_key(&key).unwrap(), key);
+        assert_eq!(
+            valid_secrets_master_key(&key.to_ascii_uppercase()).unwrap(),
+            key,
+            "normalised to lowercase so it matches what ironclaw wrote"
+        );
+    }
+
+    #[test]
+    fn rejects_anything_that_would_decrypt_nothing() {
+        // A wrong key is not an error the agent reports — it simply fails to read its own
+        // secrets — so the shape is checked before it reaches the instance env.
+        for k in [
+            "",
+            "deadbeef",
+            &"a".repeat(63),
+            &"a".repeat(65),
+            &"z".repeat(64),
+            &format!("{} ", "a".repeat(63)),
+        ] {
+            assert!(
+                valid_secrets_master_key(k).is_err(),
+                "{k:?} should be rejected"
+            );
         }
     }
 }

--- a/crates/api/tests/admin_tests.rs
+++ b/crates/api/tests/admin_tests.rs
@@ -765,3 +765,59 @@ async fn test_admin_lifecycle_change_reason_too_long_returns_400() {
         message
     );
 }
+
+#[tokio::test]
+async fn test_admin_patch_instance_config_requires_admin() {
+    let server = create_test_server().await;
+    let user_token = mock_login(&server, "patch_config_not_admin@example.com").await;
+
+    let response = server
+        .patch(&format!(
+            "/v1/admin/agents/instances/{}/config",
+            Uuid::new_v4()
+        ))
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {user_token}")).unwrap(),
+        )
+        .json(&json!({"service_type": "ironclaw"}))
+        .await;
+
+    assert_eq!(response.status_code(), 403);
+}
+
+#[tokio::test]
+async fn test_admin_patch_instance_config_validates_before_reaching_compose_api() {
+    let server = create_test_server().await;
+    let admin_token = mock_login(&server, "patch_config_admin@admin.org").await;
+    let auth = |req: axum_test::TestRequest| {
+        req.add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {admin_token}")).unwrap(),
+        )
+    };
+
+    // Malformed id is rejected before any lookup.
+    let response = auth(server.patch("/v1/admin/agents/instances/not-a-uuid/config"))
+        .json(&json!({"service_type": "ironclaw"}))
+        .await;
+    assert_eq!(response.status_code(), 400);
+
+    // A non-object body cannot be a valid compose-api patch, so it never leaves chat-api.
+    let response = auth(server.patch(&format!(
+        "/v1/admin/agents/instances/{}/config",
+        Uuid::new_v4()
+    )))
+    .json(&json!("not-an-object"))
+    .await;
+    assert_eq!(response.status_code(), 400);
+
+    // A well-formed id for an instance that does not exist is a 404, not a forward.
+    let response = auth(server.patch(&format!(
+        "/v1/admin/agents/instances/{}/config",
+        Uuid::new_v4()
+    )))
+    .json(&json!({"service_type": "ironclaw"}))
+    .await;
+    assert_eq!(response.status_code(), 404);
+}

--- a/crates/api/tests/admin_tests.rs
+++ b/crates/api/tests/admin_tests.rs
@@ -787,6 +787,49 @@ async fn test_admin_patch_instance_config_requires_admin() {
 }
 
 #[tokio::test]
+async fn test_admin_get_instance_config_requires_admin() {
+    let server = create_test_server().await;
+    let user_token = mock_login(&server, "get_config_not_admin@example.com").await;
+
+    let response = server
+        .get(&format!(
+            "/v1/admin/agents/instances/{}/config",
+            Uuid::new_v4()
+        ))
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {user_token}")).unwrap(),
+        )
+        .await;
+
+    assert_eq!(response.status_code(), 403);
+}
+
+#[tokio::test]
+async fn test_admin_get_instance_config_validates_before_reaching_compose_api() {
+    let server = create_test_server().await;
+    let admin_token = mock_login(&server, "get_config_admin@admin.org").await;
+    let auth = |req: axum_test::TestRequest| {
+        req.add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {admin_token}")).unwrap(),
+        )
+    };
+
+    // Malformed id is rejected before any lookup.
+    let response = auth(server.get("/v1/admin/agents/instances/not-a-uuid/config")).await;
+    assert_eq!(response.status_code(), 400);
+
+    // A well-formed id for an instance that does not exist is a 404, not a forward.
+    let response = auth(server.get(&format!(
+        "/v1/admin/agents/instances/{}/config",
+        Uuid::new_v4()
+    )))
+    .await;
+    assert_eq!(response.status_code(), 404);
+}
+
+#[tokio::test]
 async fn test_admin_patch_instance_config_validates_before_reaching_compose_api() {
     let server = create_test_server().await;
     let admin_token = mock_login(&server, "patch_config_admin@admin.org").await;


### PR DESCRIPTION
Two independent commits. The first is required to repair the affected instances at all; the second is conditional and can be dropped — see below.

## Commit 1 — `PATCH /v1/admin/agents/instances/{id}/config`

Pairs with [openclaw-nearai-worker#252](https://github.com/nearai/openclaw-nearai-worker/pull/252), which adds `PATCH /instances/{name}` to compose-api for repairing an instance whose recorded `service_type` or image has drifted from what it actually runs.

Admins hold no compose-api manager token, so that route is unreachable to them. This forwards it.

```bash
curl -X PATCH "$CHATAPI/v1/admin/agents/instances/$ID/config" \
  -H "Authorization: Bearer $ADMIN_TOK" -H 'Content-Type: application/json' \
  -d '{"service_type":"ironclaw",
       "image":"nearaidev/ironclaw-nearai-worker@sha256:46c302d3…"}'
```

**The body is passed through untouched** rather than mirrored into a typed struct. compose-api already validates every field — digest-only images, its own managed env keys, a `service_type` that contradicts the image — and duplicating that here would only drift out of sync. It also means a field added on that side works without redeploying chat-api, which matters because these hosts are slow to deploy.

The instance's own `agent_api_base_url` selects the manager, so the endpoint can only ever address the compose-api that already hosts that instance — it is not a general proxy. The body may carry `extra_env` values, so it is never logged; only the instance id, the manager url and the returned status.

## Commit 2 — `secrets_master_key` on `/migrate` (conditional, droppable)

Only needed if the affected instances turn out to have lost `.ironclaw/.master_key` from their config volume. That is not yet known and one call settles it, so **drop this commit if you would rather wait for the answer.**

The problem it solves: an instance whose legacy container no longer reports as ironclaw cannot be migrated, because compose-api only looks for `SECRETS_MASTER_KEY` when it believes the instance is ironclaw, so the preflight sees no key and refuses. chat-api's record still says `ironclaw`, so there is no sequence of existing calls that gets past it.

Removing the preflight would be the wrong fix. [`ironclaw-worker/entrypoint.sh:109-119`](https://github.com/nearai/openclaw-nearai-worker/blob/main/ironclaw-worker/entrypoint.sh#L109-L119) takes the key from the env, else from `.master_key` on the config volume, else **mints a fresh one and carries on** — so a migration that lands without either leaves the user's stored secrets undecryptable with no error at all. The check exists to prevent exactly that.

So the request may carry the key instead. It satisfies the preflight and is overlaid onto `extra_env` after the legacy vars, so the imported instance starts with the key the caller verified against the data being imported. Validated as 32 bytes of hex (what the entrypoint writes) and normalised; a malformed key decrypts nothing and the agent's only symptom is failing to read its own secrets. Never logged.

## Commit 3 — `GET /v1/admin/agents/instances/{id}/config`

The counterpart to commit 1, and the reason it is here: chat-api's own record cannot say which image an instance runs, whether its container is up, or whether a master key is readable — the three facts a repair turns on. Deciding them by firing a `/migrate` and reading the error is not a probe; if it passes the preflight it migrates the instance for real.

```jsonc
{ "name": "quiet-ram", "status": "running",
  "image": "nearaidev/ironclaw-nearai-worker@sha256:46c302d3…",
  "image_digest": "sha256:…", "master_key_present": true }
```

**It reports those fields rather than forwarding compose-api's body.** Commit 1's passthrough argument does not transfer to a read: there is no downstream validator, and that response carries the gateway token, the tenant's NEAR AI key and the master key itself — a secret added to it later would start flowing through chat-api on its own. So the projection is explicit, and no secret is in it.

`master_key_present` is the exact field `/migrate`'s preflight reads, so it answers whether a migration gets past it without running one. It is **absent** when the running image names openclaw: compose-api does not look for an ironclaw key then, so neither `true` nor `false` would be the truth. That is the state a drifted instance is in, and [openclaw-nearai-worker#252](https://github.com/nearai/openclaw-nearai-worker/pull/252) reports what it found from before its recreate, which is the only moment that answer is readable.

Both forwards now share one manager lookup — also the check that a forward can only ever address the compose-api already hosting that instance.

## Commit 4 — a PATCH timeout the recreate fits in

The patch recreates the container, and a recreate pulls the image when the host does not have it, which 180s does not cover for an image that was never there — the case when a repair names a digest that host never ran. The request then fails while compose-api carries on, so the caller reads a 500 over a patch that landed. 600s, and the comment points at the GET that settles it either way.

## Risk / impact

Commits 1 and 3 are new routes; nothing existing changes. Commit 2 adds one `Option` field to an existing body — absent means today's behaviour, and no existing branch changed shape. Commit 4 only widens a timeout.

Neither can reach an instance other than the one named in the path.

## Testing

`cargo test --lib -p api` — 125 passing, 2 added for the key validator (both cases accepted and normalised; empty, short, long, non-hex and trailing-space rejected).

Integration tests added for both new routes: non-admin → 403, malformed id → 400, non-object body → 400 (PATCH), unknown instance → 404. **These need Postgres and I could not run them locally** — they run in CI's `postgres:15` service.

Not covered: the forward itself and the end-to-end migrate path, both of which need a live compose-api.

Two failures in the `database` crate (`cluster_manager::tests::*`) are **pre-existing on `main`** — verified by stashing this branch and re-running. They need a live DB and are unrelated.

## Rollback

Revert any commit independently. Nothing persists: commit 1 holds no state, and commit 2's field is read per-request — an instance already imported keeps the env it was given at import.

