### PR TITLE
fix(migrate): let the caller size the stream timeout, and accept "not found" as stopped

### DIFF
--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -4260,8 +4260,7 @@ pub async fn admin_migrate_instance(
     // only covers containers that exist — so a stopped instance reads back as "not found", never
     // "stopped". Treating that as running made `backup_url` unreachable: it demands a state the
     // manager cannot report. No container means nothing can be writing, which is what this guards.
-    let was_running =
-        compose_status != "stopped" && compose_status != "exited" && compose_status != "not found";
+    let was_running = !MIGRATE_NOT_RUNNING_STATUSES.contains(&compose_status);
 
     if has_backup_url && was_running {
         return Err(ApiError::bad_request(
@@ -4969,6 +4968,46 @@ mod crabshack_user_id_tests {
     }
 
     #[test]
+    fn stream_timeout_defaults_clamps_and_ignores_zero() {
+        use super::{
+            migrate_stream_timeout, MIGRATE_STREAM_TIMEOUT_DEFAULT_SECS,
+            MIGRATE_STREAM_TIMEOUT_MAX_SECS,
+        };
+        let default = std::time::Duration::from_secs(MIGRATE_STREAM_TIMEOUT_DEFAULT_SECS);
+        // absent, and zero, both mean "caller expressed no preference"
+        assert_eq!(migrate_stream_timeout(None), default);
+        assert_eq!(migrate_stream_timeout(Some(0)), default);
+        // an honoured value, and one clamped to the ceiling
+        assert_eq!(
+            migrate_stream_timeout(Some(2400)),
+            std::time::Duration::from_secs(2400)
+        );
+        assert_eq!(
+            migrate_stream_timeout(Some(MIGRATE_STREAM_TIMEOUT_MAX_SECS + 1)),
+            std::time::Duration::from_secs(MIGRATE_STREAM_TIMEOUT_MAX_SECS)
+        );
+    }
+
+    #[test]
+    fn only_known_quiet_statuses_count_as_not_running() {
+        use super::MIGRATE_NOT_RUNNING_STATUSES;
+        for quiet in ["stopped", "exited", "dead", "not found"] {
+            assert!(
+                MIGRATE_NOT_RUNNING_STATUSES.contains(&quiet),
+                "{quiet} should count as not running"
+            );
+        }
+        // Anything unrecognised must read as running: mistaking a live container for a stopped one
+        // lets backup_url import over data still being written.
+        for live in ["running", "restarting", "paused", "unknown", ""] {
+            assert!(
+                !MIGRATE_NOT_RUNNING_STATUSES.contains(&live),
+                "{live} must not count as not running"
+            );
+        }
+    }
+
+    #[test]
     fn refuses_a_non_hex_secret() {
         assert_eq!(crabshack_user_id("not-hex"), None);
         assert_eq!(crabshack_user_id("abc"), None); // odd length
@@ -4984,6 +5023,15 @@ const MIGRATE_STREAM_TIMEOUT_DEFAULT_SECS: u64 = 600;
 /// Ceiling for a caller-supplied `stream_timeout_secs`, so one request cannot hold a connection
 /// open indefinitely.
 const MIGRATE_STREAM_TIMEOUT_MAX_SECS: u64 = 3600;
+
+/// compose-api statuses that mean nothing can be writing to the volume.
+///
+/// Deliberately a list of known-quiet states rather than `status == "running"`: the two mistakes
+/// are not symmetric. Reading a live container as stopped lets `backup_url` import over data still
+/// being written — silent loss. Reading an odd state as running only fails the migration, which is
+/// recoverable and loud. So anything unrecognised — including the "unknown" this falls back to when
+/// compose-api reports no status at all — counts as running.
+const MIGRATE_NOT_RUNNING_STATUSES: [&str; 4] = ["stopped", "exited", "dead", "not found"];
 
 /// Resolve the per-stream timeout for one migration.
 fn migrate_stream_timeout(requested: Option<u64>) -> std::time::Duration {

--- a/crates/api/src/routes/admin.rs
+++ b/crates/api/src/routes/admin.rs
@@ -3904,6 +3904,14 @@ pub struct MigrateInstanceRequest {
     /// at import, after the legacy instance is stopped. Pass the same value on a retry —
     /// the backup's encryption key derives from it.
     pub crabshack_name: Option<String>,
+    /// Seconds to allow for each of the two SSE streams (backup, then import), replacing the
+    /// `MIGRATE_STREAM_TIMEOUT_DEFAULT_SECS` default. A migration's cost is dominated by the size
+    /// of the instance's home, which the caller knows and this endpoint does not: a 44 KB agent
+    /// and a 4.7 GB one cannot share one deadline. Too low and the stream is cut while
+    /// compose-api is still working — the backup completes anyway, the migration does not.
+    /// Clamped to `MIGRATE_STREAM_TIMEOUT_MAX_SECS` so a caller cannot hold a connection open
+    /// indefinitely.
+    pub stream_timeout_secs: Option<u64>,
 }
 
 /// Response for migrate endpoint
@@ -4222,6 +4230,7 @@ pub async fn admin_migrate_instance(
         .crabshack_ironclaw_image
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty());
+    let stream_timeout = migrate_stream_timeout(request.stream_timeout_secs);
     let provided_backup_url = request.backup_url.filter(|s| !s.is_empty());
     let has_backup_url = provided_backup_url.is_some();
     if let Some(ref url) = provided_backup_url {
@@ -4247,7 +4256,12 @@ pub async fn admin_migrate_instance(
         .and_then(|v| v.as_str())
         .unwrap_or("unknown");
 
-    let was_running = compose_status != "stopped" && compose_status != "exited";
+    // compose-api's stop runs `compose down`, which REMOVES the container, and its instance record
+    // only covers containers that exist — so a stopped instance reads back as "not found", never
+    // "stopped". Treating that as running made `backup_url` unreachable: it demands a state the
+    // manager cannot report. No container means nothing can be writing, which is what this guards.
+    let was_running =
+        compose_status != "stopped" && compose_status != "exited" && compose_status != "not found";
 
     if has_backup_url && was_running {
         return Err(ApiError::bad_request(
@@ -4461,7 +4475,7 @@ pub async fn admin_migrate_instance(
             .post(&backup_url)
             .bearer_auth(&manager.token)
             .json(&backup_body)
-            .timeout(SSE_MIGRATION_TOTAL_TIMEOUT)
+            .timeout(stream_timeout)
             .send()
             .await
             .map_err(|e| {
@@ -4674,7 +4688,7 @@ pub async fn admin_migrate_instance(
         .post(&import_url)
         .bearer_auth(&crabshack_manager.token)
         .json(&import_body)
-        .timeout(SSE_MIGRATION_TOTAL_TIMEOUT)
+        .timeout(stream_timeout)
         .send()
         .await
         .map_err(|e| {
@@ -4963,9 +4977,22 @@ mod crabshack_user_id_tests {
 
 /// Maximum buffer size for SSE parsing (1 MB).
 const SSE_BUFFER_LIMIT: usize = 1024 * 1024;
-/// Total time budget for an SSE migration stream (backup or import).
-/// Applied as reqwest's per-request .timeout() on the backup/import POST calls.
-const SSE_MIGRATION_TOTAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+/// Default time budget for an SSE migration stream (backup or import), when the caller does not
+/// pass `stream_timeout_secs`. Applied as reqwest's per-request .timeout() on the backup/import
+/// POST calls.
+const MIGRATE_STREAM_TIMEOUT_DEFAULT_SECS: u64 = 600;
+/// Ceiling for a caller-supplied `stream_timeout_secs`, so one request cannot hold a connection
+/// open indefinitely.
+const MIGRATE_STREAM_TIMEOUT_MAX_SECS: u64 = 3600;
+
+/// Resolve the per-stream timeout for one migration.
+fn migrate_stream_timeout(requested: Option<u64>) -> std::time::Duration {
+    let secs = requested
+        .filter(|s| *s > 0)
+        .unwrap_or(MIGRATE_STREAM_TIMEOUT_DEFAULT_SECS)
+        .min(MIGRATE_STREAM_TIMEOUT_MAX_SECS);
+    std::time::Duration::from_secs(secs)
+}
 /// How long to wait for a single chunk before logging a stall warning.
 /// Compose-api sends keepalives every 15s, so 30s without any data means trouble.
 const SSE_STALL_DETECT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);


### PR DESCRIPTION
Two independent walls, both hit today while migrating openclaw agents off `api.agent1`. Four instances (`eager-bird`, `firm-hawk`, `smooth-hare`, `warm-pike`) could not be migrated by any route before this.

## 1. The stream timeout is one number for every instance size

`SSE_MIGRATION_TOTAL_TIMEOUT` was a fixed 600s applied to both SSE streams. A migration's cost is dominated by the size of the home it copies — a 44 KB agent and a 4.7 GB one cannot share one deadline, and the size is known to the caller, not to this endpoint.

When the deadline fires mid-backup, the failure is misleading in a way that costs real work: **compose-api finishes the backup anyway.** `eager-bird` produced a complete 4.77 GB archive on three separate attempts, every one of which chat-api recorded as a failure. Operators then re-run the migration, taking the same expensive backup again, because nothing in the response says the archive is already sitting there.

`stream_timeout_secs` now overrides the default per request:

```jsonc
{ "service_type": "openclaw", "node_id": "baremetal07", "stream_timeout_secs": 2400 }
```

Clamped to `MIGRATE_STREAM_TIMEOUT_MAX_SECS` (1 hour) so one caller cannot hold a connection open indefinitely; `0`/absent falls back to the 600s default. **No behaviour change for existing callers.**

## 2. `backup_url` demanded a state compose-api cannot report

`backup_url` requires the legacy instance to be stopped, and tested that by comparing compose-api's reported status against `"stopped"` or `"exited"`.

But compose-api's stop runs `compose down`, which **removes** the container, and its instance record only covers containers that exist. So a stopped instance reads back as `"not found"` — never `"stopped"`. Since anything that wasn't `"stopped"`/`"exited"` counted as running, the guard rejected precisely the instances that had done what it asked.

Verified on `eager-bird`: after a stop that returned 200, compose-api reported `"not found"` on every poll for five minutes. The bypass was unreachable — you could not satisfy it by stopping, and stopping is the only thing it accepts.

`"not found"` now counts as stopped, which is what the guard is actually for: no container means nothing can be writing, so there is no window in which an externally-taken backup goes stale.

This also fixes the ordinary (non-`backup_url`) path for the same rows. `if !has_backup_url && !was_running` starts a stopped instance before backing it up; with `"not found"` reading as running, that branch was skipped and the backup was attempted against a container that did not exist.

## Correctness of the shared flag

`was_running` also feeds `restore_on_failure`, which with `action: "start"` restores only when the instance was running. A row that was already stopped therefore is not spuriously started after a failure — the narrowing is safe in both directions.

## Testing

- `cargo check -p api` clean.
- Both walls were reproduced against prod before the change: the 600s teardown on four instances (each with a completed compose-api archive to show for it), and the `"not found"` refusal on `eager-bird`.
- Not yet exercised end-to-end with the new field — that needs a deploy, and the rows it unblocks are still on legacy and serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
