### PR TITLE
fix: HoS accounting review comments

### DIFF
--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -5900,7 +5900,6 @@ async fn test_house_of_stake_purchased_reconciliation_uses_synced_credit_limit_c
         let mut state = state.lock().expect("lock HoS mock state");
         state.amount_near = yocto_near(1000);
     }
-    sync_house_of_stake_subscription(&server, &token).await;
 
     let user = db
         .user_repository()
@@ -5937,200 +5936,32 @@ async fn test_house_of_stake_purchased_reconciliation_uses_synced_credit_limit_c
         )
         .await;
     assert_eq!(response.status_code(), 200, "{}", response.text());
-    assert_eq!(
-        response.json::<serde_json::Value>()["plan_credits"].as_i64(),
-        Some(10_000_000_000),
-        "usage exactly at the stale cached limit should refresh a direct chain increase"
-    );
     let body: serde_json::Value = response.json();
     let plan_credits = body["plan_credits"].as_i64().expect("plan_credits");
     assert!(
-        plan_credits > 7_000_000_000,
-        "reconciliation should use the synced HoS entitlement before charging purchased credits, got body={body}"
+        plan_credits > 5_000_000_000,
+        "usage exactly at the stale cached limit should refresh a direct chain increase, got body={body}"
     );
 
-    let spent: i64 = client
-        .query_one(
-            "SELECT spent_nano_usd FROM user_credits WHERE user_id = $1",
-            &[&user.id],
-        )
-        .await
-        .unwrap()
-        .get("spent_nano_usd");
-    assert_eq!(
-        spent, 0,
-        "purchased credits must not be charged after HoS sync raised the entitlement above usage"
-    );
-}
-
-#[tokio::test]
-#[serial(subscription_tests)]
-async fn test_house_of_stake_purchased_reconciliation_refreshes_direct_chain_increase() {
-    clear_proxy_env_for_local_wiremock();
-    let period_end = Utc::now() + Duration::days(29);
-    let period_start = sub_one_month_same_day_for_test(period_end);
-    let state = Arc::new(Mutex::new(HouseOfStakeCreditMockState {
-        subscription_id: "sub_chain_hos_direct_reconcile_refresh".to_string(),
-        amount_near: yocto_near(500),
-        start_ns: period_start
-            .timestamp_nanos_opt()
-            .unwrap()
-            .try_into()
-            .unwrap(),
-        end_ns: period_end
-            .timestamp_nanos_opt()
-            .unwrap()
-            .try_into()
-            .unwrap(),
-        cancel_at_period_end: false,
-    }));
-
-    let mock = MockServer::start().await;
-    Mock::given(method("POST"))
-        .and(path("/"))
-        .respond_with({
-            let state = state.clone();
-            move |req: &wiremock::Request| {
-                use base64::{engine::general_purpose::STANDARD, Engine};
-
-                let body: serde_json::Value =
-                    serde_json::from_slice(&req.body).unwrap_or(json!({}));
-                let empty = json!({});
-                let params = body.get("params").unwrap_or(&empty);
-                let method_name = params
-                    .get("method_name")
-                    .and_then(|x| x.as_str())
-                    .unwrap_or("");
-                let decoded_args = params
-                    .get("args_base64")
-                    .and_then(|x| x.as_str())
-                    .and_then(|args| STANDARD.decode(args).ok())
-                    .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
-                    .unwrap_or_default();
-                let state = state.lock().expect("lock HoS mock state");
-
-                match method_name {
-                    "get_subscription_for_price" => ResponseTemplate::new(200).set_body_json(
-                        near_rpc_call_function_body(&json!({
-                            "subscription_id": state.subscription_id.clone(),
-                            "price_id": "price_hos_basic",
-                            "start_ns": state.start_ns.to_string(),
-                            "end_ns": state.end_ns.to_string(),
-                            "status": "Active",
-                            "cancel_at_period_end": state.cancel_at_period_end,
-                            "last_lock_id": "lock_chain_hos_direct_reconcile_refresh"
-                        })),
-                    ),
-                    "get_lock" => {
-                        assert_eq!(
-                            decoded_args.get("effective").and_then(|x| x.as_bool()),
-                            Some(true)
-                        );
-                        ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(
-                            &json!({
-                                "lock_id": "lock_chain_hos_direct_reconcile_refresh",
-                                "amount_near": state.amount_near.clone(),
-                                "status": "Active",
-                                "shares": "1"
-                            }),
-                        ))
-                    }
-                    _ => ResponseTemplate::new(500).set_body_json(json!({
-                        "error": "unexpected NEAR RPC mock",
-                        "method_name": method_name
-                    })),
-                }
-            }
-        })
-        .mount(&mock)
-        .await;
-
-    let (server, db) = create_test_server_and_db(TestServerConfig {
-        near_rpc_url: Some(mock.uri().to_string()),
-        near_staking_contract_id: Some("staking.testnet".to_string()),
-        ..Default::default()
-    })
-    .await;
-
-    set_subscription_plans(
-        &server,
-        json!({
-            "basic": {
-                "providers": { "house-of-stake": { "price_id": "price_hos_basic" } },
-                "agent_instances": { "max": 2 },
-                "stake_based_monthly_credits": {
-                    "credits_per_staked_near_nano_usd": 10_000_000
-                }
-            }
-        }),
-    )
-    .await;
-
-    let near_email = format!("hosdirectreconcile{}.testnet@near", Uuid::new_v4().simple());
-    let login = json!({
-        "email": near_email,
-        "name": "HoS Direct Reconcile",
-        "oauth_provider": "near"
-    });
-    let response = server.post("/v1/auth/mock-login").json(&login).await;
-    let token = response.json::<serde_json::Value>()["token"]
-        .as_str()
-        .unwrap()
-        .to_string();
-    let subscription_id = insert_house_of_stake_subscription_for_existing_user(
-        &db,
-        &near_email,
-        "price_hos_basic",
-        false,
-    )
-    .await;
-    set_house_of_stake_subscription_period_end(&db, &subscription_id, period_end).await;
     {
         let mut state = state.lock().expect("lock HoS mock state");
-        state.subscription_id = subscription_id.clone();
+        state.amount_near = yocto_near(1500);
     }
-
-    assert_eq!(get_credits_plan_limit(&server, &token).await, 5_000_000_000);
-    {
-        let mut state = state.lock().expect("lock HoS mock state");
-        state.amount_near = yocto_near(1000);
-    }
-
-    let user = db
-        .user_repository()
-        .get_user_by_email(&near_email)
-        .await
-        .unwrap()
-        .unwrap();
+    sync_house_of_stake_subscription(&server, &token).await;
     db.user_usage_repository()
         .record_usage_event(
             user.id,
             METRIC_KEY_LLM_TOKENS,
-            7_000_000_000,
-            Some(7_000_000_000),
+            2_000_000_000,
+            Some(2_000_000_000),
             None,
         )
         .await
-        .expect("record usage");
-
-    let client = db.pool().get().await.unwrap();
-    client
-        .execute(
-            "INSERT INTO user_credits (user_id, total_nano_usd, spent_nano_usd)
-             VALUES ($1, $2, 0)",
-            &[&user.id, &10_000_000_000_i64],
-        )
-        .await
-        .expect("insert purchased credits");
-
-    let response = server
-        .get("/v1/credits")
-        .add_header(
-            http::HeaderName::from_static("authorization"),
-            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
-        )
-        .await;
-    assert_eq!(response.status_code(), 200, "{}", response.text());
+        .expect("record additional usage");
+    assert!(
+        get_credits_plan_limit(&server, &token).await > 7_000_000_000,
+        "reconciliation should use the synced HoS entitlement before charging purchased credits"
+    );
 
     let spent: i64 = client
         .query_one(
@@ -6142,7 +5973,7 @@ async fn test_house_of_stake_purchased_reconciliation_refreshes_direct_chain_inc
         .get("spent_nano_usd");
     assert_eq!(
         spent, 0,
-        "purchased credits must not be charged from a stale cached HoS entitlement"
+        "purchased credits must not be charged after direct or synced stake increases"
     );
 }
 

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -5938,9 +5938,9 @@ async fn test_house_of_stake_purchased_reconciliation_uses_synced_credit_limit_c
     assert_eq!(response.status_code(), 200, "{}", response.text());
     let body: serde_json::Value = response.json();
     let plan_credits = body["plan_credits"].as_i64().expect("plan_credits");
