### PR TITLE
feat: prorate HoS stake credit entitlement

### DIFF
--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -4042,21 +4042,24 @@ async fn assert_house_of_stake_credits_for_effective_lock(
     insert_house_of_stake_subscription_for_existing_user(&db, near_email, "price_hos_basic", false)
         .await;
 
-    let response = server
-        .get("/v1/credits")
-        .add_header(
-            http::HeaderName::from_static("authorization"),
-            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
-        )
-        .await;
+    for _ in 0..2 {
+        let response = server
+            .get("/v1/credits")
+            .add_header(
+                http::HeaderName::from_static("authorization"),
+                http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+            )
+            .await;
 
-    assert_eq!(response.status_code(), 200, "{}", response.text());
-    let body: serde_json::Value = response.json();
-    assert_eq!(
-        body.get("plan_credits").and_then(|x| x.as_i64()),
-        Some(expected_plan_credits),
-        "{assertion_message}"
-    );
+        assert_eq!(response.status_code(), 200, "{}", response.text());
+        let body: serde_json::Value = response.json();
+        assert_eq!(
+            body.get("plan_credits").and_then(|x| x.as_i64()),
+            Some(expected_plan_credits),
+            "{assertion_message}"
+        );
+    }
+    assert_eq!(mock.received_requests().await.unwrap().len(), 2);
 }
 
 #[tokio::test]

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -4131,6 +4131,115 @@ async fn test_house_of_stake_credits_zero_for_effective_lock_with_no_active_shar
     .await;
 }
 
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn test_fixed_house_of_stake_credits_persist_authoritative_period() {
+    clear_proxy_env_for_local_wiremock();
+    let now = Utc::now().with_nanosecond(0).unwrap();
+    let period_start = now - Duration::days(20);
+    let period_end = now + Duration::days(10);
+    let subscription_id = format!("sub_chain_hos_fixed_{}", Uuid::new_v4());
+    let chain_sub = json!({
+        "subscription_id": subscription_id,
+        "price_id": "price_hos_starter",
+        "last_lock_id": "lock_chain_hos_fixed",
+        "start_ns": period_start.timestamp_nanos_opt().unwrap().to_string(),
+        "end_ns": period_end.timestamp_nanos_opt().unwrap().to_string(),
+        "status": "Active",
+        "cancel_at_period_end": false
+    });
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(near_rpc_wiremock_hos_subscription_by_price(
+            "price_hos_starter",
+            chain_sub,
+            None,
+        ))
+        .mount(&mock)
+        .await;
+
+    let (server, db) = create_test_server_and_db(TestServerConfig {
+        near_rpc_url: Some(mock.uri().to_string()),
+        near_staking_contract_id: Some("staking.testnet".to_string()),
+        ..Default::default()
+    })
+    .await;
+    set_subscription_plans(
+        &server,
+        json!({
+            "starter": {
+                "providers": { "house-of-stake": { "price_id": "price_hos_starter" } },
+                "agent_instances": { "max": 1 },
+                "monthly_credits": { "max": 5_000_000_000_i64 }
+            }
+        }),
+    )
+    .await;
+
+    let near_email = "hos_fixed_period.testnet@near";
+    let response = server
+        .post("/v1/auth/mock-login")
+        .json(&json!({
+            "email": near_email,
+            "name": "HoS Fixed Period",
+            "oauth_provider": "near"
+        }))
+        .await;
+    let token = response.json::<serde_json::Value>()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    cleanup_user_subscriptions(&db, near_email).await;
+    insert_house_of_stake_subscription_for_existing_user(
+        &db,
+        near_email,
+        "price_hos_starter",
+        false,
+    )
+    .await;
+    let user = db
+        .user_repository()
+        .get_user_by_email(near_email)
+        .await
+        .unwrap()
+        .unwrap();
+    let client = db.pool().get().await.unwrap();
+    client
+        .execute(
+            "UPDATE subscriptions SET subscription_id = $2 WHERE user_id = $1",
+            &[&user.id, &subscription_id],
+        )
+        .await
+        .unwrap();
+
+    for _ in 0..2 {
+        let response = server
+            .get("/v1/credits")
+            .add_header(
+                http::HeaderName::from_static("authorization"),
+                http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+            )
+            .await;
+        assert_eq!(response.status_code(), 200, "{}", response.text());
+        assert_eq!(
+            response.json::<serde_json::Value>()["plan_credits"].as_i64(),
+            Some(5_000_000_000)
+        );
+    }
+
+    let persisted_start: Option<chrono::DateTime<Utc>> = client
+        .query_one(
+            "SELECT current_period_start FROM subscriptions WHERE subscription_id = $1",
+            &[&subscription_id],
+        )
+        .await
+        .unwrap()
+        .get("current_period_start");
+    assert_eq!(persisted_start, Some(period_start));
+    assert_eq!(mock.received_requests().await.unwrap().len(), 1);
+}
+
 #[test]
 fn test_change_plan_outcome_serde_uses_kind_discriminant() {
     let o = ChangePlanOutcome::NearStakingChangePlan {

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -3891,6 +3891,14 @@ fn near_rpc_wiremock_hos_subscription_by_price(
                 };
                 ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(&result))
             }
+            Some("get_lock") => {
+                ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(&json!({
+                    "lock_id": "lock_chain_hos_fixed_to_variable",
+                    "amount_near": "15000000000000000000000000",
+                    "status": "Active",
+                    "shares": "15000000000000000000000000"
+                })))
+            }
             _ => ResponseTemplate::new(500).set_body_json(json!({ "error": "unmocked NEAR RPC" })),
         }
     }