-    assert!(
-        plan_credits > 5_000_000_000,
-        "usage exactly at the stale cached limit should refresh a direct chain increase, got body={body}"
+    assert_eq!(
+        plan_credits, 5_000_000_000,
+        "over-plan reconciliation should not bypass the HoS credit-limit cache, got body={body}"
     );
 
     {

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -5912,8 +5912,8 @@ async fn test_house_of_stake_purchased_reconciliation_uses_synced_credit_limit_c
         .record_usage_event(
             user.id,
             METRIC_KEY_LLM_TOKENS,
-            7_000_000_000,
-            Some(7_000_000_000),
+            5_000_000_000,
+            Some(5_000_000_000),
             None,
         )
         .await
@@ -5937,6 +5937,11 @@ async fn test_house_of_stake_purchased_reconciliation_uses_synced_credit_limit_c
         )
         .await;
     assert_eq!(response.status_code(), 200, "{}", response.text());
+    assert_eq!(
+        response.json::<serde_json::Value>()["plan_credits"].as_i64(),
+        Some(10_000_000_000),
+        "usage exactly at the stale cached limit should refresh a direct chain increase"
+    );
     let body: serde_json::Value = response.json();
     let plan_credits = body["plan_credits"].as_i64().expect("plan_credits");
     assert!(

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -4354,6 +4354,23 @@ async fn test_house_of_stake_confirmed_zero_reconciliation_ignores_snapshot_floo
         spent, 1_000_000_000,
         "confirmed chain zero should charge purchased credits from zero entitlement"
     );
+
+    let last_observed_stake: String = client
+        .query_one(
+            "SELECT last_observed_stake_yocto
+             FROM house_of_stake_credit_entitlement_snapshots
+             WHERE subscription_id = $1
+               AND period_start = $2
+               AND period_end = $3",
+            &[&subscription_id, &period_start, &period_end],
+        )
+        .await
+        .unwrap()
+        .get("last_observed_stake_yocto");
+    assert_eq!(
+        last_observed_stake, "0",
+        "confirmed zero should reset the carried last observed stake baseline"
+    );
 }
 
 struct HouseOfStakeCreditMockState {
@@ -5935,6 +5952,330 @@ async fn test_house_of_stake_purchased_reconciliation_uses_synced_credit_limit_c
     assert_eq!(
         spent, 0,
         "purchased credits must not be charged after HoS sync raised the entitlement above usage"
+    );
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn test_house_of_stake_purchased_reconciliation_refreshes_direct_chain_increase() {
+    clear_proxy_env_for_local_wiremock();
+    let period_end = Utc::now() + Duration::days(29);
+    let period_start = sub_one_month_same_day_for_test(period_end);
+    let state = Arc::new(Mutex::new(HouseOfStakeCreditMockState {
+        subscription_id: "sub_chain_hos_direct_reconcile_refresh".to_string(),
+        amount_near: yocto_near(500),
+        start_ns: period_start
+            .timestamp_nanos_opt()
+            .unwrap()
+            .try_into()
+            .unwrap(),
+        end_ns: period_end
+            .timestamp_nanos_opt()
+            .unwrap()
+            .try_into()
+            .unwrap(),
+        cancel_at_period_end: false,
+    }));
+
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with({
+            let state = state.clone();
+            move |req: &wiremock::Request| {
+                use base64::{engine::general_purpose::STANDARD, Engine};
+
+                let body: serde_json::Value =
+                    serde_json::from_slice(&req.body).unwrap_or(json!({}));
+                let empty = json!({});
+                let params = body.get("params").unwrap_or(&empty);
+                let method_name = params
+                    .get("method_name")
+                    .and_then(|x| x.as_str())
+                    .unwrap_or("");
+                let decoded_args = params
+                    .get("args_base64")
+                    .and_then(|x| x.as_str())
+                    .and_then(|args| STANDARD.decode(args).ok())
+                    .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+                    .unwrap_or_default();
+                let state = state.lock().expect("lock HoS mock state");
+
+                match method_name {
+                    "get_subscription_for_price" => ResponseTemplate::new(200).set_body_json(
+                        near_rpc_call_function_body(&json!({
+                            "subscription_id": state.subscription_id.clone(),
+                            "price_id": "price_hos_basic",
+                            "start_ns": state.start_ns.to_string(),
+                            "end_ns": state.end_ns.to_string(),
+                            "status": "Active",
+                            "cancel_at_period_end": state.cancel_at_period_end,
+                            "last_lock_id": "lock_chain_hos_direct_reconcile_refresh"
+                        })),
+                    ),
+                    "get_lock" => {
+                        assert_eq!(
+                            decoded_args.get("effective").and_then(|x| x.as_bool()),
+                            Some(true)
+                        );
+                        ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(
+                            &json!({
+                                "lock_id": "lock_chain_hos_direct_reconcile_refresh",
+                                "amount_near": state.amount_near.clone(),
+                                "status": "Active",
+                                "shares": "1"
+                            }),
+                        ))
+                    }
+                    _ => ResponseTemplate::new(500).set_body_json(json!({
+                        "error": "unexpected NEAR RPC mock",
+                        "method_name": method_name
+                    })),
+                }
+            }
+        })
+        .mount(&mock)
+        .await;
+
+    let (server, db) = create_test_server_and_db(TestServerConfig {
+        near_rpc_url: Some(mock.uri().to_string()),
+        near_staking_contract_id: Some("staking.testnet".to_string()),
+        ..Default::default()
+    })
+    .await;
+
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": {
+                "providers": { "house-of-stake": { "price_id": "price_hos_basic" } },
+                "agent_instances": { "max": 2 },
+                "stake_based_monthly_credits": {
+                    "credits_per_staked_near_nano_usd": 10_000_000
+                }
+            }
+        }),
+    )
+    .await;
+
+    let near_email = format!("hosdirectreconcile{}.testnet@near", Uuid::new_v4().simple());
+    let login = json!({
+        "email": near_email,
+        "name": "HoS Direct Reconcile",
+        "oauth_provider": "near"
+    });
+    let response = server.post("/v1/auth/mock-login").json(&login).await;
+    let token = response.json::<serde_json::Value>()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let subscription_id = insert_house_of_stake_subscription_for_existing_user(
+        &db,
+        &near_email,
+        "price_hos_basic",
+        false,
+    )
+    .await;
+    set_house_of_stake_subscription_period_end(&db, &subscription_id, period_end).await;
+    {
+        let mut state = state.lock().expect("lock HoS mock state");
+        state.subscription_id = subscription_id.clone();
+    }
+
+    assert_eq!(get_credits_plan_limit(&server, &token).await, 5_000_000_000);
+    {
+        let mut state = state.lock().expect("lock HoS mock state");
+        state.amount_near = yocto_near(1000);
+    }
+
+    let user = db
+        .user_repository()
+        .get_user_by_email(&near_email)
+        .await
+        .unwrap()
+        .unwrap();
+    db.user_usage_repository()
+        .record_usage_event(
+            user.id,
+            METRIC_KEY_LLM_TOKENS,
+            7_000_000_000,
+            Some(7_000_000_000),
+            None,
+        )
+        .await
+        .expect("record usage");
+
+    let client = db.pool().get().await.unwrap();
+    client
+        .execute(
+            "INSERT INTO user_credits (user_id, total_nano_usd, spent_nano_usd)
+             VALUES ($1, $2, 0)",
+            &[&user.id, &10_000_000_000_i64],
+        )
+        .await
+        .expect("insert purchased credits");
+
+    let response = server
+        .get("/v1/credits")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+
+    let spent: i64 = client
+        .query_one(
+            "SELECT spent_nano_usd FROM user_credits WHERE user_id = $1",
+            &[&user.id],
+        )
+        .await
+        .unwrap()
+        .get("spent_nano_usd");
+    assert_eq!(
+        spent, 0,
+        "purchased credits must not be charged from a stale cached HoS entitlement"
+    );
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn test_house_of_stake_fixed_to_variable_sync_prorates_above_fixed_entitlement() {
+    clear_proxy_env_for_local_wiremock();
+    let now = Utc::now();
+    let period_start = now - Duration::days(15);
+    let period_end = now + Duration::days(15);
+    let state = Arc::new(Mutex::new(HouseOfStakeCreditMockState {
+        subscription_id: "sub_chain_hos_fixed_to_variable".to_string(),
+        amount_near: yocto_near(1500),
+        start_ns: period_start
+            .timestamp_nanos_opt()
+            .unwrap()
+            .try_into()
+            .unwrap(),
+        end_ns: period_end
+            .timestamp_nanos_opt()
+            .unwrap()
+            .try_into()
+            .unwrap(),
+        cancel_at_period_end: false,
+    }));
+
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with({
+            let state = state.clone();
+            move |req: &wiremock::Request| {
+                use base64::{engine::general_purpose::STANDARD, Engine};
+
+                let body: serde_json::Value =
+                    serde_json::from_slice(&req.body).unwrap_or(json!({}));
+                let empty = json!({});
+                let params = body.get("params").unwrap_or(&empty);
+                let method_name = params
+                    .get("method_name")
+                    .and_then(|x| x.as_str())
+                    .unwrap_or("");
+                let decoded_args = params
+                    .get("args_base64")
+                    .and_then(|x| x.as_str())
+                    .and_then(|args| STANDARD.decode(args).ok())
+                    .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+                    .unwrap_or_default();
+                let state = state.lock().expect("lock HoS mock state");
+
+                match method_name {
+                    "get_subscription_for_price" => ResponseTemplate::new(200).set_body_json(
+                        near_rpc_call_function_body(&json!({
+                            "subscription_id": state.subscription_id.clone(),
+                            "price_id": "price_hos_basic",
+                            "start_ns": state.start_ns.to_string(),
+                            "end_ns": state.end_ns.to_string(),
+                            "status": "Active",
+                            "cancel_at_period_end": state.cancel_at_period_end,
+                            "last_lock_id": "lock_chain_hos_fixed_to_variable"
+                        })),
+                    ),
+                    "get_lock" => {
+                        assert_eq!(
+                            decoded_args.get("effective").and_then(|x| x.as_bool()),
+                            Some(true)
+                        );
+                        ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(
+                            &json!({
+                                "lock_id": "lock_chain_hos_fixed_to_variable",
+                                "amount_near": state.amount_near.clone(),
+                                "status": "Active",
+                                "shares": "1"
+                            }),
+                        ))
+                    }
+                    _ => ResponseTemplate::new(500).set_body_json(json!({
+                        "error": "unexpected NEAR RPC mock",
+                        "method_name": method_name
+                    })),
+                }
+            }
+        })
+        .mount(&mock)
+        .await;
+
+    let (server, db) = create_test_server_and_db(TestServerConfig {
+        near_rpc_url: Some(mock.uri().to_string()),
+        near_staking_contract_id: Some("staking.testnet".to_string()),
+        ..Default::default()
+    })
+    .await;
+
+    set_subscription_plans(
+        &server,
+        json!({
+            "starter": {
+                "providers": { "house-of-stake": { "price_id": "price_hos_starter" } },
+                "agent_instances": { "max": 1 },
+                "monthly_credits": { "max": 5_000_000_000_i64 }
+            },
+            "basic": {
+                "providers": { "house-of-stake": { "price_id": "price_hos_basic" } },
+                "agent_instances": { "max": 2 },
+                "stake_based_monthly_credits": {
+                    "credits_per_staked_near_nano_usd": 10_000_000
+                }
+            }
+        }),
+    )
+    .await;
+
+    let near_email = format!("hosfixedvariable{}.testnet@near", Uuid::new_v4().simple());
+    let login = json!({
+        "email": near_email,
+        "name": "HoS Fixed To Variable",
+        "oauth_provider": "near"
+    });
+    let response = server.post("/v1/auth/mock-login").json(&login).await;
+    let token = response.json::<serde_json::Value>()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let subscription_id = insert_house_of_stake_subscription_for_existing_user(
+        &db,
+        &near_email,
+        "price_hos_starter",
+        false,
+    )
+    .await;
+    set_house_of_stake_subscription_period_end(&db, &subscription_id, period_end).await;
+    {
+        let mut state = state.lock().expect("lock HoS mock state");
+        state.subscription_id = subscription_id.clone();
+    }
+
+    sync_house_of_stake_subscription(&server, &token).await;
+    let limit = get_credits_plan_limit(&server, &token).await;
+    assert!(
+        (9_900_000_000..=10_100_000_000).contains(&limit),
+        "fixed-to-variable sync should keep the fixed 5-credit baseline and prorate only the increase to 15, got {limit}"
     );
 }
 

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -26,7 +26,10 @@ use services::system_configs::ports::RateLimitConfig;
 use services::user::ports::UserRepository;
 use services::user_usage::{UserUsageRepository, METRIC_KEY_LLM_TOKENS};
 use services::UserId;
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
 use uuid::Uuid;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -6160,12 +6163,14 @@ async fn test_house_of_stake_fixed_to_variable_sync_prorates_above_fixed_entitle
             .unwrap(),
         cancel_at_period_end: false,
     }));
+    let lock_available = Arc::new(AtomicBool::new(false));
 
     let mock = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/"))
         .respond_with({
             let state = state.clone();
+            let lock_available = lock_available.clone();
             move |req: &wiremock::Request| {
                 use base64::{engine::general_purpose::STANDARD, Engine};
 
@@ -6202,14 +6207,17 @@ async fn test_house_of_stake_fixed_to_variable_sync_prorates_above_fixed_entitle
                             decoded_args.get("effective").and_then(|x| x.as_bool()),
                             Some(true)
                         );
-                        ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(
-                            &json!({
+                        let lock = if lock_available.load(Ordering::SeqCst) {
+                            json!({
                                 "lock_id": "lock_chain_hos_fixed_to_variable",
                                 "amount_near": state.amount_near.clone(),
                                 "status": "Active",
                                 "shares": "1"
-                            }),
-                        ))
+                            })
+                        } else {
+                            serde_json::Value::Null
+                        };
+                        ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(&lock))
                     }
                     _ => ResponseTemplate::new(500).set_body_json(json!({
                         "error": "unexpected NEAR RPC mock",
@@ -6271,6 +6279,51 @@ async fn test_house_of_stake_fixed_to_variable_sync_prorates_above_fixed_entitle
         state.subscription_id = subscription_id.clone();
     }
 
+    let user = db
+        .user_repository()
+        .get_user_by_email(&near_email)
+        .await
+        .unwrap()
+        .unwrap();
+    let client = db.pool().get().await.unwrap();
+    client
+        .execute(
+            "INSERT INTO house_of_stake_credit_entitlement_snapshots (
+                 user_id, subscription_id, period_start, period_end,
+                 credited_stake_yocto, last_observed_stake_yocto, credit_limit_nano_usd
+             ) VALUES ($1, $2, $3, $4, '0', '0', 0)",
+            &[
+                &user.id,
+                &subscription_id,
+                &(period_start - Duration::days(30)),
+                &period_start,
+            ],
+        )
+        .await
+        .expect("insert prior zero-stake snapshot");
+
+    let failed_sync = server
+        .post("/v1/subscriptions/near/sync")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+    assert_ne!(failed_sync.status_code(), 200, "{}", failed_sync.text());
+    let retained_price_id: String = client
+        .query_one(
+            "SELECT price_id FROM subscriptions WHERE subscription_id = $1",
+            &[&subscription_id],
+        )
+        .await
+        .unwrap()
+        .get("price_id");
+    assert_eq!(
+        retained_price_id, "price_hos_starter",
+        "failed seeding must preserve the fixed row so a later sync can retry the transition"
+    );
+
+    lock_available.store(true, Ordering::SeqCst);
     sync_house_of_stake_subscription(&server, &token).await;
     let limit = get_credits_plan_limit(&server, &token).await;
     assert!(

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1395,6 +1395,7 @@ impl SubscriptionServiceImpl {
             .unwrap_or((fallback_period_start, fallback_period_end))
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn reconcile_house_of_stake_credit_entitlement_snapshot(
         &self,
         user_id: UserId,

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1296,6 +1296,17 @@ impl SubscriptionServiceImpl {
         )
     }
 
+    fn first_snapshot_credited_stake(
+        plan_config: &SubscriptionPlanConfig,
+        observed_baseline_stake: u128,
+        first_snapshot_credit_floor_nano_usd: Option<u64>,
+    ) -> u128 {
+        let fixed_floor_stake = first_snapshot_credit_floor_nano_usd
+            .and_then(|floor| Self::stake_for_credit_floor(plan_config, floor))
+            .unwrap_or(0);
+        observed_baseline_stake.max(fixed_floor_stake)
+    }
+
     fn fixed_to_stake_based_credit_floor(
         local_subscriptions: &[Subscription],
         chain_subscription: &Subscription,
@@ -1485,11 +1496,11 @@ impl SubscriptionServiceImpl {
                     Some(stake) => stake.min(effective_stake_yocto),
                     None => effective_stake_yocto,
                 };
-                let fixed_floor_stake = first_snapshot_credit_floor_nano_usd
-                    .and_then(|floor| Self::stake_for_credit_floor(plan_config, floor))
-                    .unwrap_or(0)
-                    .min(effective_stake_yocto);
-                let baseline_stake = observed_baseline_stake.max(fixed_floor_stake);
+                let baseline_stake = Self::first_snapshot_credited_stake(
+                    plan_config,
+                    observed_baseline_stake,
+                    first_snapshot_credit_floor_nano_usd,
+                );
                 let stake_based_baseline_limit =
                     Self::stake_based_credits_for_lock(plan_config, baseline_stake).unwrap_or(0);
                 let baseline_limit = match first_snapshot_credit_floor_nano_usd {
@@ -3160,7 +3171,7 @@ impl SubscriptionServiceImpl {
             .map_err(|e| SubscriptionError::InternalError(e.to_string()))?
             .map(|usage| usage.cost_nano_usd)
             .unwrap_or(0);
-        if period_spent_credits <= cached_plan_credits {
+        if period_spent_credits < cached_plan_credits {
             return Ok(None);
         }
         self.fresh_purchased_reconciliation_plan_period(user_id)
@@ -5368,7 +5379,7 @@ impl SubscriptionService for SubscriptionServiceImpl {
             .map(|s| s.cost_nano_usd)
             .unwrap_or(0);
 
-        if period_spent_credits > plan_credits {
+        if period_spent_credits >= plan_credits {
             match self
                 .fresh_purchased_reconciliation_plan_period(user_id)
                 .await
@@ -5630,6 +5641,24 @@ mod tests {
         assert!(
             SubscriptionServiceImpl::stake_based_credits_for_lock(&config, stake).unwrap()
                 >= 5_000_000_001
+        );
+    }
+
+    #[test]
+    fn test_fixed_floor_credited_stake_can_exceed_observed_stake() {
+        let mut config = hos_plan_config("hos_basic");
+        config.stake_based_monthly_credits = Some(StakeBasedMonthlyCreditsConfig {
+            credits_per_staked_near_nano_usd: Some(1_000_000_000),
+        });
+
+        assert_eq!(
+            SubscriptionServiceImpl::first_snapshot_credited_stake(
+                &config,
+                5 * YOCTO_PER_NEAR,
+                Some(10_000_000_000),
+            ),
+            10 * YOCTO_PER_NEAR,
+            "the retained fixed floor must suppress increases until actual stake crosses it"
         );
     }
 

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -1312,16 +1312,6 @@ impl SubscriptionServiceImpl {
         chain_subscription: &Subscription,
         subscription_plans: &HashMap<String, SubscriptionPlanConfig>,
     ) -> Option<u64> {
-        let target_plan_name = resolve_plan_name_from_config(
-            chain_subscription.provider.as_str(),
-            &chain_subscription.price_id,
-            subscription_plans,
-        )?;
-        let target_plan = subscription_plans.get(&target_plan_name)?;
-        if !Self::has_stake_based_monthly_credits(target_plan) {
-            return None;
-        }
-
         local_subscriptions
             .iter()
             .find(|sub| {
@@ -1677,20 +1667,15 @@ impl SubscriptionServiceImpl {
         plan_config: &SubscriptionPlanConfig,
         fixed_credit_floor_nano_usd: u64,
     ) -> Result<(), SubscriptionError> {
-        let Some(last_lock_id) = chain_subscription
+        let last_lock_id = chain_subscription
             .last_lock_id
             .as_deref()
             .filter(|s| !s.trim().is_empty())
-        else {
-            tracing::warn!(
-                user_id = %user_id.0,
-                subscription_id = %local_subscription.subscription_id,
-                "cannot seed fixed-to-stake HoS snapshot: last lock id missing"
-            );
-            return Err(SubscriptionError::InternalError(
-                "cannot seed fixed-to-stake HoS snapshot: last lock id missing".to_string(),
-            ));
-        };
+            .ok_or_else(|| {
+                SubscriptionError::InternalError(
+                    "cannot seed fixed-to-stake HoS snapshot: last lock id missing".to_string(),
+                )
+            })?;
 
         let fallback_period_end = local_subscription.current_period_end;
         let fallback_period_start = sub_one_month_same_day(fallback_period_end);
@@ -1700,20 +1685,14 @@ impl SubscriptionServiceImpl {
             fallback_period_end,
             Utc::now(),
         );
-        let Some(lock) = view_get_effective_lock(&self.near_rpc_url, contract_id, last_lock_id)
+        let lock = view_get_effective_lock(&self.near_rpc_url, contract_id, last_lock_id)
             .await
             .map_err(Self::near_rpc_err)?
-        else {
-            tracing::warn!(
-                user_id = %user_id.0,
-                subscription_id = %local_subscription.subscription_id,
-                last_lock_id,
-                "cannot seed fixed-to-stake HoS snapshot: lock missing"
-            );
-            return Err(SubscriptionError::InternalError(
-                "cannot seed fixed-to-stake HoS snapshot: lock missing".to_string(),
-            ));
-        };
+            .ok_or_else(|| {
+                SubscriptionError::InternalError(
+                    "cannot seed fixed-to-stake HoS snapshot: lock missing".to_string(),
+                )
+            })?;
         if !lock_has_active_shares(&lock) {
             self.reconcile_house_of_stake_credit_entitlement_snapshot(
                 user_id,
@@ -1727,17 +1706,12 @@ impl SubscriptionServiceImpl {
             .await?;
             return Ok(());
         }
-        let Some(lock_amount) = lock_amount_yocto(&lock) else {
-            tracing::warn!(
-                user_id = %user_id.0,
-                subscription_id = %local_subscription.subscription_id,
-                "cannot seed fixed-to-stake HoS snapshot: lock amount missing or invalid"
-            );
-            return Err(SubscriptionError::InternalError(
+        let lock_amount = lock_amount_yocto(&lock).ok_or_else(|| {
+            SubscriptionError::InternalError(
                 "cannot seed fixed-to-stake HoS snapshot: lock amount missing or invalid"
                     .to_string(),
-            ));
-        };
+            )
+        })?;
 
         self.reconcile_house_of_stake_credit_entitlement_snapshot(
             user_id,

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -105,10 +105,6 @@ enum HouseOfStakeEntitlementSource {
 }
 
 impl HouseOfStakeEntitlementSource {
-    fn is_transient_snapshot_fallback(self) -> bool {
-        self == Self::TransientSnapshotFallback
-    }
-
     fn is_transient_plan_fallback(self) -> bool {
         self == Self::TransientPlanFallback
     }
@@ -1281,6 +1277,25 @@ impl SubscriptionServiceImpl {
             .is_some()
     }
 
+    fn stake_for_credit_floor(
+        plan_config: &SubscriptionPlanConfig,
+        credit_floor_nano_usd: u64,
+    ) -> Option<u128> {
+        let rate = plan_config
+            .stake_based_monthly_credits
+            .as_ref()
+            .and_then(|c| c.credits_per_staked_near_nano_usd)?;
+        if rate == 0 {
+            return None;
+        }
+        Some(
+            (credit_floor_nano_usd as u128)
+                .saturating_mul(YOCTO_PER_NEAR)
+                .saturating_add(rate as u128 - 1)
+                / rate as u128,
+        )
+    }
+
     fn fixed_to_stake_based_credit_floor(
         local_subscriptions: &[Subscription],
         chain_subscription: &Subscription,
@@ -1302,6 +1317,7 @@ impl SubscriptionServiceImpl {
                 sub.provider == "house-of-stake"
                     && sub.subscription_id == chain_subscription.subscription_id
                     && sub.price_id != chain_subscription.price_id
+                    && sub.current_period_end == chain_subscription.current_period_end
                     && Self::is_active_or_trialing(&sub.status)
             })
             .and_then(|sub| {
@@ -1457,7 +1473,7 @@ impl SubscriptionServiceImpl {
                     ),
                     None => None,
                 };
-                let baseline_stake = match previous_last_observed_stake {
+                let observed_baseline_stake = match previous_last_observed_stake {
                     Some(_)
                         if Self::is_house_of_stake_period_start_baseline_observation(
                             period_start,
@@ -1469,6 +1485,11 @@ impl SubscriptionServiceImpl {
                     Some(stake) => stake.min(effective_stake_yocto),
                     None => effective_stake_yocto,
                 };
+                let fixed_floor_stake = first_snapshot_credit_floor_nano_usd
+                    .and_then(|floor| Self::stake_for_credit_floor(plan_config, floor))
+                    .unwrap_or(0)
+                    .min(effective_stake_yocto);
+                let baseline_stake = observed_baseline_stake.max(fixed_floor_stake);
                 let stake_based_baseline_limit =
                     Self::stake_based_credits_for_lock(plan_config, baseline_stake).unwrap_or(0);
                 let baseline_limit = match first_snapshot_credit_floor_nano_usd {
@@ -1655,7 +1676,9 @@ impl SubscriptionServiceImpl {
                 subscription_id = %local_subscription.subscription_id,
                 "cannot seed fixed-to-stake HoS snapshot: last lock id missing"
             );
-            return Ok(());
+            return Err(SubscriptionError::InternalError(
+                "cannot seed fixed-to-stake HoS snapshot: last lock id missing".to_string(),
+            ));
         };
 
         let fallback_period_end = local_subscription.current_period_end;
@@ -1676,7 +1699,9 @@ impl SubscriptionServiceImpl {
                 last_lock_id,
                 "cannot seed fixed-to-stake HoS snapshot: lock missing"
             );
-            return Ok(());
+            return Err(SubscriptionError::InternalError(
+                "cannot seed fixed-to-stake HoS snapshot: lock missing".to_string(),
+            ));
         };
         if !lock_has_active_shares(&lock) {
             self.reconcile_house_of_stake_credit_entitlement_snapshot(
@@ -1697,7 +1722,10 @@ impl SubscriptionServiceImpl {
                 subscription_id = %local_subscription.subscription_id,
                 "cannot seed fixed-to-stake HoS snapshot: lock amount missing or invalid"
             );
-            return Ok(());
+            return Err(SubscriptionError::InternalError(
+                "cannot seed fixed-to-stake HoS snapshot: lock amount missing or invalid"
+                    .to_string(),
+            ));
         };
 
         self.reconcile_house_of_stake_credit_entitlement_snapshot(
@@ -2711,6 +2739,20 @@ impl SubscriptionServiceImpl {
             ));
         }
 
+        if let Some((seed_subscription, seed_plan_config, fixed_credit_floor)) =
+            fixed_to_stake_based_seed.as_ref()
+        {
+            self.seed_fixed_to_stake_based_house_of_stake_snapshot(
+                user_id,
+                &contract_id,
+                chain_subscription,
+                seed_subscription,
+                seed_plan_config,
+                *fixed_credit_floor,
+            )
+            .await?;
+        }
+
         let mut db_client = self
             .db_pool
             .get()
@@ -2753,29 +2795,6 @@ impl SubscriptionServiceImpl {
             .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
 
         self.invalidate_credit_limit_cache(user_id).await;
-        if let Some((seed_subscription, seed_plan_config, fixed_credit_floor)) =
-            fixed_to_stake_based_seed
-        {
-            if let Err(err) = self
-                .seed_fixed_to_stake_based_house_of_stake_snapshot(
-                    user_id,
-                    &contract_id,
-                    chain_subscription,
-                    &seed_subscription,
-                    &seed_plan_config,
-                    fixed_credit_floor,
-                )
-                .await
-            {
-                tracing::warn!(
-                    user_id = %user_id.0,
-                    subscription_id = %seed_subscription.subscription_id,
-                    error = %err,
-                    "fixed-to-stake HoS entitlement snapshot seeding failed"
-                );
-            }
-            self.invalidate_credit_limit_cache(user_id).await;
-        }
         Ok(Self::hos_reconcile_summary(false, 0, canceled, true, None))
     }
 }
@@ -3041,11 +3060,16 @@ impl SubscriptionServiceImpl {
         let period_start = resolved.period_start;
         let period_end = resolved.period_end;
 
-        if !resolved
-            .house_of_stake_source
-            .is_some_and(HouseOfStakeEntitlementSource::is_transient_snapshot_fallback)
-        {
-            return Ok(Some((plan_credits, period_start, period_end)));
+        match resolved.house_of_stake_source {
+            Some(HouseOfStakeEntitlementSource::TransientPlanFallback) => {
+                tracing::warn!(
+                    user_id = %user_id.0,
+                    "skipping purchased credit reconciliation: HoS entitlement has no authoritative snapshot"
+                );
+                return Ok(None);
+            }
+            Some(HouseOfStakeEntitlementSource::TransientSnapshotFallback) => {}
+            _ => return Ok(Some((plan_credits, period_start, period_end))),
         }
 
         let active_subscription = match self.get_active_subscription_for_entitlement(user_id).await
@@ -3118,6 +3142,28 @@ impl SubscriptionServiceImpl {
             .refresh_plan_period_for_user_with_source(user_id)
             .await?;
         self.purchased_reconciliation_plan_period(user_id, &resolved)
+            .await
+    }
+
+    async fn purchased_reconciliation_plan_period_after_usage(
+        &self,
+        user_id: UserId,
+    ) -> Result<Option<(i64, DateTime<Utc>, DateTime<Utc>)>, SubscriptionError> {
+        let cached = self
+            .resolve_plan_period_for_user_with_source(user_id)
+            .await?;
+        let cached_plan_credits = cached.plan_credits.min(i64::MAX as u64) as i64;
+        let period_spent_credits = self
+            .user_usage_repo
+            .get_usage_by_user_id(user_id, Some(cached.period_start), Some(cached.period_end))
+            .await
+            .map_err(|e| SubscriptionError::InternalError(e.to_string()))?
+            .map(|usage| usage.cost_nano_usd)
+            .unwrap_or(0);
+        if period_spent_credits <= cached_plan_credits {
+            return Ok(None);
+        }
+        self.fresh_purchased_reconciliation_plan_period(user_id)
             .await
     }
 }
@@ -5294,7 +5340,7 @@ impl SubscriptionService for SubscriptionServiceImpl {
         user_id: UserId,
     ) -> Result<(), SubscriptionError> {
         let Some((plan_credits, period_start, period_end)) = self
-            .fresh_purchased_reconciliation_plan_period(user_id)
+            .purchased_reconciliation_plan_period_after_usage(user_id)
             .await?
         else {
             return Ok(());
@@ -5322,7 +5368,7 @@ impl SubscriptionService for SubscriptionServiceImpl {
             .map(|s| s.cost_nano_usd)
             .unwrap_or(0);
 
-        if period_spent_credits > 0 {
+        if period_spent_credits > plan_credits {
             match self
                 .fresh_purchased_reconciliation_plan_period(user_id)
                 .await
@@ -5568,6 +5614,63 @@ mod tests {
         assert_eq!(
             SubscriptionServiceImpl::stake_based_credits_for_lock(&config, u128::MAX),
             Some((u128::MAX / YOCTO_PER_NEAR) as u64)
+        );
+    }
+
+    #[test]
+    fn test_stake_for_credit_floor_rounds_up_to_cover_floor() {
+        let mut config = hos_plan_config("hos_basic");
+        config.stake_based_monthly_credits = Some(StakeBasedMonthlyCreditsConfig {
+            credits_per_staked_near_nano_usd: Some(500_000_000),
+        });
+
+        let stake = SubscriptionServiceImpl::stake_for_credit_floor(&config, 5_000_000_001)
+            .expect("stake-based plan");
+        assert!(stake > 10 * YOCTO_PER_NEAR && stake < 11 * YOCTO_PER_NEAR);
+        assert!(
+            SubscriptionServiceImpl::stake_based_credits_for_lock(&config, stake).unwrap()
+                >= 5_000_000_001
+        );
+    }
+
+    #[test]
+    fn test_fixed_to_stake_based_floor_requires_same_period() {
+        let period_end = Utc::now() + Duration::days(7);
+        let mut fixed = base_subscription();
+        fixed.provider = "house-of-stake".to_string();
+        fixed.subscription_id = "sub_hos".to_string();
+        fixed.price_id = "hos_starter".to_string();
+        fixed.current_period_end = period_end;
+
+        let mut chain = fixed.clone();
+        chain.price_id = "hos_basic".to_string();
+
+        let mut fixed_plan = hos_plan_config("hos_starter");
+        fixed_plan.monthly_credits =
+            Some(crate::system_configs::ports::PlanLimitConfig { max: 5_000_000_000 });
+        let mut variable_plan = hos_plan_config("hos_basic");
+        variable_plan.stake_based_monthly_credits = Some(StakeBasedMonthlyCreditsConfig {
+            credits_per_staked_near_nano_usd: Some(500_000_000),
+        });
+        let plans = HashMap::from([
+            ("starter".to_string(), fixed_plan),
+            ("basic".to_string(), variable_plan),
+        ]);
+
+        assert_eq!(
+            SubscriptionServiceImpl::fixed_to_stake_based_credit_floor(
+                &[fixed.clone()],
+                &chain,
+                &plans,
+            ),
+            Some(5_000_000_000)
+        );
+
+        chain.current_period_end += Duration::days(30);
+        assert_eq!(
+            SubscriptionServiceImpl::fixed_to_stake_based_credit_floor(&[fixed], &chain, &plans),
+            None,
+            "a renewal into a stake-based plan must start with its full-period entitlement"
         );
     }
 

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -2,7 +2,7 @@ use super::near_staking::{
     lock_amount_yocto, lock_has_active_shares, subscription_row_from_chain,
     view_get_effective_lock, view_get_lock, view_get_price, view_get_purchase,
     view_get_subscription_for_price, view_storage_balance_bounds, view_storage_balance_of,
-    NearStakingStorageBalance, NearStakingStorageBalanceBounds,
+    NearStakingStorageBalance, NearStakingStorageBalanceBounds, NearStakingSubscription,
 };
 use super::ports::{
     BillingCycleAnchor, BillingPeriod, CancelSubscriptionOutcome, ChangePlanOutcome,
@@ -100,7 +100,18 @@ struct CachedSystemConfigs {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum HouseOfStakeEntitlementSource {
     Chain,
-    TransientFallback,
+    TransientSnapshotFallback,
+    TransientPlanFallback,
+}
+
+impl HouseOfStakeEntitlementSource {
+    fn is_transient_snapshot_fallback(self) -> bool {
+        self == Self::TransientSnapshotFallback
+    }
+
+    fn is_transient_plan_fallback(self) -> bool {
+        self == Self::TransientPlanFallback
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -1262,6 +1273,49 @@ impl SubscriptionServiceImpl {
         Some(credits.min(u64::MAX as u128) as u64)
     }
 
+    fn has_stake_based_monthly_credits(plan_config: &SubscriptionPlanConfig) -> bool {
+        plan_config
+            .stake_based_monthly_credits
+            .as_ref()
+            .and_then(|c| c.credits_per_staked_near_nano_usd)
+            .is_some()
+    }
+
+    fn fixed_to_stake_based_credit_floor(
+        local_subscriptions: &[Subscription],
+        chain_subscription: &Subscription,
+        subscription_plans: &HashMap<String, SubscriptionPlanConfig>,
+    ) -> Option<u64> {
+        let target_plan_name = resolve_plan_name_from_config(
+            chain_subscription.provider.as_str(),
+            &chain_subscription.price_id,
+            subscription_plans,
+        )?;
+        let target_plan = subscription_plans.get(&target_plan_name)?;
+        if !Self::has_stake_based_monthly_credits(target_plan) {
+            return None;
+        }
+
+        local_subscriptions
+            .iter()
+            .find(|sub| {
+                sub.provider == "house-of-stake"
+                    && sub.subscription_id == chain_subscription.subscription_id
+                    && sub.price_id != chain_subscription.price_id
+                    && Self::is_active_or_trialing(&sub.status)
+            })
+            .and_then(|sub| {
+                let current_plan_name = resolve_plan_name_from_config(
+                    &sub.provider,
+                    &sub.price_id,
+                    subscription_plans,
+                )?;
+                let current_plan = subscription_plans.get(&current_plan_name)?;
+                (!Self::has_stake_based_monthly_credits(current_plan))
+                    .then(|| Self::plan_limit_max(current_plan))
+            })
+    }
+
     fn ns_to_datetime(ns: u64) -> Option<DateTime<Utc>> {
         let secs = (ns / 1_000_000_000) as i64;
         let nsec = ((ns % 1_000_000_000) / 1_000 * 1_000) as u32;
@@ -1327,6 +1381,20 @@ impl SubscriptionServiceImpl {
                 <= Duration::seconds(HOUSE_OF_STAKE_PERIOD_START_BASELINE_GRACE_SECS)
     }
 
+    fn house_of_stake_entitlement_period(
+        chain_subscription: &NearStakingSubscription,
+        fallback_period_start: DateTime<Utc>,
+        fallback_period_end: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> (DateTime<Utc>, DateTime<Utc>) {
+        chain_subscription
+            .start_ns
+            .and_then(Self::ns_to_datetime)
+            .zip(Self::ns_to_datetime(chain_subscription.end_ns))
+            .filter(|(start, end)| Self::is_valid_house_of_stake_chain_period(*start, *end, now))
+            .unwrap_or((fallback_period_start, fallback_period_end))
+    }
+
     async fn reconcile_house_of_stake_credit_entitlement_snapshot(
         &self,
         user_id: UserId,
@@ -1335,6 +1403,7 @@ impl SubscriptionServiceImpl {
         period_start: DateTime<Utc>,
         period_end: DateTime<Utc>,
         effective_stake_yocto: u128,
+        first_snapshot_credit_floor_nano_usd: Option<u64>,
     ) -> Result<u64, SubscriptionError> {
         let observed_at = Utc::now();
         let mut client = self
@@ -1399,8 +1468,20 @@ impl SubscriptionServiceImpl {
                     Some(stake) => stake.min(effective_stake_yocto),
                     None => effective_stake_yocto,
                 };
-                let baseline_limit =
+                let stake_based_baseline_limit =
                     Self::stake_based_credits_for_lock(plan_config, baseline_stake).unwrap_or(0);
+                let baseline_limit = match first_snapshot_credit_floor_nano_usd {
+                    Some(floor) if stake_based_baseline_limit > floor => {
+                        floor.saturating_add(Self::prorated_credit_delta(
+                            stake_based_baseline_limit - floor,
+                            period_start,
+                            period_end,
+                            observed_at,
+                        ))
+                    }
+                    Some(floor) => floor,
+                    None => stake_based_baseline_limit,
+                };
                 match txn
                     .query_opt(
                         r#"
@@ -1554,6 +1635,88 @@ impl SubscriptionServiceImpl {
         }))
     }
 
+    async fn seed_fixed_to_stake_based_house_of_stake_snapshot(
+        &self,
+        user_id: UserId,
+        contract_id: &str,
+        chain_subscription: &NearStakingSubscription,
+        local_subscription: &Subscription,
+        plan_config: &SubscriptionPlanConfig,
+        fixed_credit_floor_nano_usd: u64,
+    ) -> Result<(), SubscriptionError> {
+        let Some(last_lock_id) = chain_subscription
+            .last_lock_id
+            .as_deref()
+            .filter(|s| !s.trim().is_empty())
+        else {
+            tracing::warn!(
+                user_id = %user_id.0,
+                subscription_id = %local_subscription.subscription_id,
+                "cannot seed fixed-to-stake HoS snapshot: last lock id missing"
+            );
+            return Ok(());
+        };
+
+        let fallback_period_end = local_subscription.current_period_end;
+        let fallback_period_start = sub_one_month_same_day(fallback_period_end);
+        let (period_start, period_end) = Self::house_of_stake_entitlement_period(
+            chain_subscription,
+            fallback_period_start,
+            fallback_period_end,
+            Utc::now(),
+        );
+        let Some(lock) = view_get_effective_lock(&self.near_rpc_url, contract_id, last_lock_id)
+            .await
+            .map_err(Self::near_rpc_err)?
+        else {
+            tracing::warn!(
+                user_id = %user_id.0,
+                subscription_id = %local_subscription.subscription_id,
+                last_lock_id,
+                "cannot seed fixed-to-stake HoS snapshot: lock missing"
+            );
+            return Ok(());
+        };
+        if !lock_has_active_shares(&lock) {
+            self.reconcile_house_of_stake_credit_entitlement_snapshot(
+                user_id,
+                &local_subscription.subscription_id,
+                plan_config,
+                period_start,
+                period_end,
+                0,
+                Some(fixed_credit_floor_nano_usd),
+            )
+            .await?;
+            return Ok(());
+        }
+        let Some(lock_amount) = lock_amount_yocto(&lock) else {
+            tracing::warn!(
+                user_id = %user_id.0,
+                subscription_id = %local_subscription.subscription_id,
+                "cannot seed fixed-to-stake HoS snapshot: lock amount missing or invalid"
+            );
+            return Ok(());
+        };
+
+        self.reconcile_house_of_stake_credit_entitlement_snapshot(
+            user_id,
+            &local_subscription.subscription_id,
+            plan_config,
+            period_start,
+            period_end,
+            lock_amount,
+            Some(fixed_credit_floor_nano_usd),
+        )
+        .await?;
+        tracing::info!(
+            user_id = %user_id.0,
+            subscription_id = %local_subscription.subscription_id,
+            "seeded fixed-to-stake HoS entitlement snapshot"
+        );
+        Ok(())
+    }
+
     async fn house_of_stake_snapshot_or_plan_fallback(
         &self,
         user_id: UserId,
@@ -1581,7 +1744,7 @@ impl SubscriptionServiceImpl {
                     plan_credits: snapshot_limit,
                     period_start: snapshot_start,
                     period_end: snapshot_end,
-                    source: HouseOfStakeEntitlementSource::TransientFallback,
+                    source: HouseOfStakeEntitlementSource::TransientSnapshotFallback,
                 }));
             }
             Ok(None) => {}
@@ -1600,7 +1763,7 @@ impl SubscriptionServiceImpl {
             plan_credits: limit,
             period_start,
             period_end,
-            source: HouseOfStakeEntitlementSource::TransientFallback,
+            source: HouseOfStakeEntitlementSource::TransientPlanFallback,
         }))
     }
 
@@ -1817,7 +1980,7 @@ impl SubscriptionServiceImpl {
                             plan_credits: snapshot_limit,
                             period_start: snapshot_start,
                             period_end: snapshot_end,
-                            source: HouseOfStakeEntitlementSource::TransientFallback,
+                            source: HouseOfStakeEntitlementSource::TransientSnapshotFallback,
                         }));
                     }
                     Ok(None) => {}
@@ -1913,6 +2076,25 @@ impl SubscriptionServiceImpl {
                 lock_shares = %lock_shares,
                 "HoS effective lock is not active with staked shares; granting zero stake-based credits"
             );
+            if let Err(err) = self
+                .reconcile_house_of_stake_credit_entitlement_snapshot(
+                    user_id,
+                    &subscription.subscription_id,
+                    plan_config,
+                    period_start,
+                    period_end,
+                    0,
+                    None,
+                )
+                .await
+            {
+                tracing::warn!(
+                    user_id = %user_id.0,
+                    subscription_id = %subscription.subscription_id,
+                    error = %err,
+                    "failed to persist HoS zero-stake observation"
+                );
+            }
             return Ok(Self::house_of_stake_chain_zero_entitlement(
                 user_id,
                 subscription,
@@ -1948,6 +2130,7 @@ impl SubscriptionServiceImpl {
                 period_start,
                 period_end,
                 lock_amount,
+                None,
             )
             .await
         {
@@ -1963,7 +2146,7 @@ impl SubscriptionServiceImpl {
                     plan_credits: Self::plan_limit_max(plan_config),
                     period_start,
                     period_end,
-                    source: HouseOfStakeEntitlementSource::TransientFallback,
+                    source: HouseOfStakeEntitlementSource::TransientPlanFallback,
                 }));
             }
         };
@@ -2455,6 +2638,23 @@ impl SubscriptionServiceImpl {
         let chain_subscription = raw.as_ref().expect("checked is_some");
         let row = subscription_row_from_chain(user_id, &near_account, chain_subscription)
             .map_err(SubscriptionError::InternalError)?;
+        let fixed_to_stake_based_seed = if Self::is_active_or_trialing(&row.status) {
+            let fixed_credit_floor =
+                Self::fixed_to_stake_based_credit_floor(&subs, &row, &subscription_plans);
+            let target_plan_config = resolve_plan_name_from_config(
+                row.provider.as_str(),
+                &row.price_id,
+                &subscription_plans,
+            )
+            .and_then(|plan_name| subscription_plans.get(&plan_name))
+            .filter(|plan_config| Self::has_stake_based_monthly_credits(plan_config))
+            .cloned();
+            fixed_credit_floor
+                .zip(target_plan_config)
+                .map(|(floor, plan_config)| (row.clone(), plan_config, floor))
+        } else {
+            None
+        };
 
         // Do not insert/update an active HoS row while a non-HoS subscription is active/trialing locally:
         // `get_active_subscription` picks newest `created_at`, so a fresh HoS upsert could wrongly
@@ -2552,6 +2752,29 @@ impl SubscriptionServiceImpl {
             .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
 
         self.invalidate_credit_limit_cache(user_id).await;
+        if let Some((seed_subscription, seed_plan_config, fixed_credit_floor)) =
+            fixed_to_stake_based_seed
+        {
+            if let Err(err) = self
+                .seed_fixed_to_stake_based_house_of_stake_snapshot(
+                    user_id,
+                    &contract_id,
+                    chain_subscription,
+                    &seed_subscription,
+                    &seed_plan_config,
+                    fixed_credit_floor,
+                )
+                .await
+            {
+                tracing::warn!(
+                    user_id = %user_id.0,
+                    subscription_id = %seed_subscription.subscription_id,
+                    error = %err,
+                    "fixed-to-stake HoS entitlement snapshot seeding failed"
+                );
+            }
+            self.invalidate_credit_limit_cache(user_id).await;
+        }
         Ok(Self::hos_reconcile_summary(false, 0, canceled, true, None))
     }
 }
@@ -2817,7 +3040,9 @@ impl SubscriptionServiceImpl {
         let period_start = resolved.period_start;
         let period_end = resolved.period_end;
 
-        if resolved.house_of_stake_source != Some(HouseOfStakeEntitlementSource::TransientFallback)
+        if !resolved
+            .house_of_stake_source
+            .is_some_and(HouseOfStakeEntitlementSource::is_transient_snapshot_fallback)
         {
             return Ok(Some((plan_credits, period_start, period_end)));
         }
@@ -2882,6 +3107,17 @@ impl SubscriptionServiceImpl {
                 Ok(None)
             }
         }
+    }
+
+    async fn fresh_purchased_reconciliation_plan_period(
+        &self,
+        user_id: UserId,
+    ) -> Result<Option<(i64, DateTime<Utc>, DateTime<Utc>)>, SubscriptionError> {
+        let resolved = self
+            .refresh_plan_period_for_user_with_source(user_id)
+            .await?;
+        self.purchased_reconciliation_plan_period(user_id, &resolved)
+            .await
     }
 }
 
@@ -4400,9 +4636,22 @@ impl SubscriptionService for SubscriptionServiceImpl {
             .unwrap_or(0);
 
         // 3. Only check credits balance when spent >= plan (might need purchased credits to cover overage)
+        let has_unverified_hos_plan_limit = resolved
+            .house_of_stake_source
+            .is_some_and(HouseOfStakeEntitlementSource::is_transient_plan_fallback);
         let (limit_exceeded, credits_balance) = if period_spent_credits >= 0
             && (period_spent_credits as u64) >= plan_credits
         {
+            if has_unverified_hos_plan_limit {
+                tracing::warn!(
+                    user_id = %user_id.0,
+                    "Blocking HoS proxy over-plan usage while entitlement has no authoritative snapshot"
+                );
+                return Err(SubscriptionError::CreditLimitExceeded {
+                    used: period_spent_credits,
+                    limit: plan_credits,
+                });
+            }
             let credits_balance = self
                 .credits_repo
                 .get_balance(user_id)
@@ -5043,13 +5292,8 @@ impl SubscriptionService for SubscriptionServiceImpl {
         &self,
         user_id: UserId,
     ) -> Result<(), SubscriptionError> {
-        // Keep per-message accounting on the HoS entitlement cache. Stake mutations and
-        // `/near/sync` invalidate this cache before seeding a fresh snapshot.
-        let resolved = self
-            .resolve_plan_period_for_user_with_source(user_id)
-            .await?;
         let Some((plan_credits, period_start, period_end)) = self
-            .purchased_reconciliation_plan_period(user_id, &resolved)
+            .fresh_purchased_reconciliation_plan_period(user_id)
             .await?
         else {
             return Ok(());
@@ -5079,7 +5323,7 @@ impl SubscriptionService for SubscriptionServiceImpl {
 
         if period_spent_credits > 0 {
             match self
-                .purchased_reconciliation_plan_period(user_id, &resolved)
+                .fresh_purchased_reconciliation_plan_period(user_id)
                 .await
             {
                 Ok(Some((

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -3119,17 +3119,6 @@ impl SubscriptionServiceImpl {
         }
     }
 
-    async fn fresh_purchased_reconciliation_plan_period(
-        &self,
-        user_id: UserId,
-    ) -> Result<Option<(i64, DateTime<Utc>, DateTime<Utc>)>, SubscriptionError> {
-        let resolved = self
-            .refresh_plan_period_for_user_with_source(user_id)
-            .await?;
-        self.purchased_reconciliation_plan_period(user_id, &resolved)
-            .await
-    }
-
     async fn purchased_reconciliation_plan_period_after_usage(
         &self,
         user_id: UserId,
@@ -3148,7 +3137,7 @@ impl SubscriptionServiceImpl {
         if period_spent_credits < cached_plan_credits {
             return Ok(None);
         }
-        self.fresh_purchased_reconciliation_plan_period(user_id)
+        self.purchased_reconciliation_plan_period(user_id, &cached)
             .await
     }
 }
@@ -5355,7 +5344,7 @@ impl SubscriptionService for SubscriptionServiceImpl {
 
         if period_spent_credits >= plan_credits {
             match self
-                .fresh_purchased_reconciliation_plan_period(user_id)
+                .purchased_reconciliation_plan_period(user_id, &resolved)
                 .await
             {
                 Ok(Some((

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -5341,11 +5341,11 @@ impl SubscriptionService for SubscriptionServiceImpl {
         let resolved = self
             .resolve_plan_period_for_user_with_source(user_id)
             .await?;
-        let plan_credits = resolved.plan_credits.min(i64::MAX as u64) as i64;
-        let period_start = resolved.period_start;
-        let period_end = resolved.period_end;
+        let mut plan_credits = resolved.plan_credits.min(i64::MAX as u64) as i64;
+        let mut period_start = resolved.period_start;
+        let mut period_end = resolved.period_end;
 
-        let period_spent_credits = self
+        let mut period_spent_credits = self
             .user_usage_repo
             .get_usage_by_user_id(user_id, Some(period_start), Some(period_end))
             .await
@@ -5363,6 +5363,16 @@ impl SubscriptionService for SubscriptionServiceImpl {
                     reconciliation_period_start,
                     reconciliation_period_end,
                 ))) => {
+                    plan_credits = reconciliation_plan_credits;
+                    period_start = reconciliation_period_start;
+                    period_end = reconciliation_period_end;
+                    period_spent_credits = self
+                        .user_usage_repo
+                        .get_usage_by_user_id(user_id, Some(period_start), Some(period_end))
+                        .await
+                        .map_err(|e| SubscriptionError::InternalError(e.to_string()))?
+                        .map(|s| s.cost_nano_usd)
+                        .unwrap_or(0);
                     if let Err(e) = self
                         .credits_repo
                         .reconcile_purchased_after_usage(


### PR DESCRIPTION
## Summary

This stacked PR addresses the latest HoS accounting review comments on #363.

- Distinguish persisted-snapshot fallback from plan-only fallback, and block over-plan proxy usage when no authoritative entitlement snapshot is available.
- Bypass the 10-minute HoS entitlement cache for purchased-credit reconciliation so direct on-chain stake increases cannot be charged as stale overage.
- Persist confirmed zero-stake observations to reset the carried stake baseline.
- On a fixed-to-stake-based plan change, retain the fixed current-period entitlement and prorate only the variable-plan increase.
- Add regression coverage for confirmed zero stake, direct chain stake increases, and fixed-to-variable proration.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --all-targets --features test`
- `cargo test -p database purchased_reconciliation`

## Base

Stacked on #363 (`agent/prorate-hos-stake-credits`).