@@ -3939,11 +3947,13 @@ async fn assert_house_of_stake_credits_for_effective_lock(
     assertion_message: &str,
 ) {
     clear_proxy_env_for_local_wiremock();
+    let chain_subscription_id = format!("sub_chain_hos_effective_credits_{}", Uuid::new_v4());
     let mock = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/"))
         .respond_with({
             let effective_lock = effective_lock.clone();
+            let chain_subscription_id = chain_subscription_id.clone();
             move |req: &wiremock::Request| {
                 use base64::{engine::general_purpose::STANDARD, Engine};
 
@@ -3965,7 +3975,7 @@ async fn assert_house_of_stake_credits_for_effective_lock(
                 match method_name {
                     "get_subscription_for_price" => ResponseTemplate::new(200).set_body_json(
                         near_rpc_call_function_body(&json!({
-                            "subscription_id": "sub_chain_hos_effective_credits",
+                            "subscription_id": chain_subscription_id,
                             "price_id": "price_hos_basic",
                             "last_lock_id": "lock_chain_hos_effective_credits",
                             "end_ns": "2000000000000000000",
@@ -4041,6 +4051,23 @@ async fn assert_house_of_stake_credits_for_effective_lock(
     cleanup_user_subscriptions(&db, near_email).await;
     insert_house_of_stake_subscription_for_existing_user(&db, near_email, "price_hos_basic", false)
         .await;
+    let user = db
+        .user_repository()
+        .get_user_by_email(near_email)
+        .await
+        .unwrap()
+        .unwrap();
+    db.pool()
+        .get()
+        .await
+        .unwrap()
+        .execute(
+            "UPDATE subscriptions SET subscription_id = $2
+             WHERE user_id = $1 AND provider = 'house-of-stake'",
+            &[&user.id, &chain_subscription_id],
+        )
+        .await
+        .expect("align local and chain HoS subscription ids");
 
     for _ in 0..2 {
         let response = server
@@ -5398,10 +5425,12 @@ async fn test_near_staking_sync_marks_local_hos_canceled_when_chain_returns_null
 #[serial(subscription_tests)]
 async fn test_near_staking_sync_falls_back_to_configured_prices_before_canceling_local_row() {
     clear_proxy_env_for_local_wiremock();
+    let period_end = Utc::now() + Duration::days(15);
     let chain_sub = json!({
         "subscription_id": "sub_chain_hos_fallback",
         "price_id": "price_hos_pro",
-        "end_ns": "2000000000000000000",
+        "last_lock_id": "lock_chain_hos_fixed_to_variable",
+        "end_ns": period_end.timestamp_nanos_opt().unwrap().to_string(),
         "status": "Active",
         "cancel_at_period_end": false
     });
@@ -5425,8 +5454,18 @@ async fn test_near_staking_sync_falls_back_to_configured_prices_before_canceling
     set_subscription_plans(
         &server,
         json!({
-            "basic": { "providers": { "house-of-stake": { "price_id": "price_hos_basic" } }, "agent_instances": { "max": 1 }, "monthly_credits": { "max": 1000000 } },
-            "pro": { "providers": { "house-of-stake": { "price_id": "price_hos_pro" } }, "agent_instances": { "max": 1 }, "monthly_credits": { "max": 1000000 } }
+            "basic": {
+                "providers": { "house-of-stake": { "price_id": "price_hos_basic" } },
+                "agent_instances": { "max": 1 },
+                "monthly_credits": { "max": 5_000_000_000_i64 }
+            },
+            "pro": {
+                "providers": { "house-of-stake": { "price_id": "price_hos_pro" } },
+                "agent_instances": { "max": 1 },
+                "stake_based_monthly_credits": {
+                    "credits_per_staked_near_nano_usd": 1000000000
+                }
+            }
         }),
     )
     .await;
@@ -5456,9 +5495,10 @@ async fn test_near_staking_sync_falls_back_to_configured_prices_before_canceling
     let client = db.pool().get().await.unwrap();
     client
         .execute(
-            "UPDATE subscriptions SET subscription_id = 'sub_chain_hos_fallback'
+            "UPDATE subscriptions
+             SET subscription_id = 'sub_chain_hos_fallback', current_period_end = $2
              WHERE user_id = $1 AND provider = 'house-of-stake'",
-            &[&user.id],
+            &[&user.id, &period_end],
         )
         .await
         .expect("seed old local HoS price with chain subscription id");
@@ -5502,6 +5542,42 @@ async fn test_near_staking_sync_falls_back_to_configured_prices_before_canceling
     let price_id: Option<String> = row.get(1);
     assert_eq!(cnt, 1, "sync should update the existing HoS row");
     assert_eq!(price_id.as_deref(), Some("price_hos_pro"));
+
+    let snapshot = client
+        .query_one(
+            "SELECT credited_stake_yocto, last_observed_stake_yocto,
+                    credit_limit_nano_usd, period_start, period_end, observed_at
+             FROM house_of_stake_credit_entitlement_snapshots
+             WHERE subscription_id = 'sub_chain_hos_fallback'",
+            &[],
+        )
+        .await
+        .expect("fixed-to-variable sync should seed an entitlement snapshot");
+    assert_eq!(
+        snapshot.get::<_, String>("credited_stake_yocto"),
+        "15000000000000000000000000"
+    );
+    assert_eq!(
+        snapshot.get::<_, String>("last_observed_stake_yocto"),
+        "15000000000000000000000000"
+    );
+    let snapshot_start: chrono::DateTime<Utc> = snapshot.get("period_start");
+    let snapshot_end: chrono::DateTime<Utc> = snapshot.get("period_end");
+    let observed_at: chrono::DateTime<Utc> = snapshot.get("observed_at");
+    let total_seconds = snapshot_end
+        .signed_duration_since(snapshot_start)
+        .num_seconds() as i128;
+    let remaining_seconds = snapshot_end
+        .signed_duration_since(observed_at)
+        .num_seconds()
+        .clamp(0, total_seconds as i64) as i128;
+    let expected_limit =
+        5_000_000_000_i128 + 10_000_000_000_i128 * remaining_seconds / total_seconds;
+    assert_eq!(
+        snapshot.get::<_, i64>("credit_limit_nano_usd") as i128,
+        expected_limit,
+        "the prior fixed entitlement must be retained and only the increase prorated"
+    );
 }
 
 #[tokio::test]

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -3945,12 +3945,22 @@ async fn assert_house_of_stake_credits_for_effective_lock(
 ) {
     clear_proxy_env_for_local_wiremock();
     let chain_subscription_id = format!("sub_chain_hos_effective_credits_{}", Uuid::new_v4());
+    let period_start_ns = (Utc::now() - Duration::days(1))
+        .timestamp_nanos_opt()
+        .unwrap()
+        .to_string();
+    let period_end_ns = (Utc::now() + Duration::days(29))
+        .timestamp_nanos_opt()
+        .unwrap()
+        .to_string();
     let mock = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/"))
         .respond_with({
             let effective_lock = effective_lock.clone();
             let chain_subscription_id = chain_subscription_id.clone();
+            let period_start_ns = period_start_ns.clone();
+            let period_end_ns = period_end_ns.clone();
             move |req: &wiremock::Request| {
                 use base64::{engine::general_purpose::STANDARD, Engine};
 
@@ -3975,8 +3985,8 @@ async fn assert_house_of_stake_credits_for_effective_lock(
                             "subscription_id": chain_subscription_id,
                             "price_id": "price_hos_basic",
                             "last_lock_id": "lock_chain_hos_effective_credits",
-                            "start_ns": "1997408000000000000",
-                            "end_ns": "2000000000000000000",
+                            "start_ns": period_start_ns,
+                            "end_ns": period_end_ns,
                             "status": "Active",
                             "cancel_at_period_end": false,
                             "pending_update": {
@@ -5423,11 +5433,13 @@ async fn test_near_staking_sync_marks_local_hos_canceled_when_chain_returns_null
 #[serial(subscription_tests)]
 async fn test_near_staking_sync_falls_back_to_configured_prices_before_canceling_local_row() {
     clear_proxy_env_for_local_wiremock();
+    let period_start = Utc::now() - Duration::days(15);
     let period_end = Utc::now() + Duration::days(15);
     let chain_sub = json!({
         "subscription_id": "sub_chain_hos_fallback",
         "price_id": "price_hos_pro",
         "last_lock_id": "lock_chain_hos_fixed_to_variable",
+        "start_ns": period_start.timestamp_nanos_opt().unwrap().to_string(),
         "end_ns": period_end.timestamp_nanos_opt().unwrap().to_string(),
         "status": "Active",
         "cancel_at_period_end": false

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -3975,6 +3975,7 @@ async fn assert_house_of_stake_credits_for_effective_lock(
                             "subscription_id": chain_subscription_id,
                             "price_id": "price_hos_basic",
                             "last_lock_id": "lock_chain_hos_effective_credits",
+                            "start_ns": "1997408000000000000",
                             "end_ns": "2000000000000000000",
                             "status": "Active",
                             "cancel_at_period_end": false,

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -1983,8 +1983,33 @@ async fn test_proxy_blocks_when_monthly_token_limit_exceeded() {
 #[serial(subscription_tests)]
 async fn test_proxy_blocks_for_house_of_stake_plan_credit_limit() {
     ensure_stripe_env_for_gating();
+    let now = Utc::now().with_nanosecond(0).unwrap();
+    let period_start = now - Duration::days(20);
+    let period_end = now + Duration::days(10);
+    let subscription_id = format!("sub_chain_hos_proxy_limit_{}", Uuid::new_v4());
+    let chain_sub = json!({
+        "subscription_id": subscription_id,
+        "price_id": "price_hos_basic",
+        "last_lock_id": "lock_chain_hos_proxy_limit",
+        "start_ns": period_start.timestamp_nanos_opt().unwrap().to_string(),
+        "end_ns": period_end.timestamp_nanos_opt().unwrap().to_string(),
+        "status": "Active",
+        "cancel_at_period_end": false
+    });
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(near_rpc_wiremock_hos_subscription_by_price(
+            "price_hos_basic",
+            chain_sub,
+            None,
+        ))
+        .mount(&mock)
+        .await;
+
     let (server, db) = create_test_server_and_db(TestServerConfig {
         rate_limit_config: Some(permissive_rate_limit_config()),
+        near_rpc_url: Some(mock.uri().to_string()),
         near_staking_contract_id: Some("staking.testnet".to_string()),
         ..Default::default()
     })
@@ -2002,8 +2027,19 @@ async fn test_proxy_blocks_for_house_of_stake_plan_credit_limit() {
     )
     .await;
 
-    let user_email = "test_proxy_hos_credit_limit@example.com";
-    let user_token = mock_login(&server, user_email).await;
+    let user_email = "test_proxy_hos_credit_limit.testnet@near";
+    let response = server
+        .post("/v1/auth/mock-login")
+        .json(&json!({
+            "email": user_email,
+            "name": "HoS Proxy Limit",
+            "oauth_provider": "near"
+        }))
+        .await;
+    let user_token = response.json::<serde_json::Value>()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
     insert_test_subscription_with_provider_and_price(
         &server,
         &db,
@@ -2020,6 +2056,16 @@ async fn test_proxy_blocks_for_house_of_stake_plan_credit_limit() {
         .await
         .expect("get user")
         .expect("user exists");
+    let client = db.pool().get().await.expect("get pool client");
+    client
+        .execute(
+            "UPDATE subscriptions
+             SET subscription_id = $2, current_period_end = $3
+             WHERE user_id = $1 AND provider = 'house-of-stake'",
+            &[&user.id, &subscription_id, &period_end],
+        )
+        .await
+        .expect("align local HoS subscription with chain");
 
     db.user_usage_repository()
         .record_usage_event(user.id, METRIC_KEY_LLM_TOKENS, 150, Some(150), None)

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -5581,6 +5581,44 @@ async fn test_near_staking_sync_falls_back_to_configured_prices_before_canceling
         expected_limit,
         "the prior fixed entitlement must be retained and only the increase prorated"
     );
+
+    let response = server
+        .get("/v1/credits")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+    assert_eq!(response.status_code(), 200, "{}", response.text());
+    let body: serde_json::Value = response.json();
+    let hos = body
+        .get("house_of_stake")
+        .expect("credits should include HoS accounting metadata");
+    assert_eq!(
+        hos.get("credited_stake_yocto").and_then(|x| x.as_str()),
+        Some("15000000000000000000000000")
+    );
+    assert_eq!(
+        hos.get("last_observed_stake_yocto")
+            .and_then(|x| x.as_str()),
+        Some("15000000000000000000000000")
+    );
+    assert_eq!(
+        hos.get("credit_limit_nano_usd").and_then(|x| x.as_i64()),
+        Some(expected_limit as i64)
+    );
+    assert_eq!(
+        hos.get("period_start")
+            .and_then(|x| x.as_str())
+            .and_then(|x| x.parse::<chrono::DateTime<Utc>>().ok()),
+        Some(snapshot_start)
+    );
+    assert_eq!(
+        hos.get("period_end")
+            .and_then(|x| x.as_str())
+            .and_then(|x| x.parse::<chrono::DateTime<Utc>>().ok()),
+        Some(snapshot_end)
+    );
 }
 
 #[tokio::test]

--- a/crates/api/tests/subscriptions_tests.rs
+++ b/crates/api/tests/subscriptions_tests.rs
@@ -3862,6 +3862,7 @@ fn near_rpc_wiremock_hos_subscription_probe_only(
 fn near_rpc_wiremock_hos_subscription_by_price(
     active_price_id: &'static str,
     subscription_result: serde_json::Value,
+    effective_lock: Option<serde_json::Value>,
 ) -> impl wiremock::Respond {
     move |req: &wiremock::Request| {
         use base64::{engine::general_purpose::STANDARD, Engine};
@@ -3891,14 +3892,10 @@ fn near_rpc_wiremock_hos_subscription_by_price(
                 };
                 ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(&result))
             }
-            Some("get_lock") => {
-                ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(&json!({
-                    "lock_id": "lock_chain_hos_fixed_to_variable",
-                    "amount_near": "15000000000000000000000000",
-                    "status": "Active",
-                    "shares": "15000000000000000000000000"
-                })))
-            }
+            Some("get_lock") => effective_lock.as_ref().map_or_else(
+                || ResponseTemplate::new(500),
+                |lock| ResponseTemplate::new(200).set_body_json(near_rpc_call_function_body(lock)),
+            ),
             _ => ResponseTemplate::new(500).set_body_json(json!({ "error": "unmocked NEAR RPC" })),
         }
     }
@@ -5440,6 +5437,12 @@ async fn test_near_staking_sync_falls_back_to_configured_prices_before_canceling
         .respond_with(near_rpc_wiremock_hos_subscription_by_price(
             "price_hos_pro",
             chain_sub,
+            Some(json!({
+                "lock_id": "lock_chain_hos_fixed_to_variable",
+                "amount_near": "15000000000000000000000000",
+                "status": "Active",
+                "shares": "15000000000000000000000000"
+            })),
         ))
         .mount(&mock)
         .await;
@@ -5578,6 +5581,113 @@ async fn test_near_staking_sync_falls_back_to_configured_prices_before_canceling
         expected_limit,
         "the prior fixed entitlement must be retained and only the increase prorated"
     );
+}
+
+#[tokio::test]
+#[serial(subscription_tests)]
+async fn test_near_staking_sync_keeps_fixed_plan_when_credit_floor_seed_fails() {
+    clear_proxy_env_for_local_wiremock();
+    let period_end = Utc::now() + Duration::days(15);
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .respond_with(near_rpc_wiremock_hos_subscription_by_price(
+            "price_hos_pro",
+            json!({
+                "subscription_id": "sub_chain_hos_floor_seed_failure",
+                "price_id": "price_hos_pro",
+                "last_lock_id": "lock_chain_hos_floor_seed_failure",
+                "end_ns": period_end.timestamp_nanos_opt().unwrap().to_string(),
+                "status": "Active",
+                "cancel_at_period_end": false
+            }),
+            None,
+        ))
+        .mount(&mock)
+        .await;
+
+    let (server, db) = create_test_server_and_db(TestServerConfig {
+        near_rpc_url: Some(mock.uri().to_string()),
+        near_staking_contract_id: Some("staking.testnet".to_string()),
+        ..Default::default()
+    })
+    .await;
+    set_subscription_plans(
+        &server,
+        json!({
+            "basic": {
+                "providers": { "house-of-stake": { "price_id": "price_hos_basic" } },
+                "agent_instances": { "max": 1 },
+                "monthly_credits": { "max": 5_000_000_000_i64 }
+            },
+            "pro": {
+                "providers": { "house-of-stake": { "price_id": "price_hos_pro" } },
+                "agent_instances": { "max": 1 },
+                "stake_based_monthly_credits": {
+                    "credits_per_staked_near_nano_usd": 1_000_000_000
+                }
+            }
+        }),
+    )
+    .await;
+
+    let near_email = "hos_floor_seed_failure.testnet@near";
+    let response = server
+        .post("/v1/auth/mock-login")
+        .json(&json!({
+            "email": near_email,
+            "name": "HoS Floor Seed Failure",
+            "oauth_provider": "near"
+        }))
+        .await;
+    let token = response.json::<serde_json::Value>()["token"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    cleanup_user_subscriptions(&db, near_email).await;
+    insert_house_of_stake_subscription_for_existing_user(&db, near_email, "price_hos_basic", false)
+        .await;
+
+    let user = db
+        .user_repository()
+        .get_user_by_email(near_email)
+        .await
+        .unwrap()
+        .unwrap();
+    let client = db.pool().get().await.unwrap();
+    client
+        .execute(
+            "UPDATE subscriptions
+             SET subscription_id = 'sub_chain_hos_floor_seed_failure', current_period_end = $2
+             WHERE user_id = $1 AND provider = 'house-of-stake'",
+            &[&user.id, &period_end],
+        )
+        .await
+        .expect("seed fixed HoS subscription");
+
+    let response = server
+        .post("/v1/subscriptions/near/sync")
+        .add_header(
+            http::HeaderName::from_static("authorization"),
+            http::HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        )
+        .await;
+    assert_ne!(response.status_code(), 200);
+
+    let row = client
+        .query_one(
+            "SELECT price_id,
+                    (SELECT COUNT(*)::bigint
+                     FROM house_of_stake_credit_entitlement_snapshots
+                     WHERE subscription_id = subscriptions.subscription_id) AS snapshot_count
+             FROM subscriptions
+             WHERE user_id = $1 AND provider = 'house-of-stake'",
+            &[&user.id],
+        )
+        .await
+        .expect("load subscription after failed seed");
+    assert_eq!(row.get::<_, String>("price_id"), "price_hos_basic");
+    assert_eq!(row.get::<_, i64>("snapshot_count"), 0);
 }
 
 #[tokio::test]

--- a/crates/database/src/migrations/sql/V37__add_hos_credit_entitlement_snapshots.sql
+++ b/crates/database/src/migrations/sql/V37__add_hos_credit_entitlement_snapshots.sql
@@ -1,0 +1,14 @@
+CREATE TABLE house_of_stake_credit_entitlement_snapshots (
+    subscription_id VARCHAR(255) NOT NULL REFERENCES subscriptions(subscription_id) ON DELETE CASCADE,
+    period_start TIMESTAMPTZ NOT NULL,
+    period_end TIMESTAMPTZ NOT NULL,
+    credited_stake_yocto TEXT NOT NULL CHECK (credited_stake_yocto ~ '^[0-9]+$'),
+    last_observed_stake_yocto TEXT NOT NULL CHECK (last_observed_stake_yocto ~ '^[0-9]+$'),
+    credit_limit_nano_usd BIGINT NOT NULL CHECK (credit_limit_nano_usd >= 0),
+    observed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (subscription_id, period_start, period_end),
+    CHECK (period_end > period_start)
+);
+
+CREATE INDEX idx_hos_credit_entitlement_subscription
+    ON house_of_stake_credit_entitlement_snapshots (subscription_id, period_end DESC);

--- a/crates/database/src/migrations/sql/V38__add_subscription_period_start.sql
+++ b/crates/database/src/migrations/sql/V38__add_subscription_period_start.sql
@@ -1,0 +1,6 @@
+ALTER TABLE subscriptions
+ADD COLUMN current_period_start TIMESTAMPTZ;
+
+ALTER TABLE subscriptions
+ADD CONSTRAINT subscriptions_period_bounds_check
+CHECK (current_period_start IS NULL OR current_period_start < current_period_end);

--- a/crates/database/src/repositories/credits_repository.rs
+++ b/crates/database/src/repositories/credits_repository.rs
@@ -17,6 +17,27 @@ impl PostgresCreditsRepository {
     }
 }
 
+fn reconcile_overage(
+    spent: i64,
+    total: i64,
+    previous_overage: i64,
+    current_overage: i64,
+    same_period: bool,
+) -> (i64, i64) {
+    let previous_overage = if same_period {
+        previous_overage.max(0)
+    } else {
+        0
+    };
+    let new_spent = (spent + (current_overage - previous_overage).max(0)).clamp(0, total);
+    let cursor = if same_period {
+        previous_overage.max(current_overage)
+    } else {
+        current_overage
+    };
+    (new_spent, cursor.max(0))
+}
+
 #[async_trait]
 impl CreditsRepository for PostgresCreditsRepository {
     /// Remaining purchased credits: total_purchased - used_purchased (computed).
@@ -236,15 +257,15 @@ impl CreditsRepository for PostgresCreditsRepository {
         let is_same_period = last_period_start
             .map(|s| s == period_start)
             .unwrap_or(false);
-        let already_applied = if is_same_period {
-            last_over_plan.max(0)
-        } else {
-            0
-        };
-        let delta_over_plan = (current_over_plan - already_applied).max(0);
-
-        // Apply delta, but never exceed total_purchased.
-        let new_spent = (old_spent + delta_over_plan).min(total_purchased).max(0);
+        // Keep a high-water cursor: a later stake increase can raise the plan limit and lower the
+        // current overage, but must not make the same usage charge purchased credits twice.
+        let (new_spent, overage_cursor) = reconcile_overage(
+            old_spent,
+            total_purchased,
+            last_over_plan,
+            current_over_plan,
+            is_same_period,
+        );
 
         txn.execute(
             r#"
@@ -255,11 +276,30 @@ impl CreditsRepository for PostgresCreditsRepository {
                 updated_at = NOW()
             WHERE user_id = $1
             "#,
-            &[&user_id, &new_spent, &period_start, &current_over_plan],
+            &[&user_id, &new_spent, &period_start, &overage_cursor],
         )
         .await?;
 
         txn.commit().await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reconcile_overage;
+
+    #[test]
+    fn overage_cursor_does_not_move_backwards_within_a_period() {
+        let (spent, cursor) = reconcile_overage(100, 1_000, 100, 20, true);
+        assert_eq!((spent, cursor), (100, 100));
+
+        let (spent, cursor) = reconcile_overage(spent, 1_000, cursor, 120, true);
+        assert_eq!((spent, cursor), (120, 120));
+    }
+
+    #[test]
+    fn overage_cursor_resets_for_a_new_period() {
+        assert_eq!(reconcile_overage(100, 1_000, 500, 30, false), (130, 30));
     }
 }

--- a/crates/database/src/repositories/subscription_repository.rs
+++ b/crates/database/src/repositories/subscription_repository.rs
@@ -13,6 +13,7 @@ fn row_to_subscription(row: &tokio_postgres::Row) -> Subscription {
         customer_id: row.get("customer_id"),
         price_id: row.get("price_id"),
         status: row.get("status"),
+        current_period_start: row.get("current_period_start"),
         current_period_end: row.get("current_period_end"),
         cancel_at_period_end: row.get("cancel_at_period_end"),
         created_at: row.get("created_at"),
@@ -29,7 +30,7 @@ fn row_to_subscription(row: &tokio_postgres::Row) -> Subscription {
 
 const SUBSCRIPTION_COLUMNS: &str =
     "subscription_id, user_id, provider, customer_id, price_id, status,
-       current_period_end, cancel_at_period_end, created_at, updated_at,
+       current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at,
        pending_downgrade_target_price_id, pending_downgrade_from_price_id,
        pending_downgrade_expected_period_end, pending_downgrade_status,
        pending_downgrade_updated_at";
@@ -121,12 +122,12 @@ impl PostgresSubscriptionRepository {
         let query = format!(
             "INSERT INTO subscriptions (
                     subscription_id, user_id, provider, customer_id, price_id,
-                    status, current_period_end, cancel_at_period_end,
+                    status, current_period_start, current_period_end, cancel_at_period_end,
                     pending_downgrade_target_price_id, pending_downgrade_from_price_id,
                     pending_downgrade_expected_period_end, pending_downgrade_status,
                     pending_downgrade_updated_at
                  )
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
                  ON CONFLICT (subscription_id)
                  DO UPDATE SET
                     user_id = EXCLUDED.user_id,
@@ -134,12 +135,13 @@ impl PostgresSubscriptionRepository {
                     customer_id = EXCLUDED.customer_id,
                     price_id = EXCLUDED.price_id,
                     status = EXCLUDED.status,
+                    current_period_start = EXCLUDED.current_period_start,
                     current_period_end = EXCLUDED.current_period_end,
                     cancel_at_period_end = EXCLUDED.cancel_at_period_end,
                     {}
                     updated_at = NOW()
                  RETURNING subscription_id, user_id, provider, customer_id, price_id, status,
-                           current_period_end, cancel_at_period_end, created_at, updated_at,
+                           current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at,
                            pending_downgrade_target_price_id, pending_downgrade_from_price_id,
                            pending_downgrade_expected_period_end, pending_downgrade_status,
                            pending_downgrade_updated_at",
@@ -156,6 +158,7 @@ impl PostgresSubscriptionRepository {
                     &subscription.customer_id,
                     &subscription.price_id,
                     &subscription.status,
+                    &subscription.current_period_start,
                     &subscription.current_period_end,
                     &subscription.cancel_at_period_end,
                     &subscription.pending_downgrade_target_price_id,
@@ -461,6 +464,7 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
                      customer_id = $4,
                      price_id = $5,
                      status = $6,
+                     current_period_start = NULL,
                      current_period_end = $7,
                      cancel_at_period_end = $8,
                      created_at = $9,
@@ -472,7 +476,7 @@ impl SubscriptionRepository for PostgresSubscriptionRepository {
                      updated_at = NOW()
                  WHERE subscription_id = $1
                  RETURNING subscription_id, user_id, provider, customer_id, price_id, status,
-                           current_period_end, cancel_at_period_end, created_at, updated_at,
+                           current_period_start, current_period_end, cancel_at_period_end, created_at, updated_at,
                            pending_downgrade_target_price_id, pending_downgrade_from_price_id,
                            pending_downgrade_expected_period_end, pending_downgrade_status,
                            pending_downgrade_updated_at",

--- a/crates/services/Cargo.toml
+++ b/crates/services/Cargo.toml
@@ -28,7 +28,7 @@ urlencoding = "2.1"
 bytes = "1.5"
 http = "1.0"
 tokio-stream = "0.1"
-tokio-postgres = { version = "0.7", features = ["with-uuid-1"] }
+tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-uuid-1"] }
 deadpool-postgres = "0.14"
 # MCP protocol
 rmcp = { version = "0.6", features = [

--- a/crates/services/src/subscription/near_staking.rs
+++ b/crates/services/src/subscription/near_staking.rs
@@ -124,6 +124,8 @@ struct StorageBalanceOfArgs<'a> {
 pub struct NearStakingSubscription {
     pub subscription_id: String,
     pub price_id: String,
+    #[serde(default, deserialize_with = "deserialize_optional_u64")]
+    pub start_ns: Option<u64>,
     #[serde(deserialize_with = "deserialize_required_u64")]
     pub end_ns: u64,
     #[serde(default)]

--- a/crates/services/src/subscription/near_staking.rs
+++ b/crates/services/src/subscription/near_staking.rs
@@ -380,6 +380,7 @@ pub fn subscription_row_from_chain(
 ) -> Result<Subscription, String> {
     let subscription_id = chain.subscription_id.clone();
     let price_id = chain.price_id.clone();
+    let current_period_start = chain.start_ns.and_then(|ns| ts_ns_to_datetime(ns).ok());
     let current_period_end = ts_ns_to_datetime(chain.end_ns)?;
 
     let status_raw = chain.status.as_deref().unwrap_or("Active");
@@ -443,6 +444,7 @@ pub fn subscription_row_from_chain(
         customer_id: format!("near:{near_account}"),
         price_id,
         status,
+        current_period_start,
         current_period_end,
         cancel_at_period_end,
         created_at: Utc::now(),

--- a/crates/services/src/subscription/ports.rs
+++ b/crates/services/src/subscription/ports.rs
@@ -1367,4 +1367,20 @@ pub struct CreditsSummary {
     pub period_spent_credits: i64,
     /// Plan credit limit (nano-USD).
     pub plan_credits: i64,
+    /// HoS accounting basis for the same cached entitlement observation.
+    pub house_of_stake: Option<HouseOfStakeCreditSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+pub struct HouseOfStakeCreditSnapshot {
+    /// Highest stake already credited in this period. String preserves the full u128 value.
+    pub credited_stake_yocto: String,
+    /// Most recently observed effective stake. String preserves the full u128 value.
+    pub last_observed_stake_yocto: String,
+    /// Earned current-period limit retained by the snapshot, including while effective stake is zero.
+    pub credit_limit_nano_usd: i64,
+    pub period_start: DateTime<Utc>,
+    pub period_end: DateTime<Utc>,
+    pub observed_at: DateTime<Utc>,
 }

--- a/crates/services/src/subscription/ports.rs
+++ b/crates/services/src/subscription/ports.rs
@@ -56,6 +56,7 @@ pub struct Subscription {
     pub customer_id: String,
     pub price_id: String,
     pub status: String,
+    pub current_period_start: Option<DateTime<Utc>>,
     pub current_period_end: DateTime<Utc>,
     pub cancel_at_period_end: bool,
     pub created_at: DateTime<Utc>,

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -63,7 +63,27 @@ struct CachedCreditLimit {
     plan_credits: u64,
     period_start: chrono::DateTime<Utc>,
     period_end: chrono::DateTime<Utc>,
+    scope: CreditLimitCacheScope,
     cached_at: Instant,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CreditLimitCacheScope {
+    provider: Option<String>,
+    subscription_id: Option<String>,
+    price_id: Option<String>,
+    current_period_end: Option<DateTime<Utc>>,
+}
+
+impl CreditLimitCacheScope {
+    fn from_active_subscription(subscription: Option<&Subscription>) -> Self {
+        Self {
+            provider: subscription.map(|sub| sub.provider.clone()),
+            subscription_id: subscription.map(|sub| sub.subscription_id.clone()),
+            price_id: subscription.map(|sub| sub.price_id.clone()),
+            current_period_end: subscription.map(|sub| sub.current_period_end),
+        }
+    }
 }
 
 struct CachedHouseOfStakeRpcFailure {
@@ -222,10 +242,15 @@ fn next_house_of_stake_snapshot(
     (snapshot, effective_limit)
 }
 
-fn credit_limit_cache_is_valid(cached: &CachedCreditLimit, now: DateTime<Utc>) -> bool {
+fn credit_limit_cache_is_valid(
+    cached: &CachedCreditLimit,
+    now: DateTime<Utc>,
+    active_subscription: Option<&Subscription>,
+) -> bool {
     cached.cached_at.elapsed().as_secs() < TTL_CACHE_SECS
         && cached.period_start <= now
         && now < cached.period_end
+        && cached.scope == CreditLimitCacheScope::from_active_subscription(active_subscription)
 }
 
 pub struct SubscriptionServiceImpl {
@@ -1040,8 +1065,11 @@ impl SubscriptionServiceImpl {
         &self,
         user_id: UserId,
     ) -> Result<(i64, chrono::DateTime<Utc>, chrono::DateTime<Utc>), SubscriptionError> {
+        let active_subscription = self
+            .get_active_subscription_for_entitlement(user_id)
+            .await?;
         if let Some(cached) = self.credit_limit_cache.read().await.get(&user_id) {
-            if credit_limit_cache_is_valid(cached, Utc::now()) {
+            if credit_limit_cache_is_valid(cached, Utc::now(), active_subscription.as_ref()) {
                 return Ok((
                     cached.plan_credits.min(i64::MAX as u64) as i64,
                     cached.period_start,
@@ -1059,10 +1087,7 @@ impl SubscriptionServiceImpl {
             .and_then(|c| c.subscription_plans)
             .unwrap_or_default();
 
-        let (plan_credits, period_start, period_end) = match self
-            .get_active_subscription_for_entitlement(user_id)
-            .await?
-        {
+        let (plan_credits, period_start, period_end, cache_scope) = match active_subscription {
             Some(mut sub) => {
                 if sub.provider == "stripe" && Self::should_check_pending_downgrade(&sub) {
                     match self.try_apply_pending_downgrade(&sub.subscription_id).await {
@@ -1092,7 +1117,12 @@ impl SubscriptionServiceImpl {
                 };
                 let period_end = sub.current_period_end;
                 let period_start = sub_one_month_same_day(sub.current_period_end);
-                (plan_credits, period_start, period_end)
+                (
+                    plan_credits,
+                    period_start,
+                    period_end,
+                    CreditLimitCacheScope::from_active_subscription(Some(&sub)),
+                )
             }
             None => {
                 let plan_credits = subscription_plans
@@ -1101,7 +1131,12 @@ impl SubscriptionServiceImpl {
                     .unwrap_or(DEFAULT_MONTHLY_CREDITS_NANO_USD);
                 let (period_start, period_end) =
                     self.resolve_free_plan_period_for_user(user_id).await?;
-                (plan_credits, period_start, period_end)
+                (
+                    plan_credits,
+                    period_start,
+                    period_end,
+                    CreditLimitCacheScope::from_active_subscription(None),
+                )
             }
         };
 
@@ -1111,6 +1146,7 @@ impl SubscriptionServiceImpl {
                 plan_credits,
                 period_start,
                 period_end,
+                scope: cache_scope,
                 cached_at: Instant::now(),
             },
         );
@@ -4767,12 +4803,20 @@ mod tests {
             plan_credits: 1,
             period_start: now - Duration::days(1),
             period_end: now + Duration::days(1),
+            scope: CreditLimitCacheScope::from_active_subscription(None),
             cached_at: Instant::now(),
         };
-        assert!(credit_limit_cache_is_valid(&cached, now));
+        assert!(credit_limit_cache_is_valid(&cached, now, None));
+
+        let subscription = base_subscription();
+        assert!(!credit_limit_cache_is_valid(
+            &cached,
+            now,
+            Some(&subscription)
+        ));
 
         cached.period_end = now;
-        assert!(!credit_limit_cache_is_valid(&cached, now));
+        assert!(!credit_limit_cache_is_valid(&cached, now, None));
     }
 
     fn base_subscription() -> Subscription {

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -75,6 +75,7 @@ struct HouseOfStakeSnapshot {
     credited_stake_yocto: u128,
     last_observed_stake_yocto: u128,
     credit_limit_nano_usd: u64,
+    observed_at: DateTime<Utc>,
 }
 
 /// Cached system configs snapshot for model access checks.
@@ -112,49 +113,119 @@ fn parse_snapshot_stake(value: &str) -> Result<u128, SubscriptionError> {
     })
 }
 
+fn stake_for_credit_floor(rate: u64, credit_floor_nano_usd: u64) -> Option<u128> {
+    if rate == 0 {
+        return None;
+    }
+    Some(
+        (credit_floor_nano_usd as u128)
+            .saturating_mul(YOCTO_PER_NEAR)
+            .saturating_add(rate as u128 - 1)
+            / rate as u128,
+    )
+}
+
+fn prorated_credit_delta(
+    full_period_delta: u64,
+    period_start: DateTime<Utc>,
+    period_end: DateTime<Utc>,
+    observed_at: DateTime<Utc>,
+) -> u64 {
+    let total_seconds = period_end
+        .signed_duration_since(period_start)
+        .num_seconds()
+        .max(1) as u128;
+    let remaining_seconds = period_end
+        .signed_duration_since(observed_at.max(period_start))
+        .num_seconds()
+        .clamp(0, total_seconds as i64) as u128;
+    ((full_period_delta as u128).saturating_mul(remaining_seconds) / total_seconds)
+        .min(u64::MAX as u128) as u64
+}
+
 fn next_house_of_stake_snapshot(
     current: Option<HouseOfStakeSnapshot>,
     previous_observed_stake_yocto: Option<u128>,
     observed_stake_yocto: u128,
     rate: u64,
-    period_start: DateTime<Utc>,
-    period_end: DateTime<Utc>,
+    period: &BillingPeriod,
     observed_at: DateTime<Utc>,
+    credit_floor_nano_usd: Option<u64>,
 ) -> (HouseOfStakeSnapshot, u64) {
-    let mut snapshot = current.unwrap_or_else(|| {
-        let baseline = previous_observed_stake_yocto.unwrap_or(observed_stake_yocto);
-        HouseOfStakeSnapshot {
-            credited_stake_yocto: baseline,
-            last_observed_stake_yocto: baseline,
-            credit_limit_nano_usd: stake_credits_at_rate(rate, baseline),
+    if let Some(snapshot) = current {
+        if observed_at < snapshot.observed_at {
+            let effective_limit = if snapshot.last_observed_stake_yocto == 0 {
+                0
+            } else {
+                snapshot.credit_limit_nano_usd
+            };
+            return (snapshot, effective_limit);
         }
-    });
+    }
+
+    let floor_stake = credit_floor_nano_usd
+        .and_then(|floor| stake_for_credit_floor(rate, floor))
+        .unwrap_or(0);
+    let mut snapshot = match current {
+        Some(mut snapshot) => {
+            snapshot.credited_stake_yocto = snapshot.credited_stake_yocto.max(floor_stake);
+            snapshot.credit_limit_nano_usd = snapshot
+                .credit_limit_nano_usd
+                .max(credit_floor_nano_usd.unwrap_or(0));
+            snapshot
+        }
+        None => {
+            let baseline = previous_observed_stake_yocto
+                .unwrap_or(observed_stake_yocto)
+                .max(floor_stake);
+            let stake_limit = stake_credits_at_rate(rate, baseline);
+            let credit_limit_nano_usd = match credit_floor_nano_usd {
+                Some(floor) => floor.saturating_add(prorated_credit_delta(
+                    stake_limit.saturating_sub(floor),
+                    period.start_at,
+                    period.end_at,
+                    observed_at,
+                )),
+                None => stake_limit,
+            };
+            HouseOfStakeSnapshot {
+                credited_stake_yocto: baseline,
+                last_observed_stake_yocto: observed_stake_yocto,
+                credit_limit_nano_usd,
+                observed_at,
+            }
+        }
+    };
 
     if observed_stake_yocto > snapshot.credited_stake_yocto {
-        let total_seconds = period_end
-            .signed_duration_since(period_start)
-            .num_seconds()
-            .max(1) as u128;
-        let remaining_seconds = period_end
-            .signed_duration_since(observed_at.max(period_start))
-            .num_seconds()
-            .clamp(0, total_seconds as i64) as u128;
         let delta =
-            stake_credits_at_rate(rate, observed_stake_yocto - snapshot.credited_stake_yocto)
-                as u128;
-        snapshot.credit_limit_nano_usd = snapshot
-            .credit_limit_nano_usd
-            .saturating_add((delta * remaining_seconds / total_seconds) as u64);
+            stake_credits_at_rate(rate, observed_stake_yocto - snapshot.credited_stake_yocto);
+        snapshot.credit_limit_nano_usd =
+            snapshot
+                .credit_limit_nano_usd
+                .saturating_add(prorated_credit_delta(
+                    delta,
+                    period.start_at,
+                    period.end_at,
+                    observed_at,
+                ));
         snapshot.credited_stake_yocto = observed_stake_yocto;
     }
     snapshot.last_observed_stake_yocto = observed_stake_yocto;
+    snapshot.observed_at = observed_at;
 
-    let effective_limit = if observed_stake_yocto == 0 {
+    let effective_limit = if snapshot.last_observed_stake_yocto == 0 {
         0
     } else {
         snapshot.credit_limit_nano_usd
     };
     (snapshot, effective_limit)
+}
+
+fn credit_limit_cache_is_valid(cached: &CachedCreditLimit, now: DateTime<Utc>) -> bool {
+    cached.cached_at.elapsed().as_secs() < TTL_CACHE_SECS
+        && cached.period_start <= now
+        && now < cached.period_end
 }
 
 pub struct SubscriptionServiceImpl {
@@ -970,7 +1041,7 @@ impl SubscriptionServiceImpl {
         user_id: UserId,
     ) -> Result<(i64, chrono::DateTime<Utc>, chrono::DateTime<Utc>), SubscriptionError> {
         if let Some(cached) = self.credit_limit_cache.read().await.get(&user_id) {
-            if cached.cached_at.elapsed().as_secs() < TTL_CACHE_SECS {
+            if credit_limit_cache_is_valid(cached, Utc::now()) {
                 return Ok((
                     cached.plan_credits.min(i64::MAX as u64) as i64,
                     cached.period_start,
@@ -1080,6 +1151,40 @@ impl SubscriptionServiceImpl {
         Some(stake_credits_at_rate(rate, lock_amount_yocto))
     }
 
+    fn fixed_to_stake_based_credit_floor(
+        local_subscriptions: &[Subscription],
+        chain_subscription: &Subscription,
+        subscription_plans: &HashMap<String, SubscriptionPlanConfig>,
+    ) -> Option<(u64, u64)> {
+        let target_plan_name = resolve_plan_name_from_config(
+            &chain_subscription.provider,
+            &chain_subscription.price_id,
+            subscription_plans,
+        )?;
+        let rate = subscription_plans
+            .get(&target_plan_name)?
+            .stake_based_monthly_credits
+            .as_ref()?
+            .credits_per_staked_near_nano_usd?;
+        let local = local_subscriptions.iter().find(|sub| {
+            sub.provider == "house-of-stake"
+                && sub.subscription_id == chain_subscription.subscription_id
+                && sub.price_id != chain_subscription.price_id
+                && sub.current_period_end.timestamp()
+                    == chain_subscription.current_period_end.timestamp()
+                && Self::is_active_or_trialing(&sub.status)
+        })?;
+        let local_plan_name =
+            resolve_plan_name_from_config(&local.provider, &local.price_id, subscription_plans)?;
+        let local_plan = subscription_plans.get(&local_plan_name)?;
+        local_plan
+            .stake_based_monthly_credits
+            .as_ref()
+            .and_then(|config| config.credits_per_staked_near_nano_usd)
+            .is_none()
+            .then(|| (Self::plan_limit_max(local_plan), rate))
+    }
+
     async fn current_house_of_stake_snapshot_limit(
         &self,
         subscription: &Subscription,
@@ -1144,6 +1249,7 @@ impl SubscriptionServiceImpl {
         subscription: &Subscription,
         rate: u64,
         observed_stake_yocto: u128,
+        credit_floor_nano_usd: Option<u64>,
     ) -> Result<u64, SubscriptionError> {
         let period_end = subscription.current_period_end;
         let period_start = sub_one_month_same_day(period_end);
@@ -1168,7 +1274,8 @@ impl SubscriptionServiceImpl {
         let current = txn
             .query_opt(
                 r#"
-                SELECT credited_stake_yocto, last_observed_stake_yocto, credit_limit_nano_usd
+                SELECT credited_stake_yocto, last_observed_stake_yocto,
+                       credit_limit_nano_usd, observed_at
                 FROM house_of_stake_credit_entitlement_snapshots
                 WHERE subscription_id = $1 AND period_start = $2 AND period_end = $3
                 FOR UPDATE
@@ -1184,6 +1291,7 @@ impl SubscriptionServiceImpl {
                         row.get("last_observed_stake_yocto"),
                     )?,
                     credit_limit_nano_usd: row.get::<_, i64>("credit_limit_nano_usd").max(0) as u64,
+                    observed_at: row.get("observed_at"),
                 })
             })
             .transpose()?;
@@ -1212,9 +1320,12 @@ impl SubscriptionServiceImpl {
             previous_observed,
             observed_stake_yocto,
             rate,
-            period_start,
-            period_end,
+            &BillingPeriod {
+                start_at: period_start,
+                end_at: period_end,
+            },
             observed_at,
+            credit_floor_nano_usd,
         );
         let credited_stake = snapshot.credited_stake_yocto.to_string();
         let observed_stake = snapshot.last_observed_stake_yocto.to_string();
@@ -1238,7 +1349,7 @@ impl SubscriptionServiceImpl {
                 &credited_stake,
                 &observed_stake,
                 &stored_limit,
-                &observed_at,
+                &snapshot.observed_at,
             ],
         )
         .await
@@ -1331,6 +1442,12 @@ impl SubscriptionServiceImpl {
             }
         };
 
+        if chain_sub.subscription_id != subscription.subscription_id {
+            return Err(SubscriptionError::InternalError(
+                "HoS subscription changed on chain; sync is required".to_string(),
+            ));
+        }
+
         let status_lower = chain_sub
             .status
             .as_deref()
@@ -1342,7 +1459,7 @@ impl SubscriptionServiceImpl {
             .unwrap_or(u64::MAX);
         if status_lower != "active" || chain_sub.end_ns <= now_ns {
             return self
-                .reconcile_house_of_stake_snapshot(subscription, rate, 0)
+                .reconcile_house_of_stake_snapshot(subscription, rate, 0, None)
                 .await
                 .map(Some);
         }
@@ -1383,7 +1500,7 @@ impl SubscriptionServiceImpl {
             0
         };
         let limit = self
-            .reconcile_house_of_stake_snapshot(subscription, rate, observed_stake)
+            .reconcile_house_of_stake_snapshot(subscription, rate, observed_stake, None)
             .await?;
         self.house_of_stake_rpc_failure_cache
             .write()
@@ -1872,6 +1989,9 @@ impl SubscriptionServiceImpl {
         let chain_subscription = raw.as_ref().expect("checked is_some");
         let row = subscription_row_from_chain(user_id, &near_account, chain_subscription)
             .map_err(SubscriptionError::InternalError)?;
+        let fixed_to_stake_floor = Self::is_active_or_trialing(&row.status)
+            .then(|| Self::fixed_to_stake_based_credit_floor(&subs, &row, &subscription_plans))
+            .flatten();
 
         // Do not insert/update an active HoS row while a non-HoS subscription is active/trialing locally:
         // `get_active_subscription` picks newest `created_at`, so a fresh HoS upsert could wrongly
@@ -1925,6 +2045,37 @@ impl SubscriptionServiceImpl {
                 false,
                 Some(NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS),
             ));
+        }
+
+        if let Some((credit_floor, rate)) = fixed_to_stake_floor {
+            let last_lock_id = chain_subscription
+                .last_lock_id
+                .as_deref()
+                .filter(|id| !id.trim().is_empty())
+                .ok_or_else(|| {
+                    SubscriptionError::InternalError(
+                        "cannot seed HoS credit floor: last lock missing".to_string(),
+                    )
+                })?;
+            let lock = view_get_effective_lock(&self.near_rpc_url, &contract_id, last_lock_id)
+                .await
+                .map_err(Self::near_rpc_err)?
+                .ok_or_else(|| {
+                    SubscriptionError::InternalError(
+                        "cannot seed HoS credit floor: lock missing".to_string(),
+                    )
+                })?;
+            let observed_stake = if lock_has_active_shares(&lock) {
+                lock_amount_yocto(&lock).ok_or_else(|| {
+                    SubscriptionError::InternalError(
+                        "cannot seed HoS credit floor: invalid lock amount".to_string(),
+                    )
+                })?
+            } else {
+                0
+            };
+            self.reconcile_house_of_stake_snapshot(&row, rate, observed_stake, Some(credit_floor))
+                .await?;
         }
 
         let mut db_client = self
@@ -4467,10 +4618,15 @@ mod tests {
         let start = Utc.with_ymd_and_hms(2026, 8, 1, 0, 0, 0).unwrap();
         let end = start + Duration::days(30);
         let halfway = start + Duration::days(15);
+        let period = BillingPeriod {
+            start_at: start,
+            end_at: end,
+        };
         let baseline = HouseOfStakeSnapshot {
             credited_stake_yocto: 10 * YOCTO_PER_NEAR,
             last_observed_stake_yocto: 10 * YOCTO_PER_NEAR,
             credit_limit_nano_usd: 10_000_000_000,
+            observed_at: start,
         };
 
         let (increased, limit) = next_house_of_stake_snapshot(
@@ -4478,9 +4634,9 @@ mod tests {
             None,
             20 * YOCTO_PER_NEAR,
             1_000_000_000,
-            start,
-            end,
+            &period,
             halfway,
+            None,
         );
         assert_eq!(limit, 15_000_000_000);
 
@@ -4489,9 +4645,9 @@ mod tests {
             None,
             5 * YOCTO_PER_NEAR,
             1_000_000_000,
-            start,
-            end,
+            &period,
             halfway,
+            None,
         );
         assert_eq!(limit, 15_000_000_000);
         assert_eq!(decreased.credited_stake_yocto, 20 * YOCTO_PER_NEAR);
@@ -4503,15 +4659,19 @@ mod tests {
         let start = Utc.with_ymd_and_hms(2026, 9, 1, 0, 0, 0).unwrap();
         let end = start + Duration::days(30);
         let halfway = start + Duration::days(15);
+        let period = BillingPeriod {
+            start_at: start,
+            end_at: end,
+        };
 
         let (snapshot, limit) = next_house_of_stake_snapshot(
             None,
             Some(10 * YOCTO_PER_NEAR),
             20 * YOCTO_PER_NEAR,
             1_000_000_000,
-            start,
-            end,
+            &period,
             halfway,
+            None,
         );
         assert_eq!(limit, 15_000_000_000);
 
@@ -4520,13 +4680,99 @@ mod tests {
             None,
             0,
             1_000_000_000,
-            start,
-            end,
+            &period,
             halfway,
+            None,
         );
         assert_eq!(limit, 0);
         assert_eq!(zero.last_observed_stake_yocto, 0);
         assert_eq!(zero.credit_limit_nano_usd, 15_000_000_000);
+    }
+
+    #[test]
+    fn test_house_of_stake_snapshot_applies_fixed_plan_floor() {
+        let start = Utc.with_ymd_and_hms(2026, 10, 1, 0, 0, 0).unwrap();
+        let end = start + Duration::days(30);
+        let halfway = start + Duration::days(15);
+        let period = BillingPeriod {
+            start_at: start,
+            end_at: end,
+        };
+
+        let (first, limit) = next_house_of_stake_snapshot(
+            None,
+            None,
+            15 * YOCTO_PER_NEAR,
+            1_000_000_000,
+            &period,
+            halfway,
+            Some(5_000_000_000),
+        );
+        assert_eq!(limit, 10_000_000_000);
+
+        let existing = HouseOfStakeSnapshot {
+            credited_stake_yocto: 3 * YOCTO_PER_NEAR,
+            last_observed_stake_yocto: 3 * YOCTO_PER_NEAR,
+            credit_limit_nano_usd: 3_000_000_000,
+            observed_at: start,
+        };
+        let (resumed, limit) = next_house_of_stake_snapshot(
+            Some(existing),
+            None,
+            15 * YOCTO_PER_NEAR,
+            1_000_000_000,
+            &period,
+            halfway,
+            Some(5_000_000_000),
+        );
+        assert_eq!(limit, 10_000_000_000);
+        assert_eq!(resumed.credited_stake_yocto, 15 * YOCTO_PER_NEAR);
+        assert_eq!(first.credit_limit_nano_usd, resumed.credit_limit_nano_usd);
+    }
+
+    #[test]
+    fn test_house_of_stake_snapshot_ignores_out_of_order_observation() {
+        let start = Utc.with_ymd_and_hms(2026, 11, 1, 0, 0, 0).unwrap();
+        let end = start + Duration::days(30);
+        let newer_observed_at = start + Duration::days(15);
+        let period = BillingPeriod {
+            start_at: start,
+            end_at: end,
+        };
+        let current = HouseOfStakeSnapshot {
+            credited_stake_yocto: 20 * YOCTO_PER_NEAR,
+            last_observed_stake_yocto: 20 * YOCTO_PER_NEAR,
+            credit_limit_nano_usd: 20_000_000_000,
+            observed_at: newer_observed_at,
+        };
+
+        let (unchanged, limit) = next_house_of_stake_snapshot(
+            Some(current),
+            None,
+            0,
+            1_000_000_000,
+            &period,
+            newer_observed_at - Duration::seconds(1),
+            None,
+        );
+
+        assert_eq!(unchanged, current);
+        assert_eq!(limit, 20_000_000_000);
+    }
+
+    #[test]
+    fn test_credit_limit_cache_expires_at_period_boundary() {
+        let now = Utc.with_ymd_and_hms(2026, 12, 1, 0, 0, 0).unwrap();
+        let mut cached = CachedCreditLimit {
+            plan_credits: 1,
+            period_start: now - Duration::days(1),
+            period_end: now + Duration::days(1),
+            cached_at: Instant::now(),
+        };
+        assert!(credit_limit_cache_is_valid(&cached, now));
+
+        cached.period_end = now;
+        assert!(!credit_limit_cache_is_valid(&cached, now));
     }
 
     fn base_subscription() -> Subscription {

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -109,6 +109,15 @@ fn ns_to_datetime(ns: u64) -> Option<DateTime<Utc>> {
     DateTime::from_timestamp((ns / 1_000_000_000) as i64, (ns % 1_000_000_000) as u32)
 }
 
+fn persisted_house_of_stake_period(subscription: &Subscription) -> Option<BillingPeriod> {
+    subscription
+        .current_period_start
+        .map(|start_at| BillingPeriod {
+            start_at,
+            end_at: subscription.current_period_end,
+        })
+}
+
 /// Cached system configs snapshot for model access checks.
 struct CachedSystemConfigs {
     configs: Option<Arc<SystemConfigs>>,
@@ -1060,6 +1069,7 @@ impl SubscriptionServiceImpl {
             customer_id: stripe_sub.customer_id.clone(),
             price_id: stripe_sub.price_id.clone(),
             status: stripe_sub.status.clone(),
+            current_period_start: None,
             current_period_end: stripe_sub.current_period_end,
             cancel_at_period_end: stripe_sub.cancel_at_period_end,
             created_at: chrono::Utc::now(),
@@ -1119,15 +1129,24 @@ impl SubscriptionServiceImpl {
                     &sub.price_id,
                     &subscription_plans,
                 );
-                let stake_entitlement = match plan_name.as_deref() {
-                    Some(name) => match subscription_plans.get(name) {
-                        Some(plan_config) => {
-                            self.stake_based_plan_limit_max(user_id, &sub, plan_config)
-                                .await?
-                        }
-                        None => None,
-                    },
-                    None => None,
+                let plan_config = plan_name
+                    .as_deref()
+                    .and_then(|name| subscription_plans.get(name));
+                let is_stake_based = plan_config.is_some_and(|plan| {
+                    plan.stake_based_monthly_credits
+                        .as_ref()
+                        .and_then(|credits| credits.credits_per_staked_near_nano_usd)
+                        .is_some()
+                });
+                let stake_entitlement = if is_stake_based {
+                    self.stake_based_plan_limit_max(
+                        user_id,
+                        &sub,
+                        plan_config.expect("stake-based plan config exists"),
+                    )
+                    .await?
+                } else {
+                    None
                 };
                 let fallback_period = BillingPeriod {
                     start_at: sub_one_month_same_day(sub.current_period_end),
@@ -1138,14 +1157,23 @@ impl SubscriptionServiceImpl {
                         cacheable = !entitlement.is_fallback;
                         (entitlement.plan_credits, entitlement.period)
                     }
-                    None => (
-                        plan_name
-                            .as_deref()
-                            .and_then(|name| subscription_plans.get(name))
-                            .map(Self::plan_limit_max)
-                            .unwrap_or(DEFAULT_MONTHLY_CREDITS_NANO_USD),
-                        fallback_period,
-                    ),
+                    None => {
+                        let period = if sub.provider == "house-of-stake" && plan_config.is_some() {
+                            let (period, is_fallback) = self
+                                .resolve_fixed_house_of_stake_period(user_id, &mut sub)
+                                .await?;
+                            cacheable = !is_fallback;
+                            period
+                        } else {
+                            fallback_period
+                        };
+                        (
+                            plan_config
+                                .map(Self::plan_limit_max)
+                                .unwrap_or(DEFAULT_MONTHLY_CREDITS_NANO_USD),
+                            period,
+                        )
+                    }
                 };
                 if sub.provider == "house-of-stake" {
                     house_of_stake = self.current_house_of_stake_snapshot(&sub, &period).await?;
@@ -1395,6 +1423,128 @@ impl SubscriptionServiceImpl {
             && period_end.signed_duration_since(period_start) > Duration::zero()
             && period_end.signed_duration_since(period_start)
                 <= Duration::days(HOUSE_OF_STAKE_MAX_CHAIN_PERIOD_DAYS)
+    }
+
+    async fn fixed_house_of_stake_period_fallback(
+        &self,
+        user_id: UserId,
+        subscription: &Subscription,
+    ) -> Result<(BillingPeriod, bool), SubscriptionError> {
+        self.house_of_stake_rpc_failure_cache.write().await.insert(
+            user_id,
+            CachedHouseOfStakeRpcFailure {
+                failed_at: Instant::now(),
+            },
+        );
+        let period = persisted_house_of_stake_period(subscription).ok_or_else(|| {
+            SubscriptionError::InternalError(
+                "HoS billing period is temporarily unavailable".to_string(),
+            )
+        })?;
+        if !Self::is_valid_house_of_stake_chain_period(period.start_at, period.end_at, Utc::now()) {
+            return Err(SubscriptionError::InternalError(
+                "HoS billing period is temporarily unavailable".to_string(),
+            ));
+        }
+        Ok((period, true))
+    }
+
+    async fn resolve_fixed_house_of_stake_period(
+        &self,
+        user_id: UserId,
+        subscription: &mut Subscription,
+    ) -> Result<(BillingPeriod, bool), SubscriptionError> {
+        if self
+            .house_of_stake_rpc_failure_cache
+            .read()
+            .await
+            .get(&user_id)
+            .is_some_and(|cached| {
+                cached.failed_at.elapsed().as_secs() < HOUSE_OF_STAKE_RPC_FAILURE_TTL_SECS
+            })
+        {
+            return self
+                .fixed_house_of_stake_period_fallback(user_id, subscription)
+                .await;
+        }
+
+        let Some(contract_id) = self.near_staking_contract_id.as_deref().map(str::trim) else {
+            return self
+                .fixed_house_of_stake_period_fallback(user_id, subscription)
+                .await;
+        };
+        if contract_id.is_empty() {
+            return self
+                .fixed_house_of_stake_period_fallback(user_id, subscription)
+                .await;
+        }
+        let near_account = match self.get_near_account_id(user_id).await {
+            Ok(account) => account,
+            Err(_) => {
+                return self
+                    .fixed_house_of_stake_period_fallback(user_id, subscription)
+                    .await
+            }
+        };
+        let chain_sub = match view_get_subscription_for_price(
+            &self.near_rpc_url,
+            contract_id,
+            &near_account,
+            &subscription.price_id,
+        )
+        .await
+        {
+            Ok(Some(chain_sub)) => chain_sub,
+            Ok(None) | Err(_) => {
+                return self
+                    .fixed_house_of_stake_period_fallback(user_id, subscription)
+                    .await
+            }
+        };
+        if chain_sub.subscription_id != subscription.subscription_id {
+            return Err(SubscriptionError::InternalError(
+                "HoS subscription changed on chain; sync is required".to_string(),
+            ));
+        }
+
+        let now = Utc::now();
+        let period = chain_sub
+            .start_ns
+            .and_then(ns_to_datetime)
+            .zip(ns_to_datetime(chain_sub.end_ns))
+            .filter(|(start, end)| Self::is_valid_house_of_stake_chain_period(*start, *end, now))
+            .map(|(start_at, end_at)| BillingPeriod { start_at, end_at })
+            .ok_or_else(|| {
+                SubscriptionError::InternalError("HoS billing period is invalid".to_string())
+            })?;
+
+        if subscription.current_period_start != Some(period.start_at)
+            || subscription.current_period_end != period.end_at
+        {
+            subscription.current_period_start = Some(period.start_at);
+            subscription.current_period_end = period.end_at;
+            let mut client = self
+                .db_pool
+                .get()
+                .await
+                .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
+            let txn = client
+                .transaction()
+                .await
+                .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
+            self.subscription_repo
+                .upsert_subscription(&txn, subscription.clone())
+                .await
+                .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
+            txn.commit()
+                .await
+                .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
+        }
+        self.house_of_stake_rpc_failure_cache
+            .write()
+            .await
+            .remove(&user_id);
+        Ok((period, false))
     }
 
     async fn reconcile_house_of_stake_snapshot(
@@ -4094,6 +4244,7 @@ impl SubscriptionService for SubscriptionServiceImpl {
             customer_id,
             price_id: price_id.clone(),
             status: "active".to_string(),
+            current_period_start: None,
             current_period_end,
             cancel_at_period_end: false,
             created_at: chrono::Utc::now(),
@@ -4940,6 +5091,20 @@ mod tests {
     }
 
     #[test]
+    fn test_persisted_house_of_stake_period_preserves_month_end_start() {
+        let mut subscription = base_subscription();
+        subscription.provider = "house-of-stake".to_string();
+        subscription.current_period_start =
+            Some(Utc.with_ymd_and_hms(2026, 1, 31, 0, 0, 0).unwrap());
+        subscription.current_period_end = Utc.with_ymd_and_hms(2026, 2, 28, 0, 0, 0).unwrap();
+
+        let period = persisted_house_of_stake_period(&subscription).unwrap();
+
+        assert_eq!(period.start_at.day(), 31);
+        assert_eq!(period.end_at.day(), 28);
+    }
+
+    #[test]
     fn test_house_of_stake_snapshot_applies_fixed_plan_floor() {
         let start = Utc.with_ymd_and_hms(2026, 10, 1, 0, 0, 0).unwrap();
         let end = start + Duration::days(30);
@@ -5043,6 +5208,7 @@ mod tests {
             customer_id: "cus_test".to_string(),
             price_id: "price_basic".to_string(),
             status: "active".to_string(),
+            current_period_start: None,
             current_period_end: period_end,
             cancel_at_period_end: false,
             created_at: Utc::now(),

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -3780,7 +3780,7 @@ impl SubscriptionService for SubscriptionServiceImpl {
             return Err(SubscriptionError::NoActiveSubscription);
         }
 
-        // The shared resolver owns the 10-minute plan cache, including HoS RPC results.
+        // 1. Get plan credits (monthly_credits) from the shared resolver. Cache 10 mins.
         let (plan_credits, period_start, period_end) =
             self.resolve_plan_period_for_user(user_id).await?;
         let plan_credits = plan_credits.max(0) as u64;

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -7,13 +7,13 @@ use super::near_staking::{
 use super::ports::{
     BillingCycleAnchor, BillingPeriod, CancelSubscriptionOutcome, ChangePlanOutcome,
     CreateCreditPurchaseOutcome, CreateSubscriptionOutcome, CreditsRepository, CreditsSummary,
-    DowngradeIntentStatus, NearStakingStorageIntent, NearStakingSyncSummary, PaymentBehavior,
-    PaymentWebhookRepository, ProrationBehavior, ResumeSubscriptionOutcome, StripeClientPort,
-    StripeCreateCreditsCheckoutParams, StripeCreateSubscriptionCheckoutParams,
-    StripeCustomerRepository, StripeSubscriptionSnapshot, StripeUpdateSubscriptionParams,
-    Subscription, SubscriptionError, SubscriptionPlan, SubscriptionReplacement,
-    SubscriptionRepository, SubscriptionService, SubscriptionWithPlan, DEFAULT_MONTHLY_TOKEN_LIMIT,
-    NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS,
+    DowngradeIntentStatus, HouseOfStakeCreditSnapshot, NearStakingStorageIntent,
+    NearStakingSyncSummary, PaymentBehavior, PaymentWebhookRepository, ProrationBehavior,
+    ResumeSubscriptionOutcome, StripeClientPort, StripeCreateCreditsCheckoutParams,
+    StripeCreateSubscriptionCheckoutParams, StripeCustomerRepository, StripeSubscriptionSnapshot,
+    StripeUpdateSubscriptionParams, Subscription, SubscriptionError, SubscriptionPlan,
+    SubscriptionReplacement, SubscriptionRepository, SubscriptionService, SubscriptionWithPlan,
+    DEFAULT_MONTHLY_TOKEN_LIMIT, NEAR_STAKING_SYNC_SKIPPED_REASON_UPSERT_BLOCKED_NON_HOS,
 };
 use crate::agent::ports::AgentRepository;
 use crate::agent::ports::AgentService;
@@ -63,6 +63,7 @@ struct CachedCreditLimit {
     plan_credits: u64,
     period_start: chrono::DateTime<Utc>,
     period_end: chrono::DateTime<Utc>,
+    house_of_stake: Option<HouseOfStakeCreditSnapshot>,
     scope: CreditLimitCacheScope,
     cached_at: Instant,
 }
@@ -1087,6 +1088,7 @@ impl SubscriptionServiceImpl {
             .and_then(|c| c.subscription_plans)
             .unwrap_or_default();
 
+        let mut house_of_stake = None;
         let (plan_credits, period_start, period_end, cache_scope) = match active_subscription {
             Some(mut sub) => {
                 if sub.provider == "stripe" && Self::should_check_pending_downgrade(&sub) {
@@ -1117,6 +1119,9 @@ impl SubscriptionServiceImpl {
                 };
                 let period_end = sub.current_period_end;
                 let period_start = sub_one_month_same_day(sub.current_period_end);
+                if sub.provider == "house-of-stake" {
+                    house_of_stake = self.current_house_of_stake_snapshot(&sub).await?;
+                }
                 (
                     plan_credits,
                     period_start,
@@ -1146,6 +1151,7 @@ impl SubscriptionServiceImpl {
                 plan_credits,
                 period_start,
                 period_end,
+                house_of_stake,
                 scope: cache_scope,
                 cached_at: Instant::now(),
             },
@@ -1221,6 +1227,40 @@ impl SubscriptionServiceImpl {
             .then(|| (Self::plan_limit_max(local_plan), rate))
     }
 
+    async fn current_house_of_stake_snapshot(
+        &self,
+        subscription: &Subscription,
+    ) -> Result<Option<HouseOfStakeCreditSnapshot>, SubscriptionError> {
+        let period_end = subscription.current_period_end;
+        let period_start = sub_one_month_same_day(period_end);
+        let client = self
+            .db_pool
+            .get()
+            .await
+            .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
+        let row = client
+            .query_opt(
+                r#"
+                SELECT credited_stake_yocto, last_observed_stake_yocto,
+                       credit_limit_nano_usd, period_start, period_end, observed_at
+                FROM house_of_stake_credit_entitlement_snapshots
+                WHERE subscription_id = $1 AND period_start = $2 AND period_end = $3
+                "#,
+                &[&subscription.subscription_id, &period_start, &period_end],
+            )
+            .await
+            .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
+
+        Ok(row.map(|row| HouseOfStakeCreditSnapshot {
+            credited_stake_yocto: row.get("credited_stake_yocto"),
+            last_observed_stake_yocto: row.get("last_observed_stake_yocto"),
+            credit_limit_nano_usd: row.get("credit_limit_nano_usd"),
+            period_start: row.get("period_start"),
+            period_end: row.get("period_end"),
+            observed_at: row.get("observed_at"),
+        }))
+    }
+
     async fn current_house_of_stake_snapshot_limit(
         &self,
         subscription: &Subscription,
@@ -1243,7 +1283,6 @@ impl SubscriptionServiceImpl {
             )
             .await
             .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
-
         row.map(|row| {
             let observed = parse_snapshot_stake(row.get("last_observed_stake_yocto"))?;
             let limit = row.get::<_, i64>("credit_limit_nano_usd").max(0) as u64;
@@ -4436,6 +4475,12 @@ impl SubscriptionService for SubscriptionServiceImpl {
             .get_purchased_breakdown(user_id)
             .await
             .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
+        let house_of_stake = self
+            .credit_limit_cache
+            .read()
+            .await
+            .get(&user_id)
+            .and_then(|cached| cached.house_of_stake.clone());
 
         Ok(CreditsSummary {
             balance,
@@ -4443,6 +4488,7 @@ impl SubscriptionService for SubscriptionServiceImpl {
             spent_purchased_nano_usd,
             period_spent_credits,
             plan_credits,
+            house_of_stake,
         })
     }
 
@@ -4803,6 +4849,7 @@ mod tests {
             plan_credits: 1,
             period_start: now - Duration::days(1),
             period_end: now + Duration::days(1),
+            house_of_stake: None,
             scope: CreditLimitCacheScope::from_active_subscription(None),
             cached_at: Instant::now(),
         };

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -66,11 +66,15 @@ struct CachedCreditLimit {
     cached_at: Instant,
 }
 
-/// Cached House-of-Stake stake source. Invalid after short TTL or when the user's credit-limit cache is invalidated.
-struct CachedHouseOfStakeStakeSource {
-    last_lock_id: String,
-    amount_yocto: u128,
-    cached_at: Instant,
+struct CachedHouseOfStakeRpcFailure {
+    failed_at: Instant,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct HouseOfStakeSnapshot {
+    credited_stake_yocto: u128,
+    last_observed_stake_yocto: u128,
+    credit_limit_nano_usd: u64,
 }
 
 /// Cached system configs snapshot for model access checks.
@@ -81,8 +85,7 @@ struct CachedSystemConfigs {
 
 const TTL_CACHE_SECS: u64 = 600; // 10 minutes
 const SYSTEM_CONFIGS_TTL_CACHE_SECS: u64 = 60; // 1 minute
-/// Upper bound for cached HoS stake sources; invalidate_credit_limit_cache also clears this on subscription, credit, and sync changes.
-const HOUSE_OF_STAKE_STAKE_SOURCE_TTL_SECS: u64 = 60;
+const HOUSE_OF_STAKE_RPC_FAILURE_TTL_SECS: u64 = 60;
 /// Default monthly credits when plan has no monthly_credits config. 1 USD in nano-dollars ($1 = 1_000_000_000).
 const DEFAULT_MONTHLY_CREDITS_NANO_USD: u64 = 1_000_000_000;
 const YOCTO_PER_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
@@ -95,6 +98,64 @@ const TX_LOCK_TIMEOUT_MS: i64 = 1500;
 const SUBSCRIPTION_STATUS_ACTIVE: &str = "active";
 const SUBSCRIPTION_STATUS_TRIALING: &str = "trialing";
 const SUBSCRIPTION_STATUS_CANCELED: &str = "canceled";
+
+fn stake_credits_at_rate(rate: u64, stake_yocto: u128) -> u64 {
+    stake_yocto
+        .saturating_mul(rate as u128)
+        .saturating_div(YOCTO_PER_NEAR)
+        .min(u64::MAX as u128) as u64
+}
+
+fn parse_snapshot_stake(value: &str) -> Result<u128, SubscriptionError> {
+    value.parse::<u128>().map_err(|_| {
+        SubscriptionError::DatabaseError("invalid HoS stake snapshot value".to_string())
+    })
+}
+
+fn next_house_of_stake_snapshot(
+    current: Option<HouseOfStakeSnapshot>,
+    previous_observed_stake_yocto: Option<u128>,
+    observed_stake_yocto: u128,
+    rate: u64,
+    period_start: DateTime<Utc>,
+    period_end: DateTime<Utc>,
+    observed_at: DateTime<Utc>,
+) -> (HouseOfStakeSnapshot, u64) {
+    let mut snapshot = current.unwrap_or_else(|| {
+        let baseline = previous_observed_stake_yocto.unwrap_or(observed_stake_yocto);
+        HouseOfStakeSnapshot {
+            credited_stake_yocto: baseline,
+            last_observed_stake_yocto: baseline,
+            credit_limit_nano_usd: stake_credits_at_rate(rate, baseline),
+        }
+    });
+
+    if observed_stake_yocto > snapshot.credited_stake_yocto {
+        let total_seconds = period_end
+            .signed_duration_since(period_start)
+            .num_seconds()
+            .max(1) as u128;
+        let remaining_seconds = period_end
+            .signed_duration_since(observed_at.max(period_start))
+            .num_seconds()
+            .clamp(0, total_seconds as i64) as u128;
+        let delta =
+            stake_credits_at_rate(rate, observed_stake_yocto - snapshot.credited_stake_yocto)
+                as u128;
+        snapshot.credit_limit_nano_usd = snapshot
+            .credit_limit_nano_usd
+            .saturating_add((delta * remaining_seconds / total_seconds) as u64);
+        snapshot.credited_stake_yocto = observed_stake_yocto;
+    }
+    snapshot.last_observed_stake_yocto = observed_stake_yocto;
+
+    let effective_limit = if observed_stake_yocto == 0 {
+        0
+    } else {
+        snapshot.credit_limit_nano_usd
+    };
+    (snapshot, effective_limit)
+}
 
 pub struct SubscriptionServiceImpl {
     db_pool: crate::db_pool::DbPool,
@@ -116,8 +177,7 @@ pub struct SubscriptionServiceImpl {
     near_rpc_url: String,
     near_network_id: String,
     credit_limit_cache: Arc<RwLock<HashMap<UserId, CachedCreditLimit>>>,
-    house_of_stake_stake_source_cache:
-        Arc<RwLock<HashMap<(UserId, String), CachedHouseOfStakeStakeSource>>>,
+    house_of_stake_rpc_failure_cache: Arc<RwLock<HashMap<UserId, CachedHouseOfStakeRpcFailure>>>,
     system_configs_cache: Arc<RwLock<Option<CachedSystemConfigs>>>,
 }
 
@@ -191,7 +251,7 @@ impl SubscriptionServiceImpl {
             near_rpc_url: config.near_rpc_url,
             near_network_id: config.near_network_id,
             credit_limit_cache: Arc::new(RwLock::new(HashMap::new())),
-            house_of_stake_stake_source_cache: Arc::new(RwLock::new(HashMap::new())),
+            house_of_stake_rpc_failure_cache: Arc::new(RwLock::new(HashMap::new())),
             system_configs_cache: Arc::new(RwLock::new(None)),
         }
     }
@@ -199,10 +259,10 @@ impl SubscriptionServiceImpl {
     /// Invalidate cached credit-limit state for a user (e.g. when plan, credits, or HoS lock state changes via webhook/reconcile).
     async fn invalidate_credit_limit_cache(&self, user_id: UserId) {
         self.credit_limit_cache.write().await.remove(&user_id);
-        self.house_of_stake_stake_source_cache
+        self.house_of_stake_rpc_failure_cache
             .write()
             .await
-            .retain(|(cached_user_id, _), _| *cached_user_id != user_id);
+            .remove(&user_id);
         tracing::debug!("Invalidated credit limit cache for user_id={}", user_id);
     }
 
@@ -909,6 +969,16 @@ impl SubscriptionServiceImpl {
         &self,
         user_id: UserId,
     ) -> Result<(i64, chrono::DateTime<Utc>, chrono::DateTime<Utc>), SubscriptionError> {
+        if let Some(cached) = self.credit_limit_cache.read().await.get(&user_id) {
+            if cached.cached_at.elapsed().as_secs() < TTL_CACHE_SECS {
+                return Ok((
+                    cached.plan_credits.min(i64::MAX as u64) as i64,
+                    cached.period_start,
+                    cached.period_end,
+                ));
+            }
+        }
+
         let configs = self
             .system_configs_service
             .get_configs()
@@ -922,7 +992,18 @@ impl SubscriptionServiceImpl {
             .get_active_subscription_for_entitlement(user_id)
             .await?
         {
-            Some(ref sub) => {
+            Some(mut sub) => {
+                if sub.provider == "stripe" && Self::should_check_pending_downgrade(&sub) {
+                    match self.try_apply_pending_downgrade(&sub.subscription_id).await {
+                        Ok(Some(updated)) => sub = updated,
+                        Ok(None) => {}
+                        Err(err) => tracing::error!(
+                            user_id = %user_id,
+                            error = %err,
+                            "failed to apply pending subscription downgrade"
+                        ),
+                    }
+                }
                 let plan_name = resolve_plan_name_from_config(
                     sub.provider.as_str(),
                     &sub.price_id,
@@ -931,8 +1012,8 @@ impl SubscriptionServiceImpl {
                 let plan_credits = match plan_name.as_deref() {
                     Some(name) => match subscription_plans.get(name) {
                         Some(plan_config) => self
-                            .stake_based_plan_limit_max(user_id, sub, plan_config)
-                            .await
+                            .stake_based_plan_limit_max(user_id, &sub, plan_config)
+                            .await?
                             .unwrap_or_else(|| Self::plan_limit_max(plan_config)),
                         None => DEFAULT_MONTHLY_CREDITS_NANO_USD,
                     },
@@ -952,6 +1033,16 @@ impl SubscriptionServiceImpl {
                 (plan_credits, period_start, period_end)
             }
         };
+
+        self.credit_limit_cache.write().await.insert(
+            user_id,
+            CachedCreditLimit {
+                plan_credits,
+                period_start,
+                period_end,
+                cached_at: Instant::now(),
+            },
+        );
 
         // Clamp to i64::MAX so CreditsSummary.plan_credits and comparisons don't overflow
         let plan_credits_i64 = plan_credits.min(i64::MAX as u64) as i64;
@@ -977,6 +1068,7 @@ impl SubscriptionServiceImpl {
         credits_max_nano_usd(Some(config))
     }
 
+    #[cfg(test)]
     fn stake_based_credits_for_lock(
         plan_config: &SubscriptionPlanConfig,
         lock_amount_yocto: u128,
@@ -985,10 +1077,176 @@ impl SubscriptionServiceImpl {
             .stake_based_monthly_credits
             .as_ref()
             .and_then(|c| c.credits_per_staked_near_nano_usd)?;
-        let credits = lock_amount_yocto
-            .saturating_mul(rate as u128)
-            .saturating_div(YOCTO_PER_NEAR);
-        Some(credits.min(u64::MAX as u128) as u64)
+        Some(stake_credits_at_rate(rate, lock_amount_yocto))
+    }
+
+    async fn current_house_of_stake_snapshot_limit(
+        &self,
+        subscription: &Subscription,
+    ) -> Result<Option<u64>, SubscriptionError> {
+        let period_end = subscription.current_period_end;
+        let period_start = sub_one_month_same_day(period_end);
+        let client = self
+            .db_pool
+            .get()
+            .await
+            .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
+        let row = client
+            .query_opt(
+                r#"
+                SELECT credit_limit_nano_usd, last_observed_stake_yocto
+                FROM house_of_stake_credit_entitlement_snapshots
+                WHERE subscription_id = $1 AND period_start = $2 AND period_end = $3
+                "#,
+                &[&subscription.subscription_id, &period_start, &period_end],
+            )
+            .await
+            .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
+
+        row.map(|row| {
+            let observed = parse_snapshot_stake(row.get("last_observed_stake_yocto"))?;
+            let limit = row.get::<_, i64>("credit_limit_nano_usd").max(0) as u64;
+            Ok(if observed == 0 { 0 } else { limit })
+        })
+        .transpose()
+    }
+
+    async fn house_of_stake_rpc_fallback(
+        &self,
+        user_id: UserId,
+        subscription: &Subscription,
+        reason: &'static str,
+    ) -> Result<Option<u64>, SubscriptionError> {
+        self.house_of_stake_rpc_failure_cache.write().await.insert(
+            user_id,
+            CachedHouseOfStakeRpcFailure {
+                failed_at: Instant::now(),
+            },
+        );
+        tracing::warn!(
+            user_id = %user_id,
+            subscription_id = %subscription.subscription_id,
+            reason,
+            "using persisted HoS entitlement after chain lookup failure"
+        );
+        self.current_house_of_stake_snapshot_limit(subscription)
+            .await?
+            .map(Some)
+            .ok_or_else(|| {
+                SubscriptionError::InternalError(
+                    "HoS entitlement is temporarily unavailable".to_string(),
+                )
+            })
+    }
+
+    async fn reconcile_house_of_stake_snapshot(
+        &self,
+        subscription: &Subscription,
+        rate: u64,
+        observed_stake_yocto: u128,
+    ) -> Result<u64, SubscriptionError> {
+        let period_end = subscription.current_period_end;
+        let period_start = sub_one_month_same_day(period_end);
+        let observed_at = Utc::now();
+        let mut client = self
+            .db_pool
+            .get()
+            .await
+            .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
+        let txn = client
+            .transaction()
+            .await
+            .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
+
+        txn.query_one(
+            "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+            &[&subscription.subscription_id],
+        )
+        .await
+        .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
+
+        let current = txn
+            .query_opt(
+                r#"
+                SELECT credited_stake_yocto, last_observed_stake_yocto, credit_limit_nano_usd
+                FROM house_of_stake_credit_entitlement_snapshots
+                WHERE subscription_id = $1 AND period_start = $2 AND period_end = $3
+                FOR UPDATE
+                "#,
+                &[&subscription.subscription_id, &period_start, &period_end],
+            )
+            .await
+            .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?
+            .map(|row| {
+                Ok::<_, SubscriptionError>(HouseOfStakeSnapshot {
+                    credited_stake_yocto: parse_snapshot_stake(row.get("credited_stake_yocto"))?,
+                    last_observed_stake_yocto: parse_snapshot_stake(
+                        row.get("last_observed_stake_yocto"),
+                    )?,
+                    credit_limit_nano_usd: row.get::<_, i64>("credit_limit_nano_usd").max(0) as u64,
+                })
+            })
+            .transpose()?;
+
+        let previous_observed = if current.is_none() {
+            txn.query_opt(
+                r#"
+                SELECT last_observed_stake_yocto
+                FROM house_of_stake_credit_entitlement_snapshots
+                WHERE subscription_id = $1 AND period_end <= $2
+                ORDER BY period_end DESC
+                LIMIT 1
+                "#,
+                &[&subscription.subscription_id, &period_start],
+            )
+            .await
+            .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?
+            .map(|row| parse_snapshot_stake(row.get("last_observed_stake_yocto")))
+            .transpose()?
+        } else {
+            None
+        };
+
+        let (snapshot, effective_limit) = next_house_of_stake_snapshot(
+            current,
+            previous_observed,
+            observed_stake_yocto,
+            rate,
+            period_start,
+            period_end,
+            observed_at,
+        );
+        let credited_stake = snapshot.credited_stake_yocto.to_string();
+        let observed_stake = snapshot.last_observed_stake_yocto.to_string();
+        let stored_limit = snapshot.credit_limit_nano_usd.min(i64::MAX as u64) as i64;
+        txn.execute(
+            r#"
+            INSERT INTO house_of_stake_credit_entitlement_snapshots
+                (subscription_id, period_start, period_end, credited_stake_yocto,
+                 last_observed_stake_yocto, credit_limit_nano_usd, observed_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT (subscription_id, period_start, period_end) DO UPDATE SET
+                credited_stake_yocto = EXCLUDED.credited_stake_yocto,
+                last_observed_stake_yocto = EXCLUDED.last_observed_stake_yocto,
+                credit_limit_nano_usd = EXCLUDED.credit_limit_nano_usd,
+                observed_at = EXCLUDED.observed_at
+            "#,
+            &[
+                &subscription.subscription_id,
+                &period_start,
+                &period_end,
+                &credited_stake,
+                &observed_stake,
+                &stored_limit,
+                &observed_at,
+            ],
+        )
+        .await
+        .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
+        txn.commit()
+            .await
+            .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
+        Ok(effective_limit)
     }
 
     async fn stake_based_plan_limit_max(
@@ -996,60 +1254,55 @@ impl SubscriptionServiceImpl {
         user_id: UserId,
         subscription: &Subscription,
         plan_config: &SubscriptionPlanConfig,
-    ) -> Option<u64> {
+    ) -> Result<Option<u64>, SubscriptionError> {
         if subscription.provider != "house-of-stake" {
-            return None;
+            return Ok(None);
         }
-        plan_config
+        let Some(rate) = plan_config
             .stake_based_monthly_credits
             .as_ref()
-            .and_then(|c| c.credits_per_staked_near_nano_usd)?;
+            .and_then(|c| c.credits_per_staked_near_nano_usd)
+        else {
+            return Ok(None);
+        };
 
-        let cache_key = (user_id, subscription.subscription_id.clone());
-        if let Some(cached) = self
-            .house_of_stake_stake_source_cache
+        if self
+            .house_of_stake_rpc_failure_cache
             .read()
             .await
-            .get(&cache_key)
+            .get(&user_id)
+            .is_some_and(|cached| {
+                cached.failed_at.elapsed().as_secs() < HOUSE_OF_STAKE_RPC_FAILURE_TTL_SECS
+            })
         {
-            if cached.cached_at.elapsed().as_secs() < HOUSE_OF_STAKE_STAKE_SOURCE_TTL_SECS {
-                tracing::debug!(
-                    user_id = %user_id.0,
-                    subscription_id = %subscription.subscription_id,
-                    last_lock_id = %cached.last_lock_id,
-                    "using cached HoS stake-based credit source"
-                );
-                return Self::stake_based_credits_for_lock(plan_config, cached.amount_yocto);
-            }
+            return self
+                .current_house_of_stake_snapshot_limit(subscription)
+                .await?
+                .map(Some)
+                .ok_or_else(|| {
+                    SubscriptionError::InternalError(
+                        "HoS entitlement is temporarily unavailable".to_string(),
+                    )
+                });
         }
 
         let Some(contract_id) = self.near_staking_contract_id.as_deref().map(str::trim) else {
-            tracing::warn!(
-                user_id = %user_id.0,
-                subscription_id = %subscription.subscription_id,
-                "cannot resolve HoS stake-based credits: staking contract is not configured"
-            );
-            return None;
+            return self
+                .house_of_stake_rpc_fallback(user_id, subscription, "contract not configured")
+                .await;
         };
         if contract_id.is_empty() {
-            tracing::warn!(
-                user_id = %user_id.0,
-                subscription_id = %subscription.subscription_id,
-                "cannot resolve HoS stake-based credits: staking contract is empty"
-            );
-            return None;
+            return self
+                .house_of_stake_rpc_fallback(user_id, subscription, "empty contract id")
+                .await;
         }
 
         let near_account = match self.get_near_account_id(user_id).await {
             Ok(account) => account,
-            Err(err) => {
-                tracing::warn!(
-                    user_id = %user_id.0,
-                    subscription_id = %subscription.subscription_id,
-                    error = %err,
-                    "cannot resolve HoS stake-based credits: NEAR account unavailable"
-                );
-                return None;
+            Err(_) => {
+                return self
+                    .house_of_stake_rpc_fallback(user_id, subscription, "NEAR account unavailable")
+                    .await
             }
         };
 
@@ -1063,23 +1316,18 @@ impl SubscriptionServiceImpl {
         {
             Ok(Some(chain_sub)) => chain_sub,
             Ok(None) => {
-                tracing::warn!(
-                    user_id = %user_id.0,
-                    subscription_id = %subscription.subscription_id,
-                    price_id = %subscription.price_id,
-                    "cannot resolve HoS stake-based credits: subscription missing on chain"
-                );
-                return None;
+                return self
+                    .house_of_stake_rpc_fallback(
+                        user_id,
+                        subscription,
+                        "subscription missing on chain",
+                    )
+                    .await
             }
-            Err(err) => {
-                tracing::warn!(
-                    user_id = %user_id.0,
-                    subscription_id = %subscription.subscription_id,
-                    price_id = %subscription.price_id,
-                    error = %err,
-                    "cannot resolve HoS stake-based credits: subscription RPC failed"
-                );
-                return None;
+            Err(_) => {
+                return self
+                    .house_of_stake_rpc_fallback(user_id, subscription, "subscription RPC failed")
+                    .await
             }
         };
 
@@ -1093,15 +1341,10 @@ impl SubscriptionServiceImpl {
             .and_then(|ns| u64::try_from(ns).ok())
             .unwrap_or(u64::MAX);
         if status_lower != "active" || chain_sub.end_ns <= now_ns {
-            tracing::warn!(
-                user_id = %user_id.0,
-                subscription_id = %subscription.subscription_id,
-                price_id = %subscription.price_id,
-                chain_status = %status_lower,
-                chain_end_ns = chain_sub.end_ns,
-                "cannot resolve HoS stake-based credits: chain subscription is not active"
-            );
-            return None;
+            return self
+                .reconcile_house_of_stake_snapshot(subscription, rate, 0)
+                .await
+                .map(Some);
         }
 
         let Some(last_lock_id) = chain_sub
@@ -1109,84 +1352,44 @@ impl SubscriptionServiceImpl {
             .as_deref()
             .filter(|s| !s.trim().is_empty())
         else {
-            tracing::warn!(
-                user_id = %user_id.0,
-                subscription_id = %subscription.subscription_id,
-                price_id = %subscription.price_id,
-                "cannot resolve HoS stake-based credits: last_lock_id missing on chain subscription"
-            );
-            return None;
+            return self
+                .house_of_stake_rpc_fallback(user_id, subscription, "last lock missing")
+                .await;
         };
 
         let lock =
             match view_get_effective_lock(&self.near_rpc_url, contract_id, last_lock_id).await {
                 Ok(Some(lock)) => lock,
                 Ok(None) => {
-                    tracing::warn!(
-                        user_id = %user_id.0,
-                        subscription_id = %subscription.subscription_id,
-                        last_lock_id,
-                        "cannot resolve HoS stake-based credits: lock missing on chain"
-                    );
-                    return None;
+                    return self
+                        .house_of_stake_rpc_fallback(user_id, subscription, "lock missing")
+                        .await
                 }
-                Err(err) => {
-                    tracing::warn!(
-                        user_id = %user_id.0,
-                        subscription_id = %subscription.subscription_id,
-                        last_lock_id,
-                        error = %err,
-                        "cannot resolve HoS stake-based credits: lock RPC failed"
-                    );
-                    return None;
+                Err(_) => {
+                    return self
+                        .house_of_stake_rpc_fallback(user_id, subscription, "lock RPC failed")
+                        .await
                 }
             };
 
-        if !lock_has_active_shares(&lock) {
-            let lock_status = lock.status.as_deref().unwrap_or("<missing>");
-            let lock_shares = lock
-                .shares
-                .map(|shares| shares.to_string())
-                .unwrap_or_else(|| "<missing>".to_string());
-            tracing::warn!(
-                user_id = %user_id.0,
-                subscription_id = %subscription.subscription_id,
-                last_lock_id,
-                lock_status = %lock_status,
-                lock_shares = %lock_shares,
-                "HoS effective lock is not active with staked shares; granting zero stake-based credits"
-            );
-            self.house_of_stake_stake_source_cache.write().await.insert(
-                cache_key,
-                CachedHouseOfStakeStakeSource {
-                    last_lock_id: last_lock_id.to_string(),
-                    amount_yocto: 0,
-                    cached_at: Instant::now(),
-                },
-            );
-            return Self::stake_based_credits_for_lock(plan_config, 0);
-        }
-
-        let Some(lock_amount) = lock_amount_yocto(&lock) else {
-            tracing::warn!(
-                user_id = %user_id.0,
-                subscription_id = %subscription.subscription_id,
-                last_lock_id,
-                "cannot resolve HoS stake-based credits: lock amount missing or invalid"
-            );
-            return None;
+        let observed_stake = if lock_has_active_shares(&lock) {
+            let Some(amount) = lock_amount_yocto(&lock) else {
+                return self
+                    .house_of_stake_rpc_fallback(user_id, subscription, "invalid lock amount")
+                    .await;
+            };
+            amount
+        } else {
+            0
         };
-
-        self.house_of_stake_stake_source_cache.write().await.insert(
-            cache_key,
-            CachedHouseOfStakeStakeSource {
-                last_lock_id: last_lock_id.to_string(),
-                amount_yocto: lock_amount,
-                cached_at: Instant::now(),
-            },
-        );
-
-        Self::stake_based_credits_for_lock(plan_config, lock_amount)
+        let limit = self
+            .reconcile_house_of_stake_snapshot(subscription, rate, observed_stake)
+            .await?;
+        self.house_of_stake_rpc_failure_cache
+            .write()
+            .await
+            .remove(&user_id);
+        Ok(Some(limit))
     }
 
     fn should_check_pending_downgrade(subscription: &Subscription) -> bool {
@@ -3351,132 +3554,10 @@ impl SubscriptionService for SubscriptionServiceImpl {
             return Err(SubscriptionError::NoActiveSubscription);
         }
 
-        let active_subscription = self
-            .get_active_subscription_for_entitlement(user_id)
-            .await?;
-
-        // 1. Get plan credits (monthly_credits) from the config. Cache 10 mins.
-        let cached_limit = {
-            let cache_guard = self.credit_limit_cache.read().await;
-            if let Some(cached) = cache_guard.get(&user_id) {
-                if cached.cached_at.elapsed().as_secs() < TTL_CACHE_SECS {
-                    tracing::debug!(
-                        "Using cached credit limit for user_id={} (plan={}, age_secs={})",
-                        user_id,
-                        cached.plan_credits,
-                        cached.cached_at.elapsed().as_secs()
-                    );
-                    Some((cached.plan_credits, cached.period_start, cached.period_end))
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        };
-
-        let (plan_credits, period_start, period_end) = match cached_limit {
-            Some((plan, start, end)) => (plan, start, end),
-            None => {
-                let configs = self
-                    .system_configs_service
-                    .get_configs()
-                    .await
-                    .map_err(|e| SubscriptionError::InternalError(e.to_string()))?;
-                let subscription_plans = configs
-                    .and_then(|c| c.subscription_plans)
-                    .unwrap_or_default();
-
-                // Use monthly_credits when set (nano USD); else monthly_tokens → nano USD at 1.5 USD per M tokens. Never fail for missing config.
-                let (plan_credits, period_start, period_end) = match active_subscription.as_ref() {
-                    Some(sub) => {
-                        let effective_sub = if sub.provider == "stripe"
-                            && Self::should_check_pending_downgrade(sub)
-                        {
-                            match self.try_apply_pending_downgrade(&sub.subscription_id).await {
-                                Ok(Some(updated)) => updated,
-                                Ok(None) => sub.clone(),
-                                Err(e) => {
-                                    tracing::error!(
-                                        "Failed to apply pending downgrade for user_id={}: {}",
-                                        user_id,
-                                        e
-                                    );
-                                    sub.clone()
-                                }
-                            }
-                        } else {
-                            sub.clone()
-                        };
-                        let plan_name = resolve_plan_name_from_config(
-                            effective_sub.provider.as_str(),
-                            &effective_sub.price_id,
-                            &subscription_plans,
-                        );
-                        let plan_credits = match plan_name.as_deref() {
-                            Some(name) => match subscription_plans.get(name) {
-                                Some(plan_config) => self
-                                    .stake_based_plan_limit_max(
-                                        user_id,
-                                        &effective_sub,
-                                        plan_config,
-                                    )
-                                    .await
-                                    .unwrap_or_else(|| Self::plan_limit_max(plan_config)),
-                                None => {
-                                    tracing::warn!(
-                                        "Falling back to default monthly credits for unmatched plan '{:?}'; using {} nano-USD",
-                                        plan_name,
-                                        DEFAULT_MONTHLY_CREDITS_NANO_USD
-                                    );
-                                    DEFAULT_MONTHLY_CREDITS_NANO_USD
-                                }
-                            },
-                            None => {
-                                tracing::warn!(
-                                    "Falling back to default monthly credits for unmatched plan '{:?}'; using {} nano-USD",
-                                    plan_name,
-                                    DEFAULT_MONTHLY_CREDITS_NANO_USD
-                                );
-                                DEFAULT_MONTHLY_CREDITS_NANO_USD
-                            }
-                        };
-                        let period_end = effective_sub.current_period_end;
-                        let period_start = sub_one_month_same_day(effective_sub.current_period_end);
-                        (plan_credits, period_start, period_end)
-                    }
-                    None => {
-                        let plan_credits = subscription_plans
-                            .get("free")
-                            .map(Self::plan_limit_max)
-                            .unwrap_or_else(|| {
-                                tracing::warn!(
-                                    "Falling back to default monthly credits for missing 'free' plan; using {} nano-USD",
-                                    DEFAULT_MONTHLY_CREDITS_NANO_USD
-                                );
-                                DEFAULT_MONTHLY_CREDITS_NANO_USD
-                            });
-                        let (period_start, period_end) =
-                            self.resolve_free_plan_period_for_user(user_id).await?;
-                        (plan_credits, period_start, period_end)
-                    }
-                };
-
-                {
-                    let mut cache_guard = self.credit_limit_cache.write().await;
-                    cache_guard.insert(
-                        user_id,
-                        CachedCreditLimit {
-                            plan_credits,
-                            period_start,
-                            period_end,
-                            cached_at: Instant::now(),
-                        },
-                    );
-                }
-                (plan_credits, period_start, period_end)
-            }
-        };
+        // The shared resolver owns the 10-minute plan cache, including HoS RPC results.
+        let (plan_credits, period_start, period_end) =
+            self.resolve_plan_period_for_user(user_id).await?;
+        let plan_credits = plan_credits.max(0) as u64;
 
         // 2. Get spent credits (cost_nano_usd) in the period
         let period_spent_credits = self
@@ -4137,7 +4218,6 @@ impl SubscriptionService for SubscriptionServiceImpl {
             .reconcile_purchased_after_usage(user_id, plan_credits, period_start, period_end)
             .await
             .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
-        self.invalidate_credit_limit_cache(user_id).await;
         Ok(())
     }
 
@@ -4161,8 +4241,6 @@ impl SubscriptionService for SubscriptionServiceImpl {
                 .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))
             {
                 tracing::warn!(error = ?e, "Failed to reconcile purchased credits before get_credits");
-            } else {
-                self.invalidate_credit_limit_cache(user_id).await;
             }
         }
 
@@ -4382,6 +4460,73 @@ mod tests {
             SubscriptionServiceImpl::stake_based_credits_for_lock(&config, u128::MAX),
             Some((u128::MAX / YOCTO_PER_NEAR) as u64)
         );
+    }
+
+    #[test]
+    fn test_house_of_stake_snapshot_prorates_only_increases() {
+        let start = Utc.with_ymd_and_hms(2026, 8, 1, 0, 0, 0).unwrap();
+        let end = start + Duration::days(30);
+        let halfway = start + Duration::days(15);
+        let baseline = HouseOfStakeSnapshot {
+            credited_stake_yocto: 10 * YOCTO_PER_NEAR,
+            last_observed_stake_yocto: 10 * YOCTO_PER_NEAR,
+            credit_limit_nano_usd: 10_000_000_000,
+        };
+
+        let (increased, limit) = next_house_of_stake_snapshot(
+            Some(baseline),
+            None,
+            20 * YOCTO_PER_NEAR,
+            1_000_000_000,
+            start,
+            end,
+            halfway,
+        );
+        assert_eq!(limit, 15_000_000_000);
+
+        let (decreased, limit) = next_house_of_stake_snapshot(
+            Some(increased),
+            None,
+            5 * YOCTO_PER_NEAR,
+            1_000_000_000,
+            start,
+            end,
+            halfway,
+        );
+        assert_eq!(limit, 15_000_000_000);
+        assert_eq!(decreased.credited_stake_yocto, 20 * YOCTO_PER_NEAR);
+        assert_eq!(decreased.last_observed_stake_yocto, 5 * YOCTO_PER_NEAR);
+    }
+
+    #[test]
+    fn test_house_of_stake_snapshot_carries_baseline_and_records_zero() {
+        let start = Utc.with_ymd_and_hms(2026, 9, 1, 0, 0, 0).unwrap();
+        let end = start + Duration::days(30);
+        let halfway = start + Duration::days(15);
+
+        let (snapshot, limit) = next_house_of_stake_snapshot(
+            None,
+            Some(10 * YOCTO_PER_NEAR),
+            20 * YOCTO_PER_NEAR,
+            1_000_000_000,
+            start,
+            end,
+            halfway,
+        );
+        assert_eq!(limit, 15_000_000_000);
+
+        let (zero, limit) = next_house_of_stake_snapshot(
+            Some(snapshot),
+            None,
+            0,
+            1_000_000_000,
+            start,
+            end,
+            halfway,
+        );
+        assert_eq!(limit, 0);
+        assert_eq!(zero.last_observed_stake_yocto, 0);
+        assert_eq!(zero.credit_limit_nano_usd, 15_000_000_000);
     }
 
     fn base_subscription() -> Subscription {

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -102,6 +102,7 @@ struct HouseOfStakeSnapshot {
 struct HouseOfStakeEntitlement {
     plan_credits: u64,
     period: BillingPeriod,
+    is_fallback: bool,
 }
 
 fn ns_to_datetime(ns: u64) -> Option<DateTime<Utc>> {
@@ -117,6 +118,7 @@ struct CachedSystemConfigs {
 const TTL_CACHE_SECS: u64 = 600; // 10 minutes
 const SYSTEM_CONFIGS_TTL_CACHE_SECS: u64 = 60; // 1 minute
 const HOUSE_OF_STAKE_RPC_FAILURE_TTL_SECS: u64 = 60;
+const HOUSE_OF_STAKE_MAX_CHAIN_PERIOD_DAYS: i64 = 35;
 /// Default monthly credits when plan has no monthly_credits config. 1 USD in nano-dollars ($1 = 1_000_000_000).
 const DEFAULT_MONTHLY_CREDITS_NANO_USD: u64 = 1_000_000_000;
 const YOCTO_PER_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
@@ -1098,6 +1100,7 @@ impl SubscriptionServiceImpl {
             .unwrap_or_default();
 
         let mut house_of_stake = None;
+        let mut cacheable = true;
         let (plan_credits, period_start, period_end, cache_scope) = match active_subscription {
             Some(mut sub) => {
                 if sub.provider == "stripe" && Self::should_check_pending_downgrade(&sub) {
@@ -1131,7 +1134,10 @@ impl SubscriptionServiceImpl {
                     end_at: sub.current_period_end,
                 };
                 let (plan_credits, period) = match stake_entitlement {
-                    Some(entitlement) => (entitlement.plan_credits, entitlement.period),
+                    Some(entitlement) => {
+                        cacheable = !entitlement.is_fallback;
+                        (entitlement.plan_credits, entitlement.period)
+                    }
                     None => (
                         plan_name
                             .as_deref()
@@ -1167,15 +1173,7 @@ impl SubscriptionServiceImpl {
             }
         };
 
-        let has_recent_hos_rpc_failure = self
-            .house_of_stake_rpc_failure_cache
-            .read()
-            .await
-            .get(&user_id)
-            .is_some_and(|failure| {
-                failure.failed_at.elapsed().as_secs() < HOUSE_OF_STAKE_RPC_FAILURE_TTL_SECS
-            });
-        if !has_recent_hos_rpc_failure {
+        if cacheable {
             self.credit_limit_cache.write().await.insert(
                 user_id,
                 CachedCreditLimit {
@@ -1329,6 +1327,7 @@ impl SubscriptionServiceImpl {
                     start_at: row.get("period_start"),
                     end_at: row.get("period_end"),
                 },
+                is_fallback: true,
             })
         })
         .transpose()
@@ -1360,6 +1359,42 @@ impl SubscriptionServiceImpl {
                     "HoS entitlement is temporarily unavailable".to_string(),
                 )
             })
+    }
+
+    async fn confirmed_zero_house_of_stake_entitlement(
+        &self,
+        user_id: UserId,
+        subscription: &Subscription,
+    ) -> Result<Option<HouseOfStakeEntitlement>, SubscriptionError> {
+        let period = self
+            .current_house_of_stake_snapshot_limit(subscription)
+            .await?
+            .map(|entitlement| entitlement.period)
+            .unwrap_or_else(|| BillingPeriod {
+                start_at: sub_one_month_same_day(subscription.current_period_end),
+                end_at: subscription.current_period_end,
+            });
+        self.house_of_stake_rpc_failure_cache
+            .write()
+            .await
+            .remove(&user_id);
+        Ok(Some(HouseOfStakeEntitlement {
+            plan_credits: 0,
+            period,
+            is_fallback: false,
+        }))
+    }
+
+    fn is_valid_house_of_stake_chain_period(
+        period_start: DateTime<Utc>,
+        period_end: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> bool {
+        period_start <= now
+            && now < period_end
+            && period_end.signed_duration_since(period_start) > Duration::zero()
+            && period_end.signed_duration_since(period_start)
+                <= Duration::days(HOUSE_OF_STAKE_MAX_CHAIN_PERIOD_DAYS)
     }
 
     async fn reconcile_house_of_stake_snapshot(
@@ -1546,22 +1581,9 @@ impl SubscriptionServiceImpl {
         {
             Ok(Some(chain_sub)) => chain_sub,
             Ok(None) => {
-                let period = self
-                    .current_house_of_stake_snapshot_limit(subscription)
-                    .await?
-                    .map(|entitlement| entitlement.period)
-                    .unwrap_or_else(|| BillingPeriod {
-                        start_at: sub_one_month_same_day(subscription.current_period_end),
-                        end_at: subscription.current_period_end,
-                    });
-                self.house_of_stake_rpc_failure_cache
-                    .write()
-                    .await
-                    .remove(&user_id);
-                return Ok(Some(HouseOfStakeEntitlement {
-                    plan_credits: 0,
-                    period,
-                }));
+                return self
+                    .confirmed_zero_house_of_stake_entitlement(user_id, subscription)
+                    .await;
             }
             Err(_) => {
                 return self
@@ -1576,6 +1598,22 @@ impl SubscriptionServiceImpl {
             ));
         }
 
+        let now = Utc::now();
+        let status_lower = chain_sub
+            .status
+            .as_deref()
+            .unwrap_or("Active")
+            .to_ascii_lowercase();
+        let now_ns = now
+            .timestamp_nanos_opt()
+            .and_then(|ns| u64::try_from(ns).ok())
+            .unwrap_or(u64::MAX);
+        if status_lower != "active" || chain_sub.end_ns <= now_ns {
+            return self
+                .confirmed_zero_house_of_stake_entitlement(user_id, subscription)
+                .await;
+        }
+
         let Some(period_start) = chain_sub.start_ns.and_then(ns_to_datetime) else {
             return self
                 .house_of_stake_rpc_fallback(user_id, subscription, "period start unavailable")
@@ -1586,36 +1624,15 @@ impl SubscriptionServiceImpl {
                 .house_of_stake_rpc_fallback(user_id, subscription, "period end invalid")
                 .await;
         };
-        if period_end <= period_start {
+        if !Self::is_valid_house_of_stake_chain_period(period_start, period_end, now) {
             return self
-                .house_of_stake_rpc_fallback(user_id, subscription, "billing period invalid")
+                .confirmed_zero_house_of_stake_entitlement(user_id, subscription)
                 .await;
         }
         let period = BillingPeriod {
             start_at: period_start,
             end_at: period_end,
         };
-
-        let status_lower = chain_sub
-            .status
-            .as_deref()
-            .unwrap_or("Active")
-            .to_ascii_lowercase();
-        let now_ns = Utc::now()
-            .timestamp_nanos_opt()
-            .and_then(|ns| u64::try_from(ns).ok())
-            .unwrap_or(u64::MAX);
-        if status_lower != "active" || chain_sub.end_ns <= now_ns {
-            return self
-                .reconcile_house_of_stake_snapshot(subscription, &period, rate, 0, None)
-                .await
-                .map(|plan_credits| {
-                    Some(HouseOfStakeEntitlement {
-                        plan_credits,
-                        period,
-                    })
-                });
-        }
 
         let Some(last_lock_id) = chain_sub
             .last_lock_id
@@ -1662,6 +1679,7 @@ impl SubscriptionServiceImpl {
         Ok(Some(HouseOfStakeEntitlement {
             plan_credits: limit,
             period,
+            is_fallback: false,
         }))
     }
 
@@ -4886,6 +4904,39 @@ mod tests {
         );
 
         assert_eq!(limit, 5_000_000_000);
+    }
+
+    #[test]
+    fn test_house_of_stake_chain_period_must_be_current_and_bounded() {
+        let now = Utc.with_ymd_and_hms(2026, 8, 24, 0, 0, 0).unwrap();
+        assert!(
+            SubscriptionServiceImpl::is_valid_house_of_stake_chain_period(
+                now - Duration::days(23),
+                now + Duration::days(8),
+                now,
+            )
+        );
+        assert!(
+            !SubscriptionServiceImpl::is_valid_house_of_stake_chain_period(
+                now + Duration::days(1),
+                now + Duration::days(31),
+                now,
+            )
+        );
+        assert!(
+            !SubscriptionServiceImpl::is_valid_house_of_stake_chain_period(
+                now - Duration::days(30),
+                now,
+                now,
+            )
+        );
+        assert!(
+            !SubscriptionServiceImpl::is_valid_house_of_stake_chain_period(
+                now - Duration::days(18),
+                now + Duration::days(18),
+                now,
+            )
+        );
     }
 
     #[test]

--- a/crates/services/src/subscription/service.rs
+++ b/crates/services/src/subscription/service.rs
@@ -99,6 +99,15 @@ struct HouseOfStakeSnapshot {
     observed_at: DateTime<Utc>,
 }
 
+struct HouseOfStakeEntitlement {
+    plan_credits: u64,
+    period: BillingPeriod,
+}
+
+fn ns_to_datetime(ns: u64) -> Option<DateTime<Utc>> {
+    DateTime::from_timestamp((ns / 1_000_000_000) as i64, (ns % 1_000_000_000) as u32)
+}
+
 /// Cached system configs snapshot for model access checks.
 struct CachedSystemConfigs {
     configs: Option<Arc<SystemConfigs>>,
@@ -1107,25 +1116,38 @@ impl SubscriptionServiceImpl {
                     &sub.price_id,
                     &subscription_plans,
                 );
-                let plan_credits = match plan_name.as_deref() {
+                let stake_entitlement = match plan_name.as_deref() {
                     Some(name) => match subscription_plans.get(name) {
-                        Some(plan_config) => self
-                            .stake_based_plan_limit_max(user_id, &sub, plan_config)
-                            .await?
-                            .unwrap_or_else(|| Self::plan_limit_max(plan_config)),
-                        None => DEFAULT_MONTHLY_CREDITS_NANO_USD,
+                        Some(plan_config) => {
+                            self.stake_based_plan_limit_max(user_id, &sub, plan_config)
+                                .await?
+                        }
+                        None => None,
                     },
-                    None => DEFAULT_MONTHLY_CREDITS_NANO_USD,
+                    None => None,
                 };
-                let period_end = sub.current_period_end;
-                let period_start = sub_one_month_same_day(sub.current_period_end);
+                let fallback_period = BillingPeriod {
+                    start_at: sub_one_month_same_day(sub.current_period_end),
+                    end_at: sub.current_period_end,
+                };
+                let (plan_credits, period) = match stake_entitlement {
+                    Some(entitlement) => (entitlement.plan_credits, entitlement.period),
+                    None => (
+                        plan_name
+                            .as_deref()
+                            .and_then(|name| subscription_plans.get(name))
+                            .map(Self::plan_limit_max)
+                            .unwrap_or(DEFAULT_MONTHLY_CREDITS_NANO_USD),
+                        fallback_period,
+                    ),
+                };
                 if sub.provider == "house-of-stake" {
-                    house_of_stake = self.current_house_of_stake_snapshot(&sub).await?;
+                    house_of_stake = self.current_house_of_stake_snapshot(&sub, &period).await?;
                 }
                 (
                     plan_credits,
-                    period_start,
-                    period_end,
+                    period.start_at,
+                    period.end_at,
                     CreditLimitCacheScope::from_active_subscription(Some(&sub)),
                 )
             }
@@ -1145,17 +1167,27 @@ impl SubscriptionServiceImpl {
             }
         };
 
-        self.credit_limit_cache.write().await.insert(
-            user_id,
-            CachedCreditLimit {
-                plan_credits,
-                period_start,
-                period_end,
-                house_of_stake,
-                scope: cache_scope,
-                cached_at: Instant::now(),
-            },
-        );
+        let has_recent_hos_rpc_failure = self
+            .house_of_stake_rpc_failure_cache
+            .read()
+            .await
+            .get(&user_id)
+            .is_some_and(|failure| {
+                failure.failed_at.elapsed().as_secs() < HOUSE_OF_STAKE_RPC_FAILURE_TTL_SECS
+            });
+        if !has_recent_hos_rpc_failure {
+            self.credit_limit_cache.write().await.insert(
+                user_id,
+                CachedCreditLimit {
+                    plan_credits,
+                    period_start,
+                    period_end,
+                    house_of_stake,
+                    scope: cache_scope,
+                    cached_at: Instant::now(),
+                },
+            );
+        }
 
         // Clamp to i64::MAX so CreditsSummary.plan_credits and comparisons don't overflow
         let plan_credits_i64 = plan_credits.min(i64::MAX as u64) as i64;
@@ -1230,9 +1262,8 @@ impl SubscriptionServiceImpl {
     async fn current_house_of_stake_snapshot(
         &self,
         subscription: &Subscription,
+        period: &BillingPeriod,
     ) -> Result<Option<HouseOfStakeCreditSnapshot>, SubscriptionError> {
-        let period_end = subscription.current_period_end;
-        let period_start = sub_one_month_same_day(period_end);
         let client = self
             .db_pool
             .get()
@@ -1246,7 +1277,11 @@ impl SubscriptionServiceImpl {
                 FROM house_of_stake_credit_entitlement_snapshots
                 WHERE subscription_id = $1 AND period_start = $2 AND period_end = $3
                 "#,
-                &[&subscription.subscription_id, &period_start, &period_end],
+                &[
+                    &subscription.subscription_id,
+                    &period.start_at,
+                    &period.end_at,
+                ],
             )
             .await
             .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
@@ -1264,9 +1299,8 @@ impl SubscriptionServiceImpl {
     async fn current_house_of_stake_snapshot_limit(
         &self,
         subscription: &Subscription,
-    ) -> Result<Option<u64>, SubscriptionError> {
-        let period_end = subscription.current_period_end;
-        let period_start = sub_one_month_same_day(period_end);
+    ) -> Result<Option<HouseOfStakeEntitlement>, SubscriptionError> {
+        let now = Utc::now();
         let client = self
             .db_pool
             .get()
@@ -1275,18 +1309,27 @@ impl SubscriptionServiceImpl {
         let row = client
             .query_opt(
                 r#"
-                SELECT credit_limit_nano_usd, last_observed_stake_yocto
+                SELECT credit_limit_nano_usd, last_observed_stake_yocto,
+                       period_start, period_end
                 FROM house_of_stake_credit_entitlement_snapshots
-                WHERE subscription_id = $1 AND period_start = $2 AND period_end = $3
+                WHERE subscription_id = $1 AND period_start <= $2 AND period_end > $2
+                ORDER BY period_start DESC
+                LIMIT 1
                 "#,
-                &[&subscription.subscription_id, &period_start, &period_end],
+                &[&subscription.subscription_id, &now],
             )
             .await
             .map_err(|e| SubscriptionError::DatabaseError(e.to_string()))?;
         row.map(|row| {
             let observed = parse_snapshot_stake(row.get("last_observed_stake_yocto"))?;
             let limit = row.get::<_, i64>("credit_limit_nano_usd").max(0) as u64;
-            Ok(if observed == 0 { 0 } else { limit })
+            Ok(HouseOfStakeEntitlement {
+                plan_credits: if observed == 0 { 0 } else { limit },
+                period: BillingPeriod {
+                    start_at: row.get("period_start"),
+                    end_at: row.get("period_end"),
+                },
+            })
         })
         .transpose()
     }
@@ -1296,7 +1339,7 @@ impl SubscriptionServiceImpl {
         user_id: UserId,
         subscription: &Subscription,
         reason: &'static str,
-    ) -> Result<Option<u64>, SubscriptionError> {
+    ) -> Result<Option<HouseOfStakeEntitlement>, SubscriptionError> {
         self.house_of_stake_rpc_failure_cache.write().await.insert(
             user_id,
             CachedHouseOfStakeRpcFailure {
@@ -1322,12 +1365,13 @@ impl SubscriptionServiceImpl {
     async fn reconcile_house_of_stake_snapshot(
         &self,
         subscription: &Subscription,
+        period: &BillingPeriod,
         rate: u64,
         observed_stake_yocto: u128,
         credit_floor_nano_usd: Option<u64>,
     ) -> Result<u64, SubscriptionError> {
-        let period_end = subscription.current_period_end;
-        let period_start = sub_one_month_same_day(period_end);
+        let period_start = period.start_at;
+        let period_end = period.end_at;
         let observed_at = Utc::now();
         let mut client = self
             .db_pool
@@ -1440,7 +1484,7 @@ impl SubscriptionServiceImpl {
         user_id: UserId,
         subscription: &Subscription,
         plan_config: &SubscriptionPlanConfig,
-    ) -> Result<Option<u64>, SubscriptionError> {
+    ) -> Result<Option<HouseOfStakeEntitlement>, SubscriptionError> {
         if subscription.provider != "house-of-stake" {
             return Ok(None);
         }
@@ -1502,13 +1546,22 @@ impl SubscriptionServiceImpl {
         {
             Ok(Some(chain_sub)) => chain_sub,
             Ok(None) => {
-                return self
-                    .house_of_stake_rpc_fallback(
-                        user_id,
-                        subscription,
-                        "subscription missing on chain",
-                    )
+                let period = self
+                    .current_house_of_stake_snapshot_limit(subscription)
+                    .await?
+                    .map(|entitlement| entitlement.period)
+                    .unwrap_or_else(|| BillingPeriod {
+                        start_at: sub_one_month_same_day(subscription.current_period_end),
+                        end_at: subscription.current_period_end,
+                    });
+                self.house_of_stake_rpc_failure_cache
+                    .write()
                     .await
+                    .remove(&user_id);
+                return Ok(Some(HouseOfStakeEntitlement {
+                    plan_credits: 0,
+                    period,
+                }));
             }
             Err(_) => {
                 return self
@@ -1523,6 +1576,26 @@ impl SubscriptionServiceImpl {
             ));
         }
 
+        let Some(period_start) = chain_sub.start_ns.and_then(ns_to_datetime) else {
+            return self
+                .house_of_stake_rpc_fallback(user_id, subscription, "period start unavailable")
+                .await;
+        };
+        let Some(period_end) = ns_to_datetime(chain_sub.end_ns) else {
+            return self
+                .house_of_stake_rpc_fallback(user_id, subscription, "period end invalid")
+                .await;
+        };
+        if period_end <= period_start {
+            return self
+                .house_of_stake_rpc_fallback(user_id, subscription, "billing period invalid")
+                .await;
+        }
+        let period = BillingPeriod {
+            start_at: period_start,
+            end_at: period_end,
+        };
+
         let status_lower = chain_sub
             .status
             .as_deref()
@@ -1534,9 +1607,14 @@ impl SubscriptionServiceImpl {
             .unwrap_or(u64::MAX);
         if status_lower != "active" || chain_sub.end_ns <= now_ns {
             return self
-                .reconcile_house_of_stake_snapshot(subscription, rate, 0, None)
+                .reconcile_house_of_stake_snapshot(subscription, &period, rate, 0, None)
                 .await
-                .map(Some);
+                .map(|plan_credits| {
+                    Some(HouseOfStakeEntitlement {
+                        plan_credits,
+                        period,
+                    })
+                });
         }
 
         let Some(last_lock_id) = chain_sub
@@ -1575,13 +1653,16 @@ impl SubscriptionServiceImpl {
             0
         };
         let limit = self
-            .reconcile_house_of_stake_snapshot(subscription, rate, observed_stake, None)
+            .reconcile_house_of_stake_snapshot(subscription, &period, rate, observed_stake, None)
             .await?;
         self.house_of_stake_rpc_failure_cache
             .write()
             .await
             .remove(&user_id);
-        Ok(Some(limit))
+        Ok(Some(HouseOfStakeEntitlement {
+            plan_credits: limit,
+            period,
+        }))
     }
 
     fn should_check_pending_downgrade(subscription: &Subscription) -> bool {
@@ -2149,8 +2230,21 @@ impl SubscriptionServiceImpl {
             } else {
                 0
             };
-            self.reconcile_house_of_stake_snapshot(&row, rate, observed_stake, Some(credit_floor))
-                .await?;
+            let period = BillingPeriod {
+                start_at: chain_subscription
+                    .start_ns
+                    .and_then(ns_to_datetime)
+                    .unwrap_or_else(|| sub_one_month_same_day(row.current_period_end)),
+                end_at: row.current_period_end,
+            };
+            self.reconcile_house_of_stake_snapshot(
+                &row,
+                &period,
+                rate,
+                observed_stake,
+                Some(credit_floor),
+            )
+            .await?;
         }
 
         let mut db_client = self
@@ -4769,6 +4863,29 @@ mod tests {
         assert_eq!(limit, 0);
         assert_eq!(zero.last_observed_stake_yocto, 0);
         assert_eq!(zero.credit_limit_nano_usd, 15_000_000_000);
+    }
+
+    #[test]
+    fn test_house_of_stake_snapshot_uses_authoritative_month_end_period() {
+        let start = Utc.with_ymd_and_hms(2026, 1, 31, 0, 0, 0).unwrap();
+        let end = Utc.with_ymd_and_hms(2026, 2, 28, 0, 0, 0).unwrap();
+        let observed_at = Utc.with_ymd_and_hms(2026, 2, 14, 0, 0, 0).unwrap();
+        let period = BillingPeriod {
+            start_at: start,
+            end_at: end,
+        };
+
+        let (_, limit) = next_house_of_stake_snapshot(
+            None,
+            Some(400 * YOCTO_PER_NEAR),
+            600 * YOCTO_PER_NEAR,
+            10_000_000,
+            &period,
+            observed_at,
+            None,
+        );
+
+        assert_eq!(limit, 5_000_000_000);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replaces the stacked implementation in #363 and #395 with one commit based directly on `main`. The implementation is intentionally limited to the accounting state needed for proration and the cache behavior needed to keep NEAR RPC off the request hot path.

Final scope: **5 files, 504 additions, 302 deletions (806 changed lines)**.

### Changes

- Add a compact V37 table keyed by HoS subscription and local billing period. It stores the credited stake high-water mark, last observed stake, granted plan credits, and observation time.
- Use one entitlement transition: the period baseline receives full credits; a later observed stake increase receives only the fraction remaining in the period.
- Carry the last observed stake into the next period. Decreases do not claw back credits already granted in the current period; a confirmed zero stake returns zero entitlement and records zero for the next baseline.
- Make the existing 10-minute credit-limit cache part of the shared plan resolver used by proxy checks, `/v1/credits`, and post-usage purchased-credit reconciliation. Reconciliation no longer invalidates the plan cache.
- On a transient chain lookup failure, use only the current persisted snapshot. Without a snapshot, fail closed and negative-cache the RPC failure for 60 seconds.
- Keep the purchased-credit reconciliation cursor as a same-period high-water mark so a later plan-limit increase cannot charge the same overage twice.
- Extend the existing HoS integration helper to read credits twice and assert that the second read adds no NEAR RPC calls.

### Design assumptions

- `subscriptions.current_period_end` is the billing-period boundary; the start is derived with the existing one-month helper. This change does not introduce a second chain-period model.
- The contract exposes current effective stake, not the stake-change timestamp. Proration starts when the backend first observes an increase.
- The first-ever snapshot uses the observed stake as the full-period baseline to avoid reducing existing users during rollout. Later periods use the previous snapshot's last observed stake as their baseline.
- Direct chain changes become visible after explicit HoS sync or the normal 10-minute cache expiry. No per-request RPC refresh is attempted.
- Stake decreases do not claw back current-period entitlement. Confirmed inactive/zero-share locks return zero immediately and persist a zero observation.
- A transient RPC failure may use a snapshot for the exact local period only. If none exists, access fails closed for the 60-second failure-cache window instead of trusting a configured static limit.
- Subscription renewal and price changes update the local subscription row through the existing sync/webhook paths. This PR does not add special in-period fixed-to-variable migration semantics.

## Risk & impact

This changes plan-credit and purchased-balance accounting for stake-based House-of-Stake subscriptions. The migration is additive. Stripe and free-plan accounting keep their existing behavior, but now share the same resolver cache already used by proxy checks. RPC load is bounded by the 10-minute successful-result cache and 60-second failure cache. No customer content or credentials are logged.

## Testing

- `cargo fmt --all -- --check`
- `cargo check --all-targets --features test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p database repositories::credits_repository::tests` (2 passed)
- `cargo test -p services subscription::service::tests` (25 passed)
- `cargo test --test subscriptions_tests --features test` (88 passed)
- `cargo deny check advisories bans sources` reports advisories already present in the current lockfile. This PR does not change `Cargo.lock` or dependency versions; the repository workflow records the audit as report-only.

## Rollback plan

Revert the single commit. The additive snapshot table can remain because the previous code does not read it; remove it later with a separate migration if needed.

## Review

- [ ] Reviewed by a non-author
- [ ] Security review requested if this is a high-risk change

## Deploy path

Merge to `main` and deploy through the standard immutable image pipeline.